### PR TITLE
[WIP] Rootdirs support

### DIFF
--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -3095,13 +3095,17 @@ export class LuaTransformer {
     private getImportPath(relativePath: string): string {
         // Calculate absolute path to import
         const absolutePathToImport = this.getAbsoluteImportPath(relativePath);
-        if (this.options.rootDir) {
-            // Calculate path relative to project root
-            // and replace path.sep with dots (lua doesn't know paths)
-            const relativePathToRoot = this.pathToLuaRequirePath(
-                absolutePathToImport.replace(this.options.rootDir, "").slice(1)
-            );
-            return relativePathToRoot;
+        const rootDirs = [this.options.rootDir].concat(this.options.rootDirs);
+        for (const rootDir of rootDirs) {
+            if (rootDir) {
+                // Calculate path relative to project root
+                // and replace path.sep with dots (lua doesn't know paths)
+                const clippedPath = absolutePathToImport.replace(rootDir, "");
+                if (clippedPath !== absolutePathToImport) {
+                    const relativePathToRoot = this.pathToLuaRequirePath(clippedPath.slice(1));
+                    return relativePathToRoot;
+                }
+            }
         }
 
         return this.pathToLuaRequirePath(relativePath);

--- a/src/LuaTranspiler.ts
+++ b/src/LuaTranspiler.ts
@@ -79,14 +79,20 @@ export class LuaTranspiler {
     public emitSourceFile(sourceFile: ts.SourceFile): void {
         if (!sourceFile.isDeclarationFile) {
             try {
-                const rootDir = this.options.rootDir;
-
                 const lua = this.transpileSourceFile(sourceFile);
 
                 let outPath = sourceFile.fileName;
-                if (this.options.outDir !== this.options.rootDir) {
-                    const relativeSourcePath = path.resolve(sourceFile.fileName).replace(path.resolve(rootDir), "");
-                    outPath = path.join(this.options.outDir, relativeSourcePath);
+                const rootDirs = [this.options.rootDir].concat(this.options.rootDirs),
+                      absoluteFileName = path.resolve(sourceFile.fileName);
+
+                for (const rootDir of rootDirs) {
+                    if (rootDir && this.options.outDir !== rootDir) {
+                        const relativeSourcePath = absoluteFileName.replace(path.resolve(rootDir), "");
+                        if (relativeSourcePath !== absoluteFileName) {
+                            outPath = path.join(this.options.outDir, relativeSourcePath);
+                            break;
+                        }
+                    }
                 }
 
                 // change extension or rename to outFile


### PR DESCRIPTION
**Don't Merge!** 

This changeset addresses #372 `rootDirs support`.

Changes `emitSourceFile` and `getImportPath` to attempt relativization against `rootDirs`. This happens only if relativization fails against `rootDir` which is what is currently supported.