### PR TITLE
lua string instance methods

### DIFF
--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -3515,6 +3515,35 @@ export class LuaTransformer {
                 const firstParamPlusOne = this.expressionPlusOne(params[0]);
                 return this.createStringCall("byte", node, caller, firstParamPlusOne);
             }
+            case "byte":
+            case "char":
+            case "dump":
+            case "find":
+            case "format":
+            case "gmatch":
+            case "gsub":
+            case "len":
+            case "lower":
+            case "match":
+            case "pack":
+            case "packsize":
+            case "rep":
+            case "reverse":
+            case "sub":
+            case "unpack":
+            case "upper":
+                // Allow lua's string instance methods
+                let stringVariable = this.transformExpression(expression.expression);
+                if (ts.isStringLiteral(expression.expression)) {
+                    // "foo":method() needs to be ("foo"):method()
+                    stringVariable = tstl.createParenthesizedExpression(stringVariable);
+                }
+                return tstl.createMethodCallExpression(
+                    stringVariable,
+                    this.transformIdentifier(expression.name),
+                    params,
+                    node
+                );
             default:
                 throw TSTLErrors.UnsupportedProperty("string", expressionName, node);
         }

--- a/test/unit/string.spec.ts
+++ b/test/unit/string.spec.ts
@@ -14,6 +14,17 @@ export class StringTests
         }).toThrowError(TranspileError, "Unsupported property on string: testThisIsNoMember");
     }
 
+    @Test("Suported lua string function")
+    public stringSuportedLuaFunction(): void {
+        Expect(util.transpileAndExecute(
+                `return "test".upper()`,
+                undefined,
+                undefined,
+                `interface String { upper(): string; }`
+            )
+        ).toBe("TEST");
+    }
+
     @TestCase([])
     @TestCase([65])
     @TestCase([65, 66])


### PR DESCRIPTION
Currently, tstl doesn't allow lua's string methods to be declared and used:
```ts
interface String { upper(): string; }
print("foo".upper()); // error
```

This PR explicitly enables lua's builtin string methods.
