### PR TITLE
Console function calls

### DIFF
--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -3139,7 +3139,7 @@ export class LuaTransformer {
         }
 
         if (ownerType.symbol && ownerType.symbol.escapedName === "Console") {
-            return this.transformObjectCallExpression(node);
+            return this.transformConsoleCallExpression(node);
         }
 
         if (ownerType.symbol && ownerType.symbol.escapedName === "SymbolConstructor") {

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -3676,18 +3676,17 @@ export class LuaTransformer {
 
         switch (methodName) {
             case "log":
-                if (expression.arguments.length > 0) {
-                    if (this.isStringFormatTemplate(expression.arguments[0])) {
-                        // print(string.format([arguments]))
-                        return tstl.createCallExpression(
-                            tstl.createIdentifier("print"),
-                            [tstl.createCallExpression(
-                                tstl.createTableIndexExpression(
-                                    tstl.createIdentifier("string"),
-                                    tstl.createStringLiteral("format")),
-                                this.transformArguments(expression.arguments))]
-                        );
-                    }
+                if (expression.arguments.length > 0
+                    && this.isStringFormatTemplate(expression.arguments[0])) {
+                    // print(string.format([arguments]))
+                    return tstl.createCallExpression(
+                        tstl.createIdentifier("print"),
+                        [tstl.createCallExpression(
+                            tstl.createTableIndexExpression(
+                                tstl.createIdentifier("string"),
+                                tstl.createStringLiteral("format")),
+                            this.transformArguments(expression.arguments))]
+                    );
                 }
                 // print([arguments])
                 return tstl.createCallExpression(
@@ -3696,19 +3695,19 @@ export class LuaTransformer {
                 );
             case "assert":
                 const args = this.transformArguments(expression.arguments);
-                if (expression.arguments.length > 1) {
-                    if (this.isStringFormatTemplate(expression.arguments[1])) {
-                        // assert([condition], string.format([arguments]))
-                        return tstl.createCallExpression(
-                            tstl.createIdentifier("assert"),
-                            [args[0],
-                            tstl.createCallExpression(
-                                tstl.createTableIndexExpression(
-                                    tstl.createIdentifier("string"),
-                                    tstl.createStringLiteral("format")),
-                                args.slice(1))]
-                        );
-                    }
+                if (expression.arguments.length > 1
+                    && this.isStringFormatTemplate(expression.arguments[1])) {
+                    // assert([condition], string.format([arguments]))
+                    const stringFormatCall = tstl.createCallExpression(
+                        tstl.createTableIndexExpression(
+                            tstl.createIdentifier("string"),
+                            tstl.createStringLiteral("format")),
+                        args.slice(1)
+                    );
+                    return tstl.createCallExpression(
+                        tstl.createIdentifier("assert"),
+                        [args[0], stringFormatCall]
+                    );
                 }
                 // assert()
                 return tstl.createCallExpression(
@@ -3716,31 +3715,36 @@ export class LuaTransformer {
                     args
                 );
             case "trace":
-                if (expression.arguments.length > 0) {
-                    if (this.isStringFormatTemplate(expression.arguments[0])) {
-                        // print(debug.traceback(string.format([arguments])))
-                        return tstl.createCallExpression(
-                            tstl.createIdentifier("print"),
-                            [tstl.createCallExpression(
-                                tstl.createTableIndexExpression(
-                                    tstl.createIdentifier("debug"),
-                                    tstl.createStringLiteral("traceback")),
-                                [tstl.createCallExpression(
-                                    tstl.createTableIndexExpression(
-                                        tstl.createIdentifier("string"),
-                                        tstl.createStringLiteral("format")),
-                                    this.transformArguments(expression.arguments))])]
-                        );
-                    }
-                }
-                // print(debug.traceback([arguments])))
-                return tstl.createCallExpression(
-                    tstl.createIdentifier("print"),
-                    [tstl.createCallExpression(
+                if (expression.arguments.length > 0
+                    && this.isStringFormatTemplate(expression.arguments[0])) {
+                    // print(debug.traceback(string.format([arguments])))
+                    const stringFormatCall = tstl.createCallExpression(
+                        tstl.createTableIndexExpression(
+                            tstl.createIdentifier("string"),
+                            tstl.createStringLiteral("format")),
+                        this.transformArguments(expression.arguments)
+                    );
+                    const debugTracebackCall = tstl.createCallExpression(
                         tstl.createTableIndexExpression(
                             tstl.createIdentifier("debug"),
                             tstl.createStringLiteral("traceback")),
-                        this.transformArguments(expression.arguments))]
+                        [stringFormatCall]
+                    );
+                    return tstl.createCallExpression(
+                        tstl.createIdentifier("print"),
+                        [debugTracebackCall]
+                    );
+                }
+                // print(debug.traceback([arguments])))
+                const debugTracebackCall = tstl.createCallExpression(
+                    tstl.createTableIndexExpression(
+                        tstl.createIdentifier("debug"),
+                        tstl.createStringLiteral("traceback")),
+                    this.transformArguments(expression.arguments)
+                );
+                return tstl.createCallExpression(
+                    tstl.createIdentifier("print"),
+                    [debugTracebackCall]
                 );
             default:
                 throw TSTLErrors.UnsupportedForTarget(

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -3679,13 +3679,15 @@ export class LuaTransformer {
                 if (expression.arguments.length > 0
                     && this.isStringFormatTemplate(expression.arguments[0])) {
                     // print(string.format([arguments]))
+                    const stringFormatCall = tstl.createCallExpression(
+                        tstl.createTableIndexExpression(
+                            tstl.createIdentifier("string"),
+                            tstl.createStringLiteral("format")),
+                        this.transformArguments(expression.arguments)
+                    );
                     return tstl.createCallExpression(
                         tstl.createIdentifier("print"),
-                        [tstl.createCallExpression(
-                            tstl.createTableIndexExpression(
-                                tstl.createIdentifier("string"),
-                                tstl.createStringLiteral("format")),
-                            this.transformArguments(expression.arguments))]
+                        [stringFormatCall]
                     );
                 }
                 // print([arguments])

--- a/test/unit/console.spec.ts
+++ b/test/unit/console.spec.ts
@@ -1,0 +1,48 @@
+import { Expect, Test, TestCase, IgnoreTest, FocusTest } from "alsatian";
+import * as util from "../src/util";
+
+export class ConsoleTests {
+
+    @TestCase("console.log()", "print();")
+    @TestCase('console.log("Hello")', 'print("Hello");')
+    @TestCase('console.log("Hello %s", "there")', 'print(string.format("Hello %s", "there"));')
+    @TestCase('console.log("Hello %%s", "there")', 'print(string.format("Hello %%s", "there"));')
+    @TestCase('console.log("Hello", "There")', 'print("Hello", "There");')
+    @Test("console.log")
+    public testConsoleLog(inp: string, expected: string): void {
+        // Transpile
+        const lua = util.transpileString(inp);
+
+        // Assert
+        Expect(lua).toBe(expected);
+    }
+
+    @TestCase("console.trace()", "print(debug.traceback());")
+    @TestCase('console.trace("message")', 'print(debug.traceback("message"));')
+    @TestCase('console.trace("Hello %s", "there")', 'print(debug.traceback(string.format("Hello %s", "there")));')
+    @TestCase('console.trace("Hello %%s", "there")', 'print(debug.traceback(string.format("Hello %%s", "there")));')
+    @TestCase('console.trace("Hello", "there")', 'print(debug.traceback("Hello", "there"));')
+    @Test("console.trace")
+    public testConsoleTrace(inp: string, expected: string): void {
+        // Transpile
+        const lua = util.transpileString(inp);
+
+        // Assert
+        Expect(lua).toBe(expected);
+    }
+
+    @TestCase("console.assert(false)", "assert(false);")
+    @TestCase('console.assert(false, "message")', 'assert(false, "message");')
+    @TestCase('console.assert(false, "message %s", "info")', 'assert(false, string.format("message %s", "info"));')
+    @TestCase('console.assert(false, "message %%s", "info")', 'assert(false, string.format("message %%s", "info"));')
+    @TestCase('console.assert(false, "message", "more")', 'assert(false, "message", "more");')
+    @Test("console.assert")
+    public testConsoleAssert(inp: string, expected: string): void {
+        // Transpile
+        const lua = util.transpileString(inp);
+
+        // Assert
+        Expect(lua).toBe(expected);
+    }
+
+}


### PR DESCRIPTION
Continued from #443 as a partial solution for #439.

```ts
console.log("Hello");               // print("Hello")
console.log("Hello %s", "there");   // prints "Hello there" in Lua
console.log("Hello", "There");      // print("Hello", "There")
console.assert(true);               // assert(true)
console.assert(true, "message");    // assert(true, "message")
console.assert(false, "Hello %s", "there"); // Fails with "Hello there" as a message
console.trace();                    // Prints a stack trace in Lua
console.trace("message");           // Prints a stack trace with "message" at the top in Lua
console.trace("Hello %s", "there"); // Prints a stack trace with "Hello there" at the top in Lua
```

For the case below, the code doesn't work.

```ts
console.log("foo%%bar", "blah"); // Prints foo%bar instead of foo%%bar    blah
```

I looked into implementing these functions into LuaLibs since what happens is figured out at runtime, however something like:

```ts
function __TSTL__ConsoleLog(...args) {
    print(...args);
}
```

Transpiles to lua with `unpack`. Which means the solution won't work for all lua targets.

This is only a partial implementation of `console.log`, `console.assert` and `console.trace` since the full solution would likely be implemented in a LuaLib.

Submitting this PR just to show what I have and see if it is acceptable for now.