### PR TITLE
Fixed crash related to function expression type inference

### DIFF
--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -484,7 +484,10 @@ export class TSHelper {
             const objType = this.inferAssignedType(expression.parent.parent, checker);
             const property = objType.getProperty(expression.parent.name.getText());
             if (!property) {
-                return objType.getStringIndexType();
+                const stringPropertyType = objType.getStringIndexType();
+                if (stringPropertyType) {
+                    return stringPropertyType;
+                }
             } else {
                 return checker.getTypeAtLocation(property.valueDeclaration);
             }

--- a/test/unit/assignments.spec.ts
+++ b/test/unit/assignments.spec.ts
@@ -875,6 +875,14 @@ export class AssignmentTests {
         Expect(util.transpileAndExecute(code)).toBe("foobar");
     }
 
+    @Test("Function expression type inference in object literal assigned to narrower type")
+    public functionEXpressionTypeInferenceInObjectLiteralAssignedToNarrowerType(): void {
+        const code =
+            `let foo: {} = {bar: s => s};
+            return (foo as {bar: (a: any) => any}).bar("foobar");`;
+        Expect(util.transpileAndExecute(code)).toBe("foobar");
+    }
+
     @TestCase("const foo: Foo", "s => s")
     @TestCase("const foo: Foo", "(s => s)")
     @TestCase("const foo: Foo", "function(s) { return s; }")


### PR DESCRIPTION
This one is oddly specific. The transpiler would fail to infer the type of a function expression that was being assigned to a property in an object literal that was itself, being assigned to a type that didn't contain that property. In some circumstances, this would cause a crash.

Example:
```ts
let foo: {} = {bar: s => s};
```