### PR TITLE
check origin for standard library types

### DIFF
--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -47,6 +47,8 @@ export class LuaTransformer {
 
     private checker: ts.TypeChecker;
     protected options: CompilerOptions;
+    protected program: ts.Program;
+
     private isModule: boolean;
 
     private currentSourceFile?: ts.SourceFile;
@@ -62,8 +64,6 @@ export class LuaTransformer {
     private symbolInfo: Map<tstl.SymbolId, SymbolInfo>;
     private symbolIds: Map<ts.Symbol, tstl.SymbolId>;
     private genSymbolIdCounter: number;
-
-    private program: ts.Program;
 
     private readonly typeValidationCache: Map<ts.Type, Set<ts.Type>> = new Map<ts.Type, Set<ts.Type>>();
 

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -3116,7 +3116,7 @@ export class LuaTransformer {
         }
 
         const expressionType = this.checker.getTypeAtLocation(node.expression);
-        if (expressionType.symbol && expressionType.symbol.escapedName === "SymbolConstructor") {
+        if (tsHelper.isStandardLibraryType(expressionType, "SymbolConstructor", this.program)) {
             return this.transformLuaLibFunction(LuaLibFeature.Symbol, node, ...parameters);
         }
 
@@ -3143,7 +3143,7 @@ export class LuaTransformer {
             return this.transformConsoleCallExpression(node);
         }
 
-        if (ownerType.symbol && ownerType.symbol.escapedName === "StringConstructor") {
+        if (tsHelper.isStandardLibraryType(ownerType, "StringConstructor", this.program)) {
             return tstl.createCallExpression(
                 this.transformStringExpression(node.expression.name),
                 this.transformArguments(node.arguments),
@@ -3151,11 +3151,11 @@ export class LuaTransformer {
             );
         }
 
-        if (ownerType.symbol && ownerType.symbol.escapedName === "ObjectConstructor") {
+        if (tsHelper.isStandardLibraryType(ownerType, "ObjectConstructor", this.program)) {
             return this.transformObjectCallExpression(node);
         }
 
-        if (ownerType.symbol && ownerType.symbol.escapedName === "SymbolConstructor") {
+        if (tsHelper.isStandardLibraryType(ownerType, "SymbolConstructor", this.program)) {
             return this.transformSymbolCallExpression(node);
         }
 

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -3148,7 +3148,7 @@ export class LuaTransformer {
             return this.transformObjectCallExpression(node);
         }
 
-        if (ownerType.symbol && ownerType.symbol.escapedName === "Console") {
+        if (ownerType.symbol && ownerType.symbol.escapedName === "Console" && tsHelper.isInGlobalScope(node)) {
             return this.transformConsoleCallExpression(node);
         }
 

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -3116,7 +3116,7 @@ export class LuaTransformer {
         }
 
         const expressionType = this.checker.getTypeAtLocation(node.expression);
-        if (tsHelper.isStandardLibraryType(expressionType, "SymbolConstructor", this.program)) {
+        if (expressionType.symbol && expressionType.symbol.escapedName === "SymbolConstructor") {
             return this.transformLuaLibFunction(LuaLibFeature.Symbol, node, ...parameters);
         }
 
@@ -3143,7 +3143,7 @@ export class LuaTransformer {
             return this.transformConsoleCallExpression(node);
         }
 
-        if (tsHelper.isStandardLibraryType(ownerType, "StringConstructor", this.program)) {
+        if (ownerType.symbol && ownerType.symbol.escapedName === "StringConstructor") {
             return tstl.createCallExpression(
                 this.transformStringExpression(node.expression.name),
                 this.transformArguments(node.arguments),
@@ -3151,11 +3151,11 @@ export class LuaTransformer {
             );
         }
 
-        if (tsHelper.isStandardLibraryType(ownerType, "ObjectConstructor", this.program)) {
+        if (ownerType.symbol && ownerType.symbol.escapedName === "ObjectConstructor") {
             return this.transformObjectCallExpression(node);
         }
 
-        if (tsHelper.isStandardLibraryType(ownerType, "SymbolConstructor", this.program)) {
+        if (ownerType.symbol && ownerType.symbol.escapedName === "SymbolConstructor") {
             return this.transformSymbolCallExpression(node);
         }
 

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -63,11 +63,14 @@ export class LuaTransformer {
     private symbolIds: Map<ts.Symbol, tstl.SymbolId>;
     private genSymbolIdCounter: number;
 
+    private program: ts.Program;
+
     private readonly typeValidationCache: Map<ts.Type, Set<ts.Type>> = new Map<ts.Type, Set<ts.Type>>();
 
     public constructor(program: ts.Program, options: CompilerOptions) {
         this.checker = program.getTypeChecker();
         this.options = options;
+        this.program = program;
         this.isStrict = this.options.alwaysStrict || (this.options.strict && this.options.alwaysStrict !== false) ||
                         (this.isModule && this.options.target && this.options.target >= ts.ScriptTarget.ES2015);
 
@@ -3113,7 +3116,7 @@ export class LuaTransformer {
         }
 
         const expressionType = this.checker.getTypeAtLocation(node.expression);
-        if (expressionType.symbol && expressionType.symbol.escapedName === "SymbolConstructor") {
+        if (tsHelper.isStandardLibraryType(expressionType, "SymbolConstructor", this.program)) {
             return this.transformLuaLibFunction(LuaLibFeature.Symbol, node, ...parameters);
         }
 
@@ -3132,11 +3135,15 @@ export class LuaTransformer {
         // If the function being called is of type owner.func, get the type of owner
         const ownerType = this.checker.getTypeAtLocation(node.expression.expression);
 
-        if (ownerType.symbol && ownerType.symbol.escapedName === "Math") {
+        if (tsHelper.isStandardLibraryType(ownerType, "Math", this.program)) {
             return this.transformMathCallExpression(node);
         }
 
-        if (ownerType.symbol && ownerType.symbol.escapedName === "StringConstructor") {
+        if (tsHelper.isStandardLibraryType(ownerType, "Console", this.program)) {
+            return this.transformConsoleCallExpression(node);
+        }
+
+        if (tsHelper.isStandardLibraryType(ownerType, "StringConstructor", this.program)) {
             return tstl.createCallExpression(
                 this.transformStringExpression(node.expression.name),
                 this.transformArguments(node.arguments),
@@ -3144,15 +3151,11 @@ export class LuaTransformer {
             );
         }
 
-        if (ownerType.symbol && ownerType.symbol.escapedName === "ObjectConstructor") {
+        if (tsHelper.isStandardLibraryType(ownerType, "ObjectConstructor", this.program)) {
             return this.transformObjectCallExpression(node);
         }
 
-        if (tsHelper.isTypeDeclaredInDOM(ownerType, "Console")) {
-            return this.transformConsoleCallExpression(node);
-        }
-
-        if (ownerType.symbol && ownerType.symbol.escapedName === "SymbolConstructor") {
+        if (tsHelper.isStandardLibraryType(ownerType, "SymbolConstructor", this.program)) {
             return this.transformSymbolCallExpression(node);
         }
 
@@ -3317,9 +3320,11 @@ export class LuaTransformer {
 
         // Catch math expressions
         if (ts.isIdentifier(node.expression)) {
-            if (node.expression.escapedText === "Math") {
+            const ownerType = this.checker.getTypeAtLocation(node.expression);
+
+            if (tsHelper.isStandardLibraryType(ownerType, "Math", this.program)) {
                 return this.transformMathExpression(node.name);
-            } else if (node.expression.escapedText === "Symbol") {
+            } else if (tsHelper.isStandardLibraryType(ownerType, "Symbol", this.program)) {
                 // Pull in Symbol lib
                 this.importLuaLibFeature(LuaLibFeature.Symbol);
             }

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -3148,7 +3148,7 @@ export class LuaTransformer {
             return this.transformObjectCallExpression(node);
         }
 
-        if (ownerType.symbol && ownerType.symbol.escapedName === "Console" && tsHelper.isInGlobalScope(node)) {
+        if (tsHelper.isTypeDeclaredInDOM(ownerType, "Console")) {
             return this.transformConsoleCallExpression(node);
         }
 

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -694,7 +694,7 @@ export class TSHelper {
         const symbol = type.symbol;
         if (!symbol || symbol.escapedName !== name) { return false; }
         const declaration = symbol.valueDeclaration;
-        if(!declaration) { return false; }
+        if(!declaration) { return true; } // assume to be lib function if no valueDeclaration exists
         return this.isStandardLibraryDeclaration(declaration, program);
     }
 

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -684,25 +684,18 @@ export class TSHelper {
         return firstDeclaration === node;
     }
 
-    public static isDeclarationDeclaredIn(declaration: ts.Declaration, fileName: string): boolean {
+    public static isStandardLibraryDeclaration(declaration: ts.Declaration, program: ts.Program): boolean {
         const source = declaration.getSourceFile();
         if (!source) { return false; }
-        let sourceFileName = source.fileName;
-        if(!sourceFileName) { return false; }
-        sourceFileName = sourceFileName.replace(/^.*[\\\/]/, '');
-        return sourceFileName === fileName;
+        return program.isSourceFileDefaultLibrary(source);
     }
 
-    public static isTypeDeclaredIn(type: ts.Type, name: string, fileName: string): boolean {
+    public static isStandardLibraryType(type: ts.Type, name: string, program: ts.Program): boolean {
         const symbol = type.symbol;
         if (!symbol || symbol.escapedName !== name) { return false; }
         const declaration = symbol.valueDeclaration;
         if(!declaration) { return false; }
-        return this.isDeclarationDeclaredIn(declaration, fileName);
-    }
-
-    public static isTypeDeclaredInDOM(type: ts.Type, name: string): boolean {
-        return this.isTypeDeclaredIn(type, name, "lib.dom.d.ts");
+        return this.isStandardLibraryDeclaration(declaration, program);
     }
 
     public static isEnumMember(enumDeclaration: ts.EnumDeclaration, value: ts.Expression): [boolean, ts.PropertyName] {

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -684,17 +684,25 @@ export class TSHelper {
         return firstDeclaration === node;
     }
 
-    public static isTypeDeclaredInDOM(type: ts.Type, name: string): boolean {
+    public static isDeclarationDeclaredIn(declaration: ts.Declaration, fileName: string): boolean {
+        const source = declaration.getSourceFile();
+        if (!source) { return false; }
+        let sourceFileName = source.fileName;
+        if(!sourceFileName) { return false; }
+        sourceFileName = sourceFileName.replace(/^.*[\\\/]/, '');
+        return sourceFileName === fileName;
+    }
+
+    public static isTypeDeclaredIn(type: ts.Type, name: string, fileName: string): boolean {
         const symbol = type.symbol;
         if (!symbol || symbol.escapedName !== name) { return false; }
         const declaration = symbol.valueDeclaration;
         if(!declaration) { return false; }
-        const source = declaration.getSourceFile();
-        if (!source) { return false; }
-        let fileName = source.fileName;
-        if(!fileName) { return false; }
-        fileName = fileName.replace(/^.*[\\\/]/, '');
-        return fileName === "lib.dom.d.ts";
+        return this.isDeclarationDeclaredIn(declaration, fileName);
+    }
+
+    public static isTypeDeclaredInDOM(type: ts.Type, name: string): boolean {
+        return this.isTypeDeclaredIn(type, name, "lib.dom.d.ts");
     }
 
     public static isEnumMember(enumDeclaration: ts.EnumDeclaration, value: ts.Expression): [boolean, ts.PropertyName] {

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -684,6 +684,19 @@ export class TSHelper {
         return firstDeclaration === node;
     }
 
+    public static isTypeDeclaredInDOM(type: ts.Type, name: string): boolean {
+        const symbol = type.symbol;
+        if (!symbol || symbol.escapedName !== name) { return false; }
+        const declaration = symbol.valueDeclaration;
+        if(!declaration) { return false; }
+        const source = declaration.getSourceFile();
+        if (!source) { return false; }
+        let fileName = source.fileName;
+        if(!fileName) { return false; }
+        fileName = fileName.replace(/^.*[\\\/]/, '');
+        return fileName === "lib.dom.d.ts";
+    }
+
     public static isEnumMember(enumDeclaration: ts.EnumDeclaration, value: ts.Expression): [boolean, ts.PropertyName] {
         if (ts.isIdentifier(value)) {
             const enumMember = enumDeclaration.members.find(m => ts.isIdentifier(m.name) && m.name.text === value.text);

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -297,7 +297,7 @@ export class TSHelper {
         return node.parent === undefined || ts.isExpressionStatement(node.parent) || ts.isForStatement(node.parent);
     }
 
-    public static isInGlobalScope(node: ts.FunctionDeclaration): boolean {
+    public static isInGlobalScope(node: ts.Node): boolean {
         let parent = node.parent;
         while (parent !== undefined) {
             if (ts.isBlock(parent)) {

--- a/test/unit/console.spec.ts
+++ b/test/unit/console.spec.ts
@@ -1,4 +1,4 @@
-import { Expect, Test, TestCase, IgnoreTest, FocusTest } from "alsatian";
+import { Expect, Test, TestCase } from "alsatian";
 import * as util from "../src/util";
 
 export class ConsoleTests {
@@ -44,5 +44,24 @@ export class ConsoleTests {
         // Assert
         Expect(lua).toBe(expected);
     }
+
+    @Test("console.differentiation")
+    public testConsoleDifferentiation(): void {
+        // Transpile
+        const result = util.transpileExecuteAndReturnExport(`
+          export class Console {
+            test() { return 42; }
+          }
+
+          function test() {
+            const console = new Console();
+            return console.test();
+          }
+
+          export const result = test();
+        `, "result");
+        Expect(result).toBe(42);
+    }
+
 
 }


### PR DESCRIPTION
Avoids name collisions with user types and standard library, such as `Math`, `Console`, etc. Example:

```typescript
export class Console { 
  test() { return 42; }
}

function test() {
  const console = new Console();
  return console.test();
}

console.log(test()); // prints 42
```