### PR TITLE
Function inference fixes

### DIFF
--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -514,9 +514,20 @@ export class TSHelper {
         {
             // Expression assigned to variable
             return checker.getTypeAtLocation(expression.parent.left);
+
+        } else if (ts.isAssertionExpression(expression.parent)) {
+            // Expression being cast
+            return checker.getTypeFromTypeNode(expression.parent.type);
         }
 
         return checker.getTypeAtLocation(expression);
+    }
+
+    public static getAllCallSignatures(type: ts.Type): ReadonlyArray<ts.Signature> {
+        if (type.isUnion()) {
+            return type.types.map(t => TSHelper.getAllCallSignatures(t)).reduce((a, b) => a.concat(b));
+        }
+        return type.getCallSignatures();
     }
 
     public static getSignatureDeclarations(
@@ -533,7 +544,7 @@ export class TSHelper {
                 // Infer type of function expressions/arrow functions
                 const inferredType = TSHelper.inferAssignedType(signatureDeclaration, checker);
                 if (inferredType) {
-                    const inferredSignatures = inferredType.getCallSignatures();
+                    const inferredSignatures = TSHelper.getAllCallSignatures(inferredType);
                     if (inferredSignatures.length > 0) {
                         signatureDeclarations.push(...inferredSignatures.map(s => s.getDeclaration()));
                         continue;

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -436,7 +436,7 @@ export class TSHelper {
             // Ignore expressions wrapped in parenthesis
             return this.inferAssignedType(expression.parent, checker);
 
-        } else if (ts.isCallExpression(expression.parent)) {
+        } else if (ts.isCallOrNewExpression(expression.parent)) {
             // Expression being passed as argument to a function
             const argumentIndex = expression.parent.arguments.indexOf(expression);
             if (argumentIndex >= 0) {

--- a/test/unit/assignments.spec.ts
+++ b/test/unit/assignments.spec.ts
@@ -1,4 +1,4 @@
-import { Expect, Test, TestCase } from "alsatian";
+import { Expect, Test, TestCase, FocusTest } from "alsatian";
 import { TranspileError } from "../../src/TranspileError";
 
 import * as util from "../src/util";
@@ -970,6 +970,56 @@ export class AssignmentTests {
             ${assignTo} = [${funcExp}];
             const foo: Foo = {method: ${method}};
             return foo.method("foo");`;
+        Expect(util.transpileAndExecute(code)).toBe("foo");
+    }
+
+    @TestCase("(this: void, s: string) => string", "s => s")
+    @TestCase("(this: any, s: string) => string", "s => s")
+    @TestCase("(s: string) => string", "s => s")
+    @TestCase("(this: void, s: string) => string", "(s => s)")
+    @TestCase("(this: any, s: string) => string", "(s => s)")
+    @TestCase("(s: string) => string", "(s => s)")
+    @TestCase("(this: void, s: string) => string", "function(s) { return s; }")
+    @TestCase("(this: any, s: string) => string", "function(s) { return s; }")
+    @TestCase("(s: string) => string", "function(s) { return s; }")
+    @TestCase("(this: void, s: string) => string", "(function(s) { return s; })")
+    @TestCase("(this: any, s: string) => string", "(function(s) { return s; })")
+    @TestCase("(s: string) => string", "(function(s) { return s; })")
+    @Test("Function expression type inference in union")
+    public functionExpressionTypeInferenceInUnion(funcType: string, funcExp: string): void {
+        const code =
+            `type U = string | number | (${funcType});
+            const u: U = ${funcExp};
+            return (u as ${funcType})("foo");`;
+        Expect(util.transpileAndExecute(code)).toBe("foo");
+    }
+
+    @TestCase("(this: void, s: string) => string", "s => s")
+    @TestCase("(this: any, s: string) => string", "s => s")
+    @TestCase("(s: string) => string", "s => s")
+    @TestCase("(this: void, s: string) => string", "function(s) { return s; }")
+    @TestCase("(this: any, s: string) => string", "function(s) { return s; }")
+    @TestCase("(s: string) => string", "function(s) { return s; }")
+    @Test("Function expression type inference in as cast")
+    public functionExpressionTypeInferenceInAsCast(funcType: string, funcExp: string): void {
+        const code =
+            `const fn: ${funcType} = (${funcExp}) as (${funcType});
+            return fn("foo");`;
+            console.log(code);
+        Expect(util.transpileAndExecute(code)).toBe("foo");
+    }
+
+    @TestCase("(this: void, s: string) => string", "s => s")
+    @TestCase("(this: any, s: string) => string", "s => s")
+    @TestCase("(s: string) => string", "s => s")
+    @TestCase("(this: void, s: string) => string", "function(s) { return s; }")
+    @TestCase("(this: any, s: string) => string", "function(s) { return s; }")
+    @TestCase("(s: string) => string", "function(s) { return s; }")
+    @Test("Function expression type inference in type assertion")
+    public functionExpressionTypeInferenceInTypeAssert(funcType: string, funcExp: string): void {
+        const code =
+            `const fn: ${funcType} = <${funcType}>(${funcExp});
+            return fn("foo");`;
         Expect(util.transpileAndExecute(code)).toBe("foo");
     }
 

--- a/test/unit/assignments.spec.ts
+++ b/test/unit/assignments.spec.ts
@@ -976,15 +976,9 @@ export class AssignmentTests {
     @TestCase("(this: void, s: string) => string", "s => s")
     @TestCase("(this: any, s: string) => string", "s => s")
     @TestCase("(s: string) => string", "s => s")
-    @TestCase("(this: void, s: string) => string", "(s => s)")
-    @TestCase("(this: any, s: string) => string", "(s => s)")
-    @TestCase("(s: string) => string", "(s => s)")
     @TestCase("(this: void, s: string) => string", "function(s) { return s; }")
     @TestCase("(this: any, s: string) => string", "function(s) { return s; }")
     @TestCase("(s: string) => string", "function(s) { return s; }")
-    @TestCase("(this: void, s: string) => string", "(function(s) { return s; })")
-    @TestCase("(this: any, s: string) => string", "(function(s) { return s; })")
-    @TestCase("(s: string) => string", "(function(s) { return s; })")
     @Test("Function expression type inference in union")
     public functionExpressionTypeInferenceInUnion(funcType: string, funcExp: string): void {
         const code =
@@ -1020,6 +1014,24 @@ export class AssignmentTests {
         const code =
             `const fn: ${funcType} = <${funcType}>(${funcExp});
             return fn("foo");`;
+        Expect(util.transpileAndExecute(code)).toBe("foo");
+    }
+
+    @TestCase("(this: void, s: string) => string", "s => s")
+    @TestCase("(this: any, s: string) => string", "s => s")
+    @TestCase("(s: string) => string", "s => s")
+    @TestCase("(this: void, s: string) => string", "function(s) { return s; }")
+    @TestCase("(this: any, s: string) => string", "function(s) { return s; }")
+    @TestCase("(s: string) => string", "function(s) { return s; }")
+    @Test("Function expression type inference in constructor")
+    public functionExpresssionTypeInferenceInConstructor(funcType: string, funcExp: string): void {
+        const code =
+            `class C {
+                result: string;
+                constructor(fn: (s: string) => string) { this.result = fn("foo"); }
+            }
+            const c = new C(s => s);
+            return c.result;`;
         Expect(util.transpileAndExecute(code)).toBe("foo");
     }
 

--- a/test/unit/assignments.spec.ts
+++ b/test/unit/assignments.spec.ts
@@ -1,4 +1,4 @@
-import { Expect, Test, TestCase, FocusTest } from "alsatian";
+import { Expect, Test, TestCase } from "alsatian";
 import { TranspileError } from "../../src/TranspileError";
 
 import * as util from "../src/util";


### PR DESCRIPTION
This PR fixes inferring the 'self' type on function expressions when assigned to unions, `as`-casts and type assertions:
```ts
type Fn = (this: any, s: string) => string;
const foo: string | Fn = (s => s);
const bar = (s => s) as Fn;
const baz = <Fn>(s => s);
