### PR TITLE
fixed function expression inference in binary operators

### DIFF
--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -509,11 +509,14 @@ export class TSHelper {
             // Expression assigned to declaration
             return checker.getTypeAtLocation(expression.parent.name);
 
-        } else if (ts.isBinaryExpression(expression.parent)
-            && expression.parent.operatorToken.kind === ts.SyntaxKind.EqualsToken)
-        {
-            // Expression assigned to variable
-            return checker.getTypeAtLocation(expression.parent.left);
+        } else if (ts.isBinaryExpression(expression.parent)) {
+            if (expression.parent.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+                // Expression assigned to variable
+                return checker.getTypeAtLocation(expression.parent.left);
+            } else {
+                // Other binary expressions
+                return TSHelper.inferAssignedType(expression.parent, checker);
+            }
 
         } else if (ts.isAssertionExpression(expression.parent)) {
             // Expression being cast

--- a/test/unit/assignments.spec.ts
+++ b/test/unit/assignments.spec.ts
@@ -837,6 +837,19 @@ export class AssignmentTests {
             + "Overloads should either be all functions or all methods, but not both.");
     }
 
+    @TestCase("(this: void, s: string) => string")
+    @TestCase("(this: any, s: string) => string")
+    @TestCase("(s: string) => string")
+    @Test("Function expression type inference in binary operator")
+    public functionExpressionTypeInferenceInBinaryOp(funcType: string): void {
+        const header = `declare const undefinedFunc: ${funcType};`;
+        const code =
+            `let func: ${funcType} = s => s;
+            func = undefinedFunc || (s => s);
+            return func("foo");`;
+        Expect(util.transpileAndExecute(code, undefined, undefined, header)).toBe("foo");
+    }
+
     @TestCase("s => s")
     @TestCase("(s => s)")
     @TestCase("function(s) { return s; }")


### PR DESCRIPTION
fixes this scenario:
```ts
let callback: (this: void, a: number) => number;
declare const undefinedCallback: typeof callback;
callback = undefinedCallback || (a => a+1); // fallback gets transpiled with context
callback(3); // errors with arithmetic on a nil value
```