### PR TITLE
Feature/small bugfixes

### DIFF
--- a/src/LuaAST.ts
+++ b/src/LuaAST.ts
@@ -70,7 +70,6 @@ export enum SyntaxKind {
     BitwiseOrOperator,
     BitwiseExclusiveOrOperator,
     BitwiseRightShiftOperator,
-    BitwiseArithmeticRightShift,
     BitwiseLeftShiftOperator,
     BitwiseNotOperator,  // Unary
 }
@@ -85,7 +84,7 @@ export type UnaryOperator = SyntaxKind.NegationOperator
 
 export type BinaryBitwiseOperator = SyntaxKind.BitwiseAndOperator | SyntaxKind.BitwiseOrOperator
     | SyntaxKind.BitwiseExclusiveOrOperator | SyntaxKind.BitwiseRightShiftOperator
-    | SyntaxKind.BitwiseArithmeticRightShift | SyntaxKind.BitwiseLeftShiftOperator;
+    | SyntaxKind.BitwiseLeftShiftOperator;
 
 export type BinaryOperator =
     SyntaxKind.AdditionOperator | SyntaxKind.SubractionOperator | SyntaxKind.MultiplicationOperator

--- a/src/LuaPrinter.ts
+++ b/src/LuaPrinter.ts
@@ -30,8 +30,8 @@ export class LuaPrinter {
         [tstl.SyntaxKind.BitwiseAndOperator]: "&",
         [tstl.SyntaxKind.BitwiseOrOperator]: "|",
         [tstl.SyntaxKind.BitwiseExclusiveOrOperator]: "~",
-        [tstl.SyntaxKind.BitwiseRightShiftOperator]: ">>",
-        [tstl.SyntaxKind.BitwiseArithmeticRightShift]: ">>>",
+        [tstl.SyntaxKind.BitwiseArithmeticRightShift]: ">>",
+        [tstl.SyntaxKind.BitwiseRightShiftOperator]: ">>>",
         [tstl.SyntaxKind.BitwiseLeftShiftOperator]: "<<",
         [tstl.SyntaxKind.BitwiseNotOperator]: "~",
     };

--- a/src/LuaPrinter.ts
+++ b/src/LuaPrinter.ts
@@ -30,7 +30,6 @@ export class LuaPrinter {
         [tstl.SyntaxKind.BitwiseAndOperator]: "&",
         [tstl.SyntaxKind.BitwiseOrOperator]: "|",
         [tstl.SyntaxKind.BitwiseExclusiveOrOperator]: "~",
-        [tstl.SyntaxKind.BitwiseArithmeticRightShift]: ">>>",
         [tstl.SyntaxKind.BitwiseRightShiftOperator]: ">>",
         [tstl.SyntaxKind.BitwiseLeftShiftOperator]: "<<",
         [tstl.SyntaxKind.BitwiseNotOperator]: "~",

--- a/src/LuaPrinter.ts
+++ b/src/LuaPrinter.ts
@@ -30,8 +30,8 @@ export class LuaPrinter {
         [tstl.SyntaxKind.BitwiseAndOperator]: "&",
         [tstl.SyntaxKind.BitwiseOrOperator]: "|",
         [tstl.SyntaxKind.BitwiseExclusiveOrOperator]: "~",
-        [tstl.SyntaxKind.BitwiseArithmeticRightShift]: ">>",
-        [tstl.SyntaxKind.BitwiseRightShiftOperator]: ">>>",
+        [tstl.SyntaxKind.BitwiseArithmeticRightShift]: ">>>",
+        [tstl.SyntaxKind.BitwiseRightShiftOperator]: ">>",
         [tstl.SyntaxKind.BitwiseLeftShiftOperator]: "<<",
         [tstl.SyntaxKind.BitwiseNotOperator]: "~",
     };

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -2331,15 +2331,6 @@ export class LuaTransformer {
             case ts.SyntaxKind.GreaterThanGreaterThanToken:
             case ts.SyntaxKind.GreaterThanGreaterThanGreaterThanToken:
                 return this.transformBinaryBitOperation(tsOriginal, left, right, operator);
-            case ts.SyntaxKind.PlusToken:
-                if (ts.isBinaryExpression(tsOriginal)) {
-                    // Replace string + with ..
-                    const typeLeft = this.checker.getTypeAtLocation(tsOriginal.left);
-                    const typeRight = this.checker.getTypeAtLocation(tsOriginal.right);
-                    if (tsHelper.isStringType(typeLeft) || tsHelper.isStringType(typeRight)) {
-                        return tstl.createBinaryExpression(left, right, tstl.SyntaxKind.ConcatOperator, tsOriginal);
-                    }
-                }
             default:
                 const luaOperator = this.transformBinaryOperator(operator, tsOriginal);
                 return tstl.createBinaryExpression(left, right, luaOperator, tsOriginal);
@@ -2646,22 +2637,10 @@ export class LuaTransformer {
             // Bitwise operators
             case ts.SyntaxKind.BarToken:
                 return tstl.SyntaxKind.BitwiseOrOperator;
-            case ts.SyntaxKind.PlusToken:
-                return tstl.SyntaxKind.AdditionOperator;
             case ts.SyntaxKind.CaretToken:
                 return tstl.SyntaxKind.BitwiseExclusiveOrOperator;
-            case ts.SyntaxKind.MinusToken:
-                return tstl.SyntaxKind.SubractionOperator;
-            case ts.SyntaxKind.SlashToken:
-                return tstl.SyntaxKind.DivisionOperator;
-            case ts.SyntaxKind.PercentToken:
-                return tstl.SyntaxKind.ModuloOperator;
-            case ts.SyntaxKind.AsteriskToken:
-                return tstl.SyntaxKind.MultiplicationOperator;
             case ts.SyntaxKind.AmpersandToken:
                 return tstl.SyntaxKind.BitwiseAndOperator;
-            case ts.SyntaxKind.AsteriskAsteriskToken:
-                return tstl.SyntaxKind.PowerOperator;
             case ts.SyntaxKind.LessThanLessThanToken:
                 return tstl.SyntaxKind.BitwiseLeftShiftOperator;
             case ts.SyntaxKind.GreaterThanGreaterThanToken:

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -2666,11 +2666,8 @@ export class LuaTransformer {
     }
 
     public transformClassExpression(expression: ts.ClassExpression): ExpressionVisitResult {
-        const className = expression.name !== undefined
-            ? this.transformIdentifier(expression.name)
-            : tstl.createAnnonymousIdentifier();
-
-        const classDeclaration =  this.transformClassDeclaration(expression as ts.ClassExpression);
+        const className = tstl.createAnnonymousIdentifier();
+        const classDeclaration =  this.transformClassDeclaration(expression as ts.ClassExpression, className);
         return this.createImmediatelyInvokedFunctionExpression(classDeclaration, className, expression);
     }
 

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -1745,8 +1745,8 @@ export class LuaTransformer {
                 || expression.operator === ts.SyntaxKind.MinusMinusToken)) {
             // ++i, --i
             const replacementOperator = expression.operator === ts.SyntaxKind.PlusPlusToken
-                ? tstl.SyntaxKind.AdditionOperator
-                : tstl.SyntaxKind.SubractionOperator;
+                ? ts.SyntaxKind.PlusToken
+                : ts.SyntaxKind.MinusToken;
 
             return this.transformCompoundAssignmentStatement(
                 expression,
@@ -1759,8 +1759,8 @@ export class LuaTransformer {
         else if (ts.isPostfixUnaryExpression(expression)) {
             // i++, i--
             const replacementOperator = expression.operator === ts.SyntaxKind.PlusPlusToken
-                ? tstl.SyntaxKind.AdditionOperator
-                : tstl.SyntaxKind.SubractionOperator;
+                ? ts.SyntaxKind.PlusToken
+                : ts.SyntaxKind.MinusToken;
 
             return this.transformCompoundAssignmentStatement(
                 expression,
@@ -2317,23 +2317,24 @@ export class LuaTransformer {
     }
 
     public transformBinaryOperation(
-        node: ts.Node,
         left: tstl.Expression,
         right: tstl.Expression,
-        operator: tstl.BinaryOperator
+        operator: ts.BinaryOperator,
+        tsOriginal: ts.Node
     ): tstl.Expression
     {
         switch (operator) {
-            case tstl.SyntaxKind.BitwiseAndOperator:
-            case tstl.SyntaxKind.BitwiseOrOperator:
-            case tstl.SyntaxKind.BitwiseExclusiveOrOperator:
-            case tstl.SyntaxKind.BitwiseLeftShiftOperator:
-            case tstl.SyntaxKind.BitwiseRightShiftOperator:
-            case tstl.SyntaxKind.BitwiseArithmeticRightShift:
-                return this.transformBinaryBitOperation(node, left, right, operator);
+            case ts.SyntaxKind.AmpersandToken:
+            case ts.SyntaxKind.BarToken:
+            case ts.SyntaxKind.CaretToken:
+            case ts.SyntaxKind.LessThanLessThanToken:
+            case ts.SyntaxKind.GreaterThanGreaterThanToken:
+            case ts.SyntaxKind.GreaterThanGreaterThanGreaterThanToken:
+                return this.transformBinaryBitOperation(tsOriginal, left, right, operator);
 
             default:
-                return tstl.createBinaryExpression(left, right, operator, node);
+                const luaOperator = this.transformBinaryOperator(operator, tsOriginal);
+                return tstl.createBinaryExpression(left, right, luaOperator, tsOriginal);
         }
     }
 
@@ -2357,55 +2358,41 @@ export class LuaTransformer {
         // Transpile operators
         switch (expression.operatorToken.kind) {
             case ts.SyntaxKind.AmpersandToken:
-                return this.transformBinaryOperation(expression, lhs, rhs, tstl.SyntaxKind.BitwiseAndOperator);
             case ts.SyntaxKind.BarToken:
-                return this.transformBinaryOperation(expression, lhs, rhs, tstl.SyntaxKind.BitwiseOrOperator);
             case ts.SyntaxKind.CaretToken:
-                return this.transformBinaryOperation(expression, lhs, rhs, tstl.SyntaxKind.BitwiseExclusiveOrOperator);
             case ts.SyntaxKind.LessThanLessThanToken:
-                return this.transformBinaryOperation(expression, lhs, rhs, tstl.SyntaxKind.BitwiseLeftShiftOperator);
             case ts.SyntaxKind.GreaterThanGreaterThanToken:
-                return this.transformBinaryOperation(expression, lhs, rhs, tstl.SyntaxKind.BitwiseArithmeticRightShift);
             case ts.SyntaxKind.GreaterThanGreaterThanGreaterThanToken:
-                return this.transformBinaryOperation(expression, lhs, rhs, tstl.SyntaxKind.BitwiseRightShiftOperator);
-            case ts.SyntaxKind.AmpersandAmpersandToken:
-                return this.transformBinaryOperation(expression, lhs, rhs, tstl.SyntaxKind.AndOperator);
-            case ts.SyntaxKind.BarBarToken:
-                return this.transformBinaryOperation(expression, lhs, rhs, tstl.SyntaxKind.OrOperator);
-            case ts.SyntaxKind.PlusToken:
+                return this.transformBinaryBitOperation(expression, lhs, rhs, expression.operatorToken.kind);
+            case ts.SyntaxKind.PlusToken: {
                 // Replace string + with ..
                 const typeLeft = this.checker.getTypeAtLocation(expression.left);
                 const typeRight = this.checker.getTypeAtLocation(expression.right);
                 if (tsHelper.isStringType(typeLeft) || tsHelper.isStringType(typeRight)) {
-                    return this.transformBinaryOperation(expression, lhs, rhs, tstl.SyntaxKind.ConcatOperator);
+                    return tstl.createBinaryExpression(lhs, rhs, tstl.SyntaxKind.ConcatOperator, expression);
                 }
-                return this.transformBinaryOperation(expression, lhs, rhs, tstl.SyntaxKind.AdditionOperator);
+
+                return this.transformBinaryOperation(lhs, rhs, expression.operatorToken.kind, expression);
+            }
+            case ts.SyntaxKind.AmpersandAmpersandToken:
+            case ts.SyntaxKind.BarBarToken:
             case ts.SyntaxKind.MinusToken:
-                return this.transformBinaryOperation(expression, lhs, rhs, tstl.SyntaxKind.SubractionOperator);
             case ts.SyntaxKind.AsteriskToken:
-                return this.transformBinaryOperation(expression, lhs, rhs, tstl.SyntaxKind.MultiplicationOperator);
             case ts.SyntaxKind.AsteriskAsteriskToken:
-                return this.transformBinaryOperation(expression, lhs, rhs, tstl.SyntaxKind.PowerOperator);
             case ts.SyntaxKind.SlashToken:
-                return this.transformBinaryOperation(expression, lhs, rhs, tstl.SyntaxKind.DivisionOperator);
             case ts.SyntaxKind.PercentToken:
-                return this.transformBinaryOperation(expression, lhs, rhs, tstl.SyntaxKind.ModuloOperator);
             case ts.SyntaxKind.GreaterThanToken:
-                return this.transformBinaryOperation(expression, lhs, rhs, tstl.SyntaxKind.GreaterThanOperator);
             case ts.SyntaxKind.GreaterThanEqualsToken:
-                return this.transformBinaryOperation(expression, lhs, rhs, tstl.SyntaxKind.GreaterEqualOperator);
             case ts.SyntaxKind.LessThanToken:
-                return this.transformBinaryOperation(expression, lhs, rhs, tstl.SyntaxKind.LessThanOperator);
             case ts.SyntaxKind.LessThanEqualsToken:
-                return this.transformBinaryOperation(expression, lhs, rhs, tstl.SyntaxKind.LessEqualOperator);
-            case ts.SyntaxKind.EqualsToken:
-                return this.transformAssignmentExpression(expression);
             case ts.SyntaxKind.EqualsEqualsToken:
             case ts.SyntaxKind.EqualsEqualsEqualsToken:
-                return this.transformBinaryOperation(expression, lhs, rhs, tstl.SyntaxKind.EqualityOperator);
             case ts.SyntaxKind.ExclamationEqualsToken:
             case ts.SyntaxKind.ExclamationEqualsEqualsToken:
-                return this.transformBinaryOperation(expression, lhs, rhs, tstl.SyntaxKind.InequalityOperator);
+                const luaOperator = this.transformBinaryOperator(expression.operatorToken.kind, expression);
+                return tstl.createBinaryExpression(lhs, rhs, luaOperator, expression);
+            case ts.SyntaxKind.EqualsToken:
+                return this.transformAssignmentExpression(expression);
             case ts.SyntaxKind.InKeyword:
                 const indexExpression = tstl.createTableIndexExpression(rhs, lhs);
                 return tstl.createBinaryExpression(
@@ -2563,7 +2550,7 @@ export class LuaTransformer {
         expression: ts.Expression,
         lhs: ts.Expression,
         rhs: ts.Expression,
-        replacementOperator: tstl.BinaryOperator,
+        replacementOperator: ts.BinaryOperator,
         isPostfix: boolean
     ): tstl.CallExpression
     {
@@ -2600,16 +2587,16 @@ export class LuaTransformer {
                 // local ____TS_tmp = ____TS_obj[____TS_index];
                 // ____TS_obj[____TS_index] = ____TS_tmp ${replacementOperator} ${right};
                 tmpDeclaration = tstl.createVariableDeclarationStatement(tmp, accessExpression);
-                const operatorExpression = this.transformBinaryOperation(expression, tmp, right, replacementOperator);
+                const operatorExpression = this.transformBinaryOperation(tmp, right, replacementOperator, expression);
                 assignStatement = tstl.createAssignmentStatement(accessExpression, operatorExpression);
             } else {
                 // local ____TS_tmp = ____TS_obj[____TS_index] ${replacementOperator} ${right};
                 // ____TS_obj[____TS_index] = ____TS_tmp;
                 const operatorExpression = this.transformBinaryOperation(
-                    expression,
                     accessExpression,
                     right,
-                    replacementOperator
+                    replacementOperator,
+                    expression
                 );
                 tmpDeclaration = tstl.createVariableDeclarationStatement(tmp, operatorExpression);
                 assignStatement = tstl.createAssignmentStatement(accessExpression, tmp);
@@ -2629,10 +2616,10 @@ export class LuaTransformer {
             const tmpIdentifier = tstl.createIdentifier("____TS_tmp");
             const tmpDeclaration = tstl.createVariableDeclarationStatement(tmpIdentifier, left);
             const operatorExpression = this.transformBinaryOperation(
-                expression,
                 tmpIdentifier,
                 right,
-                replacementOperator
+                replacementOperator,
+                expression
             );
             const assignStatement = this.transformAssignment(lhs, operatorExpression);
             return this.createImmediatelyInvokedFunctionExpression(
@@ -2647,7 +2634,7 @@ export class LuaTransformer {
             // ${left} = ____TS_tmp;
             // return ____TS_tmp
             const tmpIdentifier = tstl.createIdentifier("____TS_tmp");
-            const operatorExpression = this.transformBinaryOperation(lhs.parent, left, right, replacementOperator);
+            const operatorExpression = this.transformBinaryOperation(left, right, replacementOperator, lhs.parent);
             const tmpDeclaration = tstl.createVariableDeclarationStatement(tmpIdentifier, operatorExpression);
             const assignStatement = this.transformAssignment(lhs, tmpIdentifier);
             return this.createImmediatelyInvokedFunctionExpression(
@@ -2659,9 +2646,70 @@ export class LuaTransformer {
         } else {
             // Simple expressions
             // ${left} = ${right}; return ${right}
-            const operatorExpression = this.transformBinaryOperation(lhs.parent, left, right, replacementOperator);
+            const operatorExpression = this.transformBinaryOperation(left, right, replacementOperator, lhs.parent);
             const assignStatement = this.transformAssignment(lhs, operatorExpression);
             return this.createImmediatelyInvokedFunctionExpression([assignStatement], left, lhs.parent);
+        }
+    }
+
+    public transformBinaryOperator(operator: ts.BinaryOperator, node: ts.Node): tstl.BinaryOperator {
+        switch (operator) {
+            // Bitwise operators
+            case ts.SyntaxKind.BarToken:
+                return tstl.SyntaxKind.BitwiseOrOperator;
+            case ts.SyntaxKind.PlusToken:
+                return tstl.SyntaxKind.AdditionOperator;
+            case ts.SyntaxKind.CaretToken:
+                return tstl.SyntaxKind.BitwiseExclusiveOrOperator;
+            case ts.SyntaxKind.MinusToken:
+                return tstl.SyntaxKind.SubractionOperator;
+            case ts.SyntaxKind.SlashToken:
+                return tstl.SyntaxKind.DivisionOperator;
+            case ts.SyntaxKind.PercentToken:
+                return tstl.SyntaxKind.ModuloOperator;
+            case ts.SyntaxKind.AsteriskToken:
+                return tstl.SyntaxKind.MultiplicationOperator;
+            case ts.SyntaxKind.AmpersandToken:
+                return tstl.SyntaxKind.BitwiseAndOperator;
+            case ts.SyntaxKind.AsteriskAsteriskToken:
+                return tstl.SyntaxKind.PowerOperator;
+            case ts.SyntaxKind.LessThanLessThanToken:
+                return tstl.SyntaxKind.BitwiseLeftShiftOperator;
+            case ts.SyntaxKind.GreaterThanGreaterThanToken:
+                throw TSTLErrors.UnsupportedKind("right shift operator (use >>> instead)", operator, node);
+            case ts.SyntaxKind.GreaterThanGreaterThanGreaterThanToken:
+                return tstl.SyntaxKind.BitwiseRightShiftOperator;
+            // Regular operators
+            case ts.SyntaxKind.AmpersandAmpersandToken:
+                return tstl.SyntaxKind.AndOperator;
+            case ts.SyntaxKind.BarBarToken:
+                return tstl.SyntaxKind.OrOperator;
+            case ts.SyntaxKind.MinusToken:
+                return tstl.SyntaxKind.SubractionOperator;
+            case ts.SyntaxKind.AsteriskToken:
+                return tstl.SyntaxKind.MultiplicationOperator;
+            case ts.SyntaxKind.AsteriskAsteriskToken:
+                return tstl.SyntaxKind.PowerOperator;
+            case ts.SyntaxKind.SlashToken:
+                return tstl.SyntaxKind.DivisionOperator;
+            case ts.SyntaxKind.PercentToken:
+                return tstl.SyntaxKind.ModuloOperator;
+            case ts.SyntaxKind.GreaterThanToken:
+                return tstl.SyntaxKind.GreaterThanOperator;
+            case ts.SyntaxKind.GreaterThanEqualsToken:
+                return tstl.SyntaxKind.GreaterEqualOperator;
+            case ts.SyntaxKind.LessThanToken:
+                return tstl.SyntaxKind.LessThanOperator;
+            case ts.SyntaxKind.LessThanEqualsToken:
+                return tstl.SyntaxKind.LessEqualOperator;
+            case ts.SyntaxKind.EqualsEqualsToken:
+            case ts.SyntaxKind.EqualsEqualsEqualsToken:
+                return tstl.SyntaxKind.EqualityOperator;
+            case ts.SyntaxKind.ExclamationEqualsToken:
+            case ts.SyntaxKind.ExclamationEqualsEqualsToken:
+                return tstl.SyntaxKind.InequalityOperator;
+            default:
+                throw TSTLErrors.UnsupportedKind("binary operator", operator, node);
         }
     }
 
@@ -2675,7 +2723,7 @@ export class LuaTransformer {
         node: ts.Node,
         lhs: ts.Expression,
         rhs: ts.Expression,
-        replacementOperator: tstl.BinaryOperator
+        replacementOperator: ts.BinaryOperator
     ): tstl.Statement
     {
         if (replacementOperator === tstl.SyntaxKind.AdditionOperator) {
@@ -2704,10 +2752,10 @@ export class LuaTransformer {
                 [obj, index], [this.transformExpression(objExpression), this.transformExpression(indexExpression)]);
             const accessExpression = tstl.createTableIndexExpression(obj, index);
             const operatorExpression = this.transformBinaryOperation(
-                node,
                 accessExpression,
                 tstl.createParenthesizedExpression(right),
-                replacementOperator
+                replacementOperator,
+                node
             );
             const assignStatement = tstl.createAssignmentStatement(accessExpression, operatorExpression);
             return tstl.createDoStatement([objAndIndexDeclaration, assignStatement]);
@@ -2715,7 +2763,7 @@ export class LuaTransformer {
         } else {
             // Simple statements
             // ${left} = ${left} ${replacementOperator} ${right}
-            const operatorExpression = this.transformBinaryOperation(node, left, right, replacementOperator);
+            const operatorExpression = this.transformBinaryOperation(left, right, replacementOperator, node);
             return this.transformAssignment(lhs, operatorExpression);
         }
     }
@@ -2767,28 +2815,28 @@ export class LuaTransformer {
         node: ts.Node,
         left: tstl.Expression,
         right: tstl.Expression,
-        operator: tstl.BinaryBitwiseOperator,
+        operator: ts.BinaryOperator,
         lib: string
     ): ExpressionVisitResult
     {
         let bitFunction: string;
         switch (operator) {
-            case tstl.SyntaxKind.BitwiseAndOperator:
+            case ts.SyntaxKind.AmpersandToken:
                 bitFunction = "band";
                 break;
-            case tstl.SyntaxKind.BitwiseOrOperator:
+            case ts.SyntaxKind.BarToken:
                 bitFunction = "bor";
                 break;
-            case tstl.SyntaxKind.BitwiseExclusiveOrOperator:
+            case ts.SyntaxKind.CaretToken:
                 bitFunction = "bxor";
                 break;
-            case tstl.SyntaxKind.BitwiseLeftShiftOperator:
+            case ts.SyntaxKind.LessThanLessThanToken:
                 bitFunction = "lshift";
                 break;
-            case tstl.SyntaxKind.BitwiseRightShiftOperator:
+            case ts.SyntaxKind.GreaterThanGreaterThanGreaterThanToken:
                 bitFunction = "rshift";
                 break;
-            case tstl.SyntaxKind.BitwiseArithmeticRightShift:
+            case ts.SyntaxKind.GreaterThanGreaterThanToken:
                 bitFunction = "arshift";
                 break;
             default:
@@ -2805,7 +2853,7 @@ export class LuaTransformer {
         node: ts.Node,
         left: tstl.Expression,
         right: tstl.Expression,
-        operator: tstl.BinaryBitwiseOperator
+        operator: ts.BinaryOperator
     ): ExpressionVisitResult
     {
         switch (this.options.luaTarget) {
@@ -2819,11 +2867,8 @@ export class LuaTransformer {
                 return this.transformBinaryBitLibOperation(node, left, right, operator, "bit");
 
             default:
-                if (operator === tstl.SyntaxKind.BitwiseArithmeticRightShift) {
-                    throw TSTLErrors.UnsupportedForTarget("Bitwise >> operator (use >>> instead)",
-                        this.options.luaTarget, node);
-                }
-                return tstl.createBinaryExpression(left, right, operator, node);
+                const luaOperator = this.transformBinaryOperator(operator, node);
+                return tstl.createBinaryExpression(left, right, luaOperator, node);
         }
     }
 
@@ -2867,7 +2912,7 @@ export class LuaTransformer {
                     expression,
                     expression.operand,
                     ts.createLiteral(1),
-                    tstl.SyntaxKind.AdditionOperator,
+                    ts.SyntaxKind.PlusToken,
                     true
                 );
 
@@ -2876,7 +2921,7 @@ export class LuaTransformer {
                     expression,
                     expression.operand,
                     ts.createLiteral(1),
-                    tstl.SyntaxKind.SubractionOperator,
+                    ts.SyntaxKind.MinusToken,
                     true
                 );
 
@@ -2892,7 +2937,7 @@ export class LuaTransformer {
                     expression,
                     expression.operand,
                     ts.createLiteral(1),
-                    tstl.SyntaxKind.AdditionOperator,
+                    ts.SyntaxKind.PlusToken,
                     false
                 );
 
@@ -2901,7 +2946,7 @@ export class LuaTransformer {
                     expression,
                     expression.operand,
                     ts.createLiteral(1),
-                    tstl.SyntaxKind.SubractionOperator,
+                    ts.SyntaxKind.MinusToken,
                     false
                 );
 

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -394,7 +394,7 @@ export class LuaTransformer {
 
         let className = statement.name
             ? this.transformIdentifier(statement.name)
-            : tstl.createIdentifier("____");
+            : tstl.createAnnonymousIdentifier();
 
         if (!className) {
             throw TSTLErrors.MissingClassName(statement);
@@ -2667,7 +2667,7 @@ export class LuaTransformer {
     public transformClassExpression(expression: ts.ClassExpression): ExpressionVisitResult {
         const className = expression.name !== undefined
             ? this.transformIdentifier(expression.name)
-            : tstl.createIdentifier("____");
+            : tstl.createAnnonymousIdentifier();
 
         const classDeclaration =  this.transformClassDeclaration(expression as ts.ClassExpression);
         return this.createImmediatelyInvokedFunctionExpression(classDeclaration, className, expression);

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -2364,9 +2364,9 @@ export class LuaTransformer {
             case ts.SyntaxKind.LessThanLessThanToken:
                 return this.transformBinaryOperation(expression, lhs, rhs, tstl.SyntaxKind.BitwiseLeftShiftOperator);
             case ts.SyntaxKind.GreaterThanGreaterThanToken:
-                return this.transformBinaryOperation(expression, lhs, rhs, tstl.SyntaxKind.BitwiseRightShiftOperator);
-            case ts.SyntaxKind.GreaterThanGreaterThanGreaterThanToken:
                 return this.transformBinaryOperation(expression, lhs, rhs, tstl.SyntaxKind.BitwiseArithmeticRightShift);
+            case ts.SyntaxKind.GreaterThanGreaterThanGreaterThanToken:
+                return this.transformBinaryOperation(expression, lhs, rhs, tstl.SyntaxKind.BitwiseRightShiftOperator);
             case ts.SyntaxKind.AmpersandAmpersandToken:
                 return this.transformBinaryOperation(expression, lhs, rhs, tstl.SyntaxKind.AndOperator);
             case ts.SyntaxKind.BarBarToken:
@@ -2812,7 +2812,7 @@ export class LuaTransformer {
                 return this.transformBinaryBitLibOperation(node, left, right, operator, "bit");
 
             default:
-                if (operator === tstl.SyntaxKind.BitwiseArithmeticRightShift) {
+                if (operator === tstl.SyntaxKind.BitwiseRightShiftOperator) {
                     throw TSTLErrors.UnsupportedForTarget("Bitwise >>> operator", this.options.luaTarget, node);
                 }
                 return tstl.createBinaryExpression(left, right, operator, node);

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -2554,15 +2554,6 @@ export class LuaTransformer {
         isPostfix: boolean
     ): tstl.CallExpression
     {
-        if (replacementOperator === tstl.SyntaxKind.AdditionOperator) {
-            // Check is we need to use string concat operator
-            const typeLeft = this.checker.getTypeAtLocation(lhs);
-            const typeRight = this.checker.getTypeAtLocation(rhs);
-            if (tsHelper.isStringType(typeLeft) || tsHelper.isStringType(typeRight)) {
-                replacementOperator = tstl.SyntaxKind.ConcatOperator;
-            }
-        }
-
         const left = this.transformExpression(lhs) as tstl.IdentifierOrTableIndexExpression;
         let right = this.transformExpression(rhs);
 
@@ -2686,6 +2677,16 @@ export class LuaTransformer {
                 return tstl.SyntaxKind.OrOperator;
             case ts.SyntaxKind.MinusToken:
                 return tstl.SyntaxKind.SubractionOperator;
+            case ts.SyntaxKind.PlusToken:
+                if (ts.isBinaryExpression(node)) {
+                    // Check is we need to use string concat operator
+                    const typeLeft = this.checker.getTypeAtLocation(node.left);
+                    const typeRight = this.checker.getTypeAtLocation(node.right);
+                    if (tsHelper.isStringType(typeLeft) || tsHelper.isStringType(typeRight)) {
+                        return tstl.SyntaxKind.ConcatOperator;
+                    }
+                }
+                return tstl.SyntaxKind.AdditionOperator;
             case ts.SyntaxKind.AsteriskToken:
                 return tstl.SyntaxKind.MultiplicationOperator;
             case ts.SyntaxKind.AsteriskAsteriskToken:
@@ -2726,15 +2727,6 @@ export class LuaTransformer {
         replacementOperator: ts.BinaryOperator
     ): tstl.Statement
     {
-        if (replacementOperator === tstl.SyntaxKind.AdditionOperator) {
-            // Check is we need to use string concat operator
-            const typeLeft = this.checker.getTypeAtLocation(lhs);
-            const typeRight = this.checker.getTypeAtLocation(rhs);
-            if (tsHelper.isStringType(typeLeft) || tsHelper.isStringType(typeRight)) {
-                replacementOperator = tstl.SyntaxKind.ConcatOperator;
-            }
-        }
-
         const left = this.transformExpression(lhs) as tstl.IdentifierOrTableIndexExpression;
         const right = this.transformExpression(rhs);
 

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -275,13 +275,13 @@ export class TSHelper {
             case ts.SyntaxKind.SlashEqualsToken:
                 return [true, ts.SyntaxKind.SlashToken];
             case ts.SyntaxKind.PercentEqualsToken:
-                return [true, ts.SyntaxKind.PercentEqualsToken];
+                return [true, ts.SyntaxKind.PercentToken];
             case ts.SyntaxKind.AsteriskEqualsToken:
                 return [true, ts.SyntaxKind.AsteriskToken];
             case ts.SyntaxKind.AmpersandEqualsToken:
                 return [true, ts.SyntaxKind.AmpersandToken];
             case ts.SyntaxKind.AsteriskAsteriskEqualsToken:
-                return [true, ts.SyntaxKind.AsteriskEqualsToken];
+                return [true, ts.SyntaxKind.AsteriskToken];
             case ts.SyntaxKind.LessThanLessThanEqualsToken:
                 return [true, ts.SyntaxKind.LessThanLessThanToken];
             case ts.SyntaxKind.GreaterThanGreaterThanEqualsToken:

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -281,7 +281,7 @@ export class TSHelper {
             case ts.SyntaxKind.AmpersandEqualsToken:
                 return [true, ts.SyntaxKind.AmpersandToken];
             case ts.SyntaxKind.AsteriskAsteriskEqualsToken:
-                return [true, ts.SyntaxKind.AsteriskToken];
+                return [true, ts.SyntaxKind.AsteriskAsteriskToken];
             case ts.SyntaxKind.LessThanLessThanEqualsToken:
                 return [true, ts.SyntaxKind.LessThanLessThanToken];
             case ts.SyntaxKind.GreaterThanGreaterThanEqualsToken:

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -285,9 +285,9 @@ export class TSHelper {
             case ts.SyntaxKind.LessThanLessThanEqualsToken:
                 return [true, tstl.SyntaxKind.BitwiseLeftShiftOperator];
             case ts.SyntaxKind.GreaterThanGreaterThanEqualsToken:
-                return [true, tstl.SyntaxKind.BitwiseRightShiftOperator];
-            case ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken:
                 return [true, tstl.SyntaxKind.BitwiseArithmeticRightShift];
+            case ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken:
+                return [true, tstl.SyntaxKind.BitwiseRightShiftOperator];
         }
 
         return [false, undefined];

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -262,32 +262,32 @@ export class TSHelper {
         return undefined;
     }
 
-    public static isBinaryAssignmentToken(token: ts.SyntaxKind): [boolean, tstl.BinaryOperator] {
+    public static isBinaryAssignmentToken(token: ts.SyntaxKind): [boolean, ts.BinaryOperator] {
         switch (token) {
             case ts.SyntaxKind.BarEqualsToken:
-                return [true, tstl.SyntaxKind.BitwiseOrOperator];
+                return [true, ts.SyntaxKind.BarToken];
             case ts.SyntaxKind.PlusEqualsToken:
-                return [true, tstl.SyntaxKind.AdditionOperator];
+                return [true, ts.SyntaxKind.PlusToken];
             case ts.SyntaxKind.CaretEqualsToken:
-                return [true, tstl.SyntaxKind.BitwiseExclusiveOrOperator];
+                return [true, ts.SyntaxKind.CaretToken];
             case ts.SyntaxKind.MinusEqualsToken:
-                return [true, tstl.SyntaxKind.SubractionOperator];
+                return [true, ts.SyntaxKind.MinusToken];
             case ts.SyntaxKind.SlashEqualsToken:
-                return [true, tstl.SyntaxKind.DivisionOperator];
+                return [true, ts.SyntaxKind.SlashToken];
             case ts.SyntaxKind.PercentEqualsToken:
-                return [true, tstl.SyntaxKind.ModuloOperator];
+                return [true, ts.SyntaxKind.PercentEqualsToken];
             case ts.SyntaxKind.AsteriskEqualsToken:
-                return [true, tstl.SyntaxKind.MultiplicationOperator];
+                return [true, ts.SyntaxKind.AsteriskToken];
             case ts.SyntaxKind.AmpersandEqualsToken:
-                return [true, tstl.SyntaxKind.BitwiseAndOperator];
+                return [true, ts.SyntaxKind.AmpersandToken];
             case ts.SyntaxKind.AsteriskAsteriskEqualsToken:
-                return [true, tstl.SyntaxKind.PowerOperator];
+                return [true, ts.SyntaxKind.AsteriskEqualsToken];
             case ts.SyntaxKind.LessThanLessThanEqualsToken:
-                return [true, tstl.SyntaxKind.BitwiseLeftShiftOperator];
+                return [true, ts.SyntaxKind.LessThanLessThanToken];
             case ts.SyntaxKind.GreaterThanGreaterThanEqualsToken:
-                return [true, tstl.SyntaxKind.BitwiseArithmeticRightShift];
+                return [true, ts.SyntaxKind.GreaterThanGreaterThanToken];
             case ts.SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken:
-                return [true, tstl.SyntaxKind.BitwiseRightShiftOperator];
+                return [true, ts.SyntaxKind.GreaterThanGreaterThanGreaterThanToken];
         }
 
         return [false, undefined];

--- a/test/unit/class.spec.ts
+++ b/test/unit/class.spec.ts
@@ -710,6 +710,22 @@ export class ClassTests {
         Expect(result).toBe("instance of b");
     }
 
+    @Test("Named Class Expression")
+    public namedClassExpression(): void {
+        const result = util.transpileAndExecute(
+            `const a = class MyClass {
+                public method() {
+                    return "foo";
+                }
+            }
+            let inst = new a();
+            return inst.method();`
+        );
+
+        // Assert
+        Expect(result).toBe("foo");
+    }
+
     @Test("classExpressionBaseClassMethod")
     public classExpressionBaseClassMethod(): void {
         const result = util.transpileAndExecute(

--- a/test/unit/expressions.spec.ts
+++ b/test/unit/expressions.spec.ts
@@ -250,7 +250,7 @@ export class ExpressionTests {
     @TestCase("(inst.field + 3) & 3", (8 + 3) & 3)
     @TestCase("inst.field | 3", 8 | 3)
     @TestCase("inst.field << 3", 8 << 3)
-    @TestCase("inst.field >> 1", 8 >> 1)
+    @TestCase("inst.field >>> 1", 8 >> 1)
     @TestCase("inst.field = 3", 3)
     @TestCase(`"abc" + inst.field`, "abc8")
     @Test("Get accessor expression")
@@ -279,7 +279,7 @@ export class ExpressionTests {
     @TestCase("&= 3", (4 & 3) + 4)
     @TestCase("|= 3", (4 | 3) + 4)
     @TestCase("<<= 3", (4 << 3) + 4)
-    @TestCase(">>= 3", (4 >> 3) + 4)
+    @TestCase(">>>= 3", (4 >> 3) + 4)
     @Test("Set accessorExpression")
     public setAccessorBinary(expression: string, expected: any): void {
         const source = `class MyClass {`

--- a/test/unit/expressions.spec.ts
+++ b/test/unit/expressions.spec.ts
@@ -4,6 +4,7 @@ import { LuaTarget, LuaLibImportKind } from "../../src/CompilerOptions";
 
 import * as ts from "typescript";
 import * as util from "../src/util";
+import { TSTLErrors } from "../../src/TSTLErrors";
 
 export class ExpressionTests {
 
@@ -165,8 +166,11 @@ export class ExpressionTests {
     @Test("Unsupported bitop 5.3")
     public bitOperatorOverride53Unsupported(input: string): void {
         Expect(() => util.transpileString(input, { luaTarget: LuaTarget.Lua53, luaLibImport: LuaLibImportKind.None }))
-            .toThrowError(TranspileError,
-                "Bitwise >> operator (use >>> instead) is/are not supported for target Lua 5.3.");
+            .toThrowError(TranspileError, TSTLErrors.UnsupportedKind(
+                "Bitwise >> operator (use >>> instead)",
+                ts.SyntaxKind.GreaterThanGreaterThanToken,
+                undefined
+            ).message);
     }
 
     @TestCase("1+1", "1 + 1;")

--- a/test/unit/expressions.spec.ts
+++ b/test/unit/expressions.spec.ts
@@ -152,20 +152,21 @@ export class ExpressionTests {
     @TestCase("a^=b", "a = a ~ b;")
     @TestCase("a<<b", "a << b;")
     @TestCase("a<<=b", "a = a << b;")
-    @TestCase("a>>b", "a >> b;")
-    @TestCase("a>>=b", "a = a >> b;")
+    @TestCase("a>>>b", "a >> b;")
+    @TestCase("a>>>=b", "a = a >> b;")
     @Test("Bitop [5.3]")
     public bitOperatorOverride53(input: string, lua: string): void {
         const options = { luaTarget: LuaTarget.Lua53, luaLibImport: LuaLibImportKind.None };
         Expect(util.transpileString(input, options)).toBe(lua);
     }
 
-    @TestCase("a>>>b")
-    @TestCase("a>>>=b")
+    @TestCase("a>>b")
+    @TestCase("a>>=b")
     @Test("Unsupported bitop 5.3")
     public bitOperatorOverride53Unsupported(input: string): void {
         Expect(() => util.transpileString(input, { luaTarget: LuaTarget.Lua53, luaLibImport: LuaLibImportKind.None }))
-            .toThrowError(TranspileError, "Bitwise >>> operator is/are not supported for target Lua 5.3.");
+            .toThrowError(TranspileError,
+                "Bitwise >> operator (use >>> instead) is/are not supported for target Lua 5.3.");
     }
 
     @TestCase("1+1", "1 + 1;")

--- a/test/unit/expressions.spec.ts
+++ b/test/unit/expressions.spec.ts
@@ -167,7 +167,7 @@ export class ExpressionTests {
     public bitOperatorOverride53Unsupported(input: string): void {
         Expect(() => util.transpileString(input, { luaTarget: LuaTarget.Lua53, luaLibImport: LuaLibImportKind.None }))
             .toThrowError(TranspileError, TSTLErrors.UnsupportedKind(
-                "Bitwise >> operator (use >>> instead)",
+                "right shift operator (use >>> instead)",
                 ts.SyntaxKind.GreaterThanGreaterThanToken,
                 undefined
             ).message);

--- a/test/unit/expressions.spec.ts
+++ b/test/unit/expressions.spec.ts
@@ -114,10 +114,10 @@ export class ExpressionTests {
     @TestCase("a^=b", "a = bit.bxor(a, b);")
     @TestCase("a<<b", "bit.lshift(a, b);")
     @TestCase("a<<=b", "a = bit.lshift(a, b);")
-    @TestCase("a>>b", "bit.rshift(a, b);")
-    @TestCase("a>>=b", "a = bit.rshift(a, b);")
-    @TestCase("a>>>b", "bit.arshift(a, b);")
-    @TestCase("a>>>=b", "a = bit.arshift(a, b);")
+    @TestCase("a>>b", "bit.arshift(a, b);")
+    @TestCase("a>>=b", "a = bit.arshift(a, b);")
+    @TestCase("a>>>b", "bit.rshift(a, b);")
+    @TestCase("a>>>=b", "a = bit.rshift(a, b);")
     @Test("Bitop [JIT]")
     public bitOperatorOverrideJIT(input: string, lua: string): void {
         const options = { luaTarget: LuaTarget.LuaJIT, luaLibImport: LuaLibImportKind.None };
@@ -133,10 +133,10 @@ export class ExpressionTests {
     @TestCase("a^=b", "a = bit32.bxor(a, b);")
     @TestCase("a<<b", "bit32.lshift(a, b);")
     @TestCase("a<<=b", "a = bit32.lshift(a, b);")
-    @TestCase("a>>b", "bit32.rshift(a, b);")
-    @TestCase("a>>=b", "a = bit32.rshift(a, b);")
-    @TestCase("a>>>b", "bit32.arshift(a, b);")
-    @TestCase("a>>>=b", "a = bit32.arshift(a, b);")
+    @TestCase("a>>b", "bit32.arshift(a, b);")
+    @TestCase("a>>=b", "a = bit32.arshift(a, b);")
+    @TestCase("a>>>b", "bit32.rshift(a, b);")
+    @TestCase("a>>>=b", "a = bit32.rshift(a, b);")
     @Test("Bitop [5.2]")
     public bitOperatorOverride52(input: string, lua: string): void {
         const options = { luaTarget: LuaTarget.Lua52, luaLibImport: LuaLibImportKind.None };

--- a/test/unit/math.spec.ts
+++ b/test/unit/math.spec.ts
@@ -51,7 +51,7 @@ export class MathTests {
     @TestCase("x &= y", "x=2;y=6")
     @TestCase("x ^= y", "x=5;y=6")
     @TestCase("x <<= y", "x=192;y=6")
-    @TestCase("x >>= y", "x=0;y=6")
+    @TestCase("x >>>= y", "x=0;y=6")
     @Test("Operator assignment statements")
     public opAssignmentStatement(statement: string, expected: string): void {
         const result = util.transpileAndExecute(
@@ -76,7 +76,7 @@ export class MathTests {
     @TestCase("o.p &= a[0]", "o=2;a=6")
     @TestCase("o.p ^= a[0]", "o=5;a=6")
     @TestCase("o.p <<= a[0]", "o=192;a=6")
-    @TestCase("o.p >>= a[0]", "o=0;a=6")
+    @TestCase("o.p >>>= a[0]", "o=0;a=6")
     @Test("Operator assignment to simple property statements")
     public opSimplePropAssignmentStatement(statement: string, expected: string): void {
         const result = util.transpileAndExecute(
@@ -101,7 +101,7 @@ export class MathTests {
     @TestCase("o.p.d &= a[0][0]", "o=2;a=[6,11],[7,13]")
     @TestCase("o.p.d ^= a[0][0]", "o=5;a=[6,11],[7,13]")
     @TestCase("o.p.d <<= a[0][0]", "o=192;a=[6,11],[7,13]")
-    @TestCase("o.p.d >>= a[0][0]", "o=0;a=[6,11],[7,13]")
+    @TestCase("o.p.d >>>= a[0][0]", "o=0;a=[6,11],[7,13]")
     @Test("Operator assignment to deep property statements")
     public opDeepPropAssignmentStatement(statement: string, expected: string): void {
         const result = util.transpileAndExecute(
@@ -126,7 +126,7 @@ export class MathTests {
     @TestCase("of().p &= af()[i()]", "o=2;a=6")
     @TestCase("of().p ^= af()[i()]", "o=5;a=6")
     @TestCase("of().p <<= af()[i()]", "o=192;a=6")
-    @TestCase("of().p >>= af()[i()]", "o=0;a=6")
+    @TestCase("of().p >>>= af()[i()]", "o=0;a=6")
     @Test("Operator assignment to complex property statements")
     public opComplexPropAssignmentStatement(statement: string, expected: string): void {
         const result = util.transpileAndExecute(
@@ -154,7 +154,7 @@ export class MathTests {
     @TestCase("of().p.d &= af()[i()][i()]", "o=2;a=[7,6],[11,13];i=2")
     @TestCase("of().p.d ^= af()[i()][i()]", "o=5;a=[7,6],[11,13];i=2")
     @TestCase("of().p.d <<= af()[i()][i()]", "o=192;a=[7,6],[11,13];i=2")
-    @TestCase("of().p.d >>= af()[i()][i()]", "o=0;a=[7,6],[11,13];i=2")
+    @TestCase("of().p.d >>>= af()[i()][i()]", "o=0;a=[7,6],[11,13];i=2")
     @Test("Operator assignment to complex deep property statements")
     public opComplexDeepPropAssignmentStatement(statement: string, expected: string): void {
         const result = util.transpileAndExecute(
@@ -183,7 +183,7 @@ export class MathTests {
     @TestCase("x &= y", "2;x=2;y=6")
     @TestCase("x ^= y", "5;x=5;y=6")
     @TestCase("x <<= y", "192;x=192;y=6")
-    @TestCase("x >>= y", "0;x=0;y=6")
+    @TestCase("x >>>= y", "0;x=0;y=6")
     @TestCase("x + (y += 7)", "16;x=3;y=13")
     @TestCase("x + (y += 7)", "16;x=3;y=13")
     @TestCase("x++ + (y += 7)", "16;x=4;y=13")
@@ -211,7 +211,7 @@ export class MathTests {
     @TestCase("o.p &= a[0]", "2;o=2;a=6")
     @TestCase("o.p ^= a[0]", "5;o=5;a=6")
     @TestCase("o.p <<= a[0]", "192;o=192;a=6")
-    @TestCase("o.p >>= a[0]", "0;o=0;a=6")
+    @TestCase("o.p >>>= a[0]", "0;o=0;a=6")
     @TestCase("o.p + (a[0] += 7)", "16;o=3;a=13")
     @TestCase("o.p += (a[0] += 7)", "16;o=16;a=13")
     @TestCase("o.p++ + (a[0] += 7)", "16;o=4;a=13")
@@ -239,7 +239,7 @@ export class MathTests {
     @TestCase("of().p &= af()[i()]", "2;o=2;a=6")
     @TestCase("of().p ^= af()[i()]", "5;o=5;a=6")
     @TestCase("of().p <<= af()[i()]", "192;o=192;a=6")
-    @TestCase("of().p >>= af()[i()]", "0;o=0;a=6")
+    @TestCase("of().p >>>= af()[i()]", "0;o=0;a=6")
     @TestCase("of().p + (af()[i()] += 7)", "16;o=3;a=13")
     @TestCase("of().p += (af()[i()] += 7)", "16;o=16;a=13")
     @TestCase("of().p++ + (af()[i()] += 7)", "16;o=4;a=13")

--- a/tslint.json
+++ b/tslint.json
@@ -34,6 +34,7 @@
         "no-construct": true,
         "no-debugger": true,
         "no-default-export": true,
+        "no-duplicate-switch-case": true,
         "no-duplicate-variable": true,
         "no-inferrable-types": true,
         "no-namespace": [true, "allow-declarations"],


### PR DESCRIPTION
Fixed an issue where `const foo = class Bar {}` would translate as:
```lua
local foo = (function()
    local Bar = Bar or {};
    -- ...
    return ____;
end)()
```
The function will now just return `Bar`.

Also swapped around the meaning of right shift operators. Fixes #471