### PR TITLE
@luaIterator on array types

### DIFF
--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -2073,13 +2073,13 @@ export class LuaTransformer {
         // Transpile body
         const body = tstl.createBlock(this.transformLoopBody(statement));
 
-        if (tsHelper.isArrayType(this.checker.getTypeAtLocation(statement.expression), this.checker)) {
-            // Arrays
-            return this.transformForOfArrayStatement(statement, body);
-
-        } else if (tsHelper.isLuaIteratorType(statement.expression, this.checker)) {
+        if (tsHelper.isLuaIteratorType(statement.expression, this.checker)) {
             // LuaIterators
             return this.transformForOfLuaIteratorStatement(statement, body);
+
+        } else if (tsHelper.isArrayType(this.checker.getTypeAtLocation(statement.expression), this.checker)) {
+            // Arrays
+            return this.transformForOfArrayStatement(statement, body);
 
         } else {
             // TS Iterables

--- a/test/unit/loops.spec.ts
+++ b/test/unit/loops.spec.ts
@@ -1,4 +1,4 @@
-import { Expect, Test, TestCase, FocusTest } from "alsatian";
+import { Expect, Test, TestCase } from "alsatian";
 import * as ts from "typescript";
 import { TranspileError } from "../../src/TranspileError";
 import { LuaLibImportKind, LuaTarget } from "../../src/CompilerOptions";

--- a/test/unit/loops.spec.ts
+++ b/test/unit/loops.spec.ts
@@ -1,4 +1,4 @@
-import { Expect, Test, TestCase } from "alsatian";
+import { Expect, Test, TestCase, FocusTest } from "alsatian";
 import * as ts from "typescript";
 import { TranspileError } from "../../src/TranspileError";
 import { LuaLibImportKind, LuaTarget } from "../../src/CompilerOptions";
@@ -526,6 +526,27 @@ export class LuaLoopTests
         const code = `const arr = ["a", "b", "c"];
             /** @luaIterator */
             interface Iter extends Iterable<string> {}
+            function luaIter(): Iter {
+                let i = 0;
+                return (() => arr[i++]) as any;
+            }
+            let result = "";
+            for (let e of luaIter()) { result += e; }
+            return result;`;
+        const compilerOptions = {
+            luaLibImport: LuaLibImportKind.Require,
+            luaTarget: LuaTarget.Lua53,
+            target: ts.ScriptTarget.ES2015,
+        };
+        const result = util.transpileAndExecute(code, compilerOptions);
+        Expect(result).toBe("abc");
+    }
+
+    @Test("forof array lua iterator")
+    public forofArrayLuaIterator(): void {
+        const code = `const arr = ["a", "b", "c"];
+            /** @luaIterator */
+            interface Iter extends Array<string> {}
             function luaIter(): Iter {
                 let i = 0;
                 return (() => arr[i++]) as any;


### PR DESCRIPTION
This adds support for using `@luaIterator` directive on array types in addition to `Iterable`. This allows it to work when targetting older ES versions that don't define `Iterable`.

```ts
/** @luaIterator */ declare interface IterableLuaIterator<T> extends Iterable<T> {} // Works in ES6+ only
/** @luaIterator */ declare interface ArrayLuaIterator<T> extends Array<T> {} // Works in all ES targets
```
