### PR TITLE
Using getContextualType in inferAssignedType

### DIFF
--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -1088,7 +1088,7 @@ export class LuaTransformer {
         }
 
         const type = this.checker.getTypeAtLocation(node);
-        const context = tsHelper.getFunctionContextType(type, this.checker, this.program) !== ContextType.Void
+        const context = tsHelper.getFunctionContextType(type, this.checker) !== ContextType.Void
             ? this.createSelfIdentifier()
             : undefined;
         const [paramNames, dots, restParamName] = this.transformParameters(node.parameters, context);
@@ -1594,7 +1594,7 @@ export class LuaTransformer {
         }
 
         const type = this.checker.getTypeAtLocation(functionDeclaration);
-        const context = tsHelper.getFunctionContextType(type, this.checker, this.program) !== ContextType.Void
+        const context = tsHelper.getFunctionContextType(type, this.checker) !== ContextType.Void
             ? this.createSelfIdentifier()
             : undefined;
         const [params, dotsLiteral, restParamName] = this.transformParameters(functionDeclaration.parameters, context);
@@ -1794,7 +1794,7 @@ export class LuaTransformer {
                 const expressionType = this.checker.getTypeAtLocation(statement.expression);
                 this.validateFunctionAssignment(statement, expressionType, returnType);
             }
-            if (tsHelper.isInTupleReturnFunction(statement, this.checker, this.program)) {
+            if (tsHelper.isInTupleReturnFunction(statement, this.checker)) {
                 // Parent function is a TupleReturn function
                 if (ts.isArrayLiteralExpression(statement.expression)) {
                     // If return expression is an array literal, leave out brackets.
@@ -3005,7 +3005,7 @@ export class LuaTransformer {
     ): ExpressionVisitResult
     {
         const type = this.checker.getTypeAtLocation(node);
-        const hasContext = tsHelper.getFunctionContextType(type, this.checker, this.program) !== ContextType.Void;
+        const hasContext = tsHelper.getFunctionContextType(type, this.checker) !== ContextType.Void;
         // Build parameter string
         const [paramNames, dotsLiteral, spreadIdentifier] = this.transformParameters(
             node.parameters,
@@ -3099,7 +3099,7 @@ export class LuaTransformer {
         const isTupleReturn = tsHelper.isTupleReturnCall(node, this.checker);
         const isTupleReturnForward = node.parent
             && ts.isReturnStatement(node.parent)
-            && tsHelper.isInTupleReturnFunction(node, this.checker, this.program);
+            && tsHelper.isInTupleReturnFunction(node, this.checker);
         const isInDestructingAssignment = tsHelper.isInDestructingAssignment(node);
         const isInSpread = node.parent && ts.isSpreadElement(node.parent);
         const returnValueIsUsed = node.parent && !ts.isExpressionStatement(node.parent);
@@ -3885,7 +3885,7 @@ export class LuaTransformer {
     public transformFunctionCallExpression(node: ts.CallExpression): tstl.CallExpression {
         const expression = node.expression as ts.PropertyAccessExpression;
         const callerType = this.checker.getTypeAtLocation(expression.expression);
-        if (tsHelper.getFunctionContextType(callerType, this.checker, this.program) === ContextType.Void) {
+        if (tsHelper.getFunctionContextType(callerType, this.checker) === ContextType.Void) {
             throw TSTLErrors.UnsupportedSelfFunctionConversion(node);
         }
         const params = this.transformArguments(node.arguments);
@@ -4320,8 +4320,8 @@ export class LuaTransformer {
         fromTypeCache.add(toType);
 
         // Check function assignments
-        const fromContext = tsHelper.getFunctionContextType(fromType, this.checker, this.program);
-        const toContext = tsHelper.getFunctionContextType(toType, this.checker, this.program);
+        const fromContext = tsHelper.getFunctionContextType(fromType, this.checker);
+        const toContext = tsHelper.getFunctionContextType(toType, this.checker);
 
         if (fromContext === ContextType.Mixed || toContext === ContextType.Mixed) {
             throw TSTLErrors.UnsupportedOverloadAssignment(node, toName);

--- a/test/unit/assignments.spec.ts
+++ b/test/unit/assignments.spec.ts
@@ -1105,6 +1105,21 @@ export class AssignmentTests {
     @TestCase("(this: void, s: string) => string", "function(s) { return s; }")
     @TestCase("(this: any, s: string) => string", "function(s) { return s; }")
     @TestCase("(s: string) => string", "function(s) { return s; }")
+    @Test("Function expression type inference in union tuple")
+    public functionExpressionTypeInferenceInUnionTuple(funcType: string, funcExp: string): void {
+        const code =
+            `interface I { callback: ${funcType}; }
+            let a: I[] | number = [{ callback: ${funcExp} }];
+            return a[0].callback("foo");`;
+        Expect(util.transpileAndExecute(code)).toBe("foo");
+    }
+
+    @TestCase("(this: void, s: string) => string", "s => s")
+    @TestCase("(this: any, s: string) => string", "s => s")
+    @TestCase("(s: string) => string", "s => s")
+    @TestCase("(this: void, s: string) => string", "function(s) { return s; }")
+    @TestCase("(this: any, s: string) => string", "function(s) { return s; }")
+    @TestCase("(s: string) => string", "function(s) { return s; }")
     @Test("Function expression type inference in as cast")
     public functionExpressionTypeInferenceInAsCast(funcType: string, funcExp: string): void {
         const code =


### PR DESCRIPTION
fixes #486 

This replaces the body of inferAssignedType with typescript's api function that does the same thing. Hopefully this will prevent more issues arising regarding function expression inference.
