### PR TITLE
support for @tupleReturn per overloaded function signature

### DIFF
--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -1800,8 +1800,13 @@ export class LuaTransformer {
                     // If return expression is an array literal, leave out brackets.
                     return tstl.createReturnStatement(statement.expression.elements
                         .map(elem => this.transformExpression(elem)));
-                } else if (!tsHelper.isTupleReturnCall(statement.expression, this.checker)) {
-                    // If return expression is not another TupleReturn call, unpack it
+                }
+
+                const expressionType = this.checker.getTypeAtLocation(statement.expression);
+                if (!tsHelper.isTupleReturnCall(statement.expression, this.checker)
+                    && tsHelper.isArrayType(expressionType, this.checker, this.program))
+                {
+                    // If return expression is an array-type and not another TupleReturn call, unpack it
                     const expression = this.createUnpackCall(
                         this.transformExpression(statement.expression),
                         statement.expression

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -184,7 +184,7 @@ export class TSHelper {
                 // Only check function type for directive if it is declared as an interface or type alias
                 const declaration = signature.getDeclaration();
                 const isInterfaceOrAlias = declaration && declaration.parent
-                    && (ts.isInterfaceDeclaration(declaration.parent)
+                    && ((ts.isInterfaceDeclaration(declaration.parent) && ts.isCallSignatureDeclaration(declaration))
                         || ts.isTypeAliasDeclaration(declaration.parent));
                 if (!isInterfaceOrAlias) {
                     return false;

--- a/test/unit/tuples.spec.ts
+++ b/test/unit/tuples.spec.ts
@@ -340,6 +340,31 @@ export class TupleTests {
         Expect(result).toBe("3foobar");
     }
 
+    @Test("Tuple Return on Interface Method Overload")
+    public tupleReturnOnInterfaceMethodOverload(): void {
+        const code =
+            `interface Foo {
+                foo(a: number): number;
+                /** @tupleReturn */ foo(a: string, b: string): [string, string];
+            }
+            const bar = ({
+                foo: (a: number | string, b?: string): number | [string, string] => {
+                    if (typeof a === "number") {
+                        return a;
+                    } else {
+                        return [a, b as string];
+                    }
+                }
+            }) as Foo;
+            const a = bar.foo(3);
+            const [b, c] = bar.foo("foo", "bar");
+            return a + b + c`;
+        const lua = util.transpileString(code);
+        Expect(lua).not.toContain("unpack");
+        const result = util.executeLua(lua);
+        Expect(result).toBe("3foobar");
+    }
+
     @Test("Tuple Return vs Non-Tuple Return Overload")
     public tupleReturnVsNonTupleReturnOverload(): void {
         const luaHeader =

--- a/test/unit/tuples.spec.ts
+++ b/test/unit/tuples.spec.ts
@@ -254,4 +254,110 @@ export class TupleTests {
         const result = util.executeLua(lua);
         Expect(result).toBe("foobar");
     }
+
+    @Test("Tuple Return on Type Alias")
+    public tupleReturnOnTypeAlias(): void {
+        const code =
+            `/** @tupleReturn */ type Fn = () => [number, number];
+            const fn: Fn = () => [1, 2];
+            const [a, b] = fn();
+            return a + b;`;
+        const lua = util.transpileString(code);
+        Expect(lua).not.toContain("unpack");
+        const result = util.executeLua(lua);
+        Expect(result).toBe(3);
+    }
+
+    @Test("Tuple Return on Interface")
+    public tupleReturnOnInterface(): void {
+        const code =
+            `/** @tupleReturn */ interface Fn { (): [number, number]; }
+            const fn: Fn = () => [1, 2];
+            const [a, b] = fn();
+            return a + b;`;
+        const lua = util.transpileString(code);
+        Expect(lua).not.toContain("unpack");
+        const result = util.executeLua(lua);
+        Expect(result).toBe(3);
+    }
+
+    @Test("Tuple Return on Interface Signature")
+    public tupleReturnOnInterfaceSignature(): void {
+        const code =
+            `interface Fn {
+                /** @tupleReturn */ (): [number, number];
+            }
+            const fn: Fn = () => [1, 2];
+            const [a, b] = fn();
+            return a + b;`;
+        const lua = util.transpileString(code);
+        Expect(lua).not.toContain("unpack");
+        const result = util.executeLua(lua);
+        Expect(result).toBe(3);
+    }
+
+    @Test("Tuple Return on Overload")
+    public tupleReturnOnOverload(): void {
+        const code =
+            `function fn(a: number): number;
+            /** @tupleReturn */ function fn(a: string, b: string): [string, string];
+            function fn(a: number | string, b?: string): number | [string, string] {
+                if (typeof a === "number") {
+                    return a;
+                } else {
+                    return [a, b as string];
+                }
+            }
+            const a = fn(3);
+            const [b, c] = fn("foo", "bar");
+            return a + b + c`;
+        const lua = util.transpileString(code);
+        Expect(lua).not.toContain("unpack");
+        const result = util.executeLua(lua);
+        Expect(result).toBe("3foobar");
+    }
+
+    @Test("Tuple Return on Interface Overload")
+    public tupleReturnOnInterfaceOverload(): void {
+        const code =
+            `interface Fn {
+                (a: number): number;
+                /** @tupleReturn */ (a: string, b: string): [string, string];
+            }
+            const fn = ((a: number | string, b?: string): number | [string, string] => {
+                if (typeof a === "number") {
+                    return a;
+                } else {
+                    return [a, b as string];
+                }
+            }) as Fn;
+            const a = fn(3);
+            const [b, c] = fn("foo", "bar");
+            return a + b + c`;
+        const lua = util.transpileString(code);
+        Expect(lua).not.toContain("unpack");
+        const result = util.executeLua(lua);
+        Expect(result).toBe("3foobar");
+    }
+
+    @Test("Tuple Return vs Non-Tuple Return Overload")
+    public tupleReturnVsNonTupleReturnOverload(): void {
+        const luaHeader =
+            `function fn(a, b)
+                if type(a) == "number" then
+                    return {a, a + 1}
+                else
+                    return a, b
+                end
+            end`;
+        const tsHeader =
+            `declare function fn(this: void, a: number): [number, number];
+            /** @tupleReturn */ declare function fn(this: void, a: string, b: string): [string, string];`;
+        const code =
+            `const [a, b] = fn(3);
+            const [c, d] = fn("foo", "bar");
+            return (a + b) + c + d;`;
+        const result = util.transpileAndExecute(code, undefined, luaHeader, tsHeader);
+        Expect(result).toBe("7foobar");
+    }
 }


### PR DESCRIPTION
This adds support for per-signature `@tupleReturn` directives. This allows declaring a function with overloads where some return multiple values, and some do not.

Example:
```ts
declare function foo(n: number): number;
/** @tupleReturn */ declare function foo(s: string): [string, string];

const n = foo(1);
const [s1, s2] = foo("bar");
```

This also works on function types declared as interfaces:
```ts
interface Fn {
    (n: number): number;
    /** @tupleReturn */ (s: string): [string, string];
}
```

Note that if `@tupleReturn` is placed on the interface itself, it affects all signatures in it:
```ts
/** @tupleReturn */
interface Fn {
    (n: number): [number, number];
    (s: string): [string, string];
}
```

If a function implementation has overloaded declarations, and at least one of those signatures has the `@tupleReturn` directive, then any array-like return values will be unpacked upon return. Non-array values won't.

Example:
```ts
function foo(n: number): number;
/** @tupleReturn */ function foo(s: string): [string, string];
function foo(a: number | string): number | [string, string] {
    if (typeof a === "number") {
        return a;
    } else {
        return [a, "bar"];
    }
}
const x = foo(1);
const [y, z] = foo("bar");
```
```lua
foo = function(self, a)
    if (((type(a) == "table") and "object") or type(a)) == "number" then
        return a;
    else
        return a, "bar"; -- unpacked
    end
end;
local x = foo(_G, 1);
local y, z = foo(_G, "bar"); -- assumed to be unpacked
```
