### PR TITLE
 Update outdated repo urls and add description to package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 ## 0.16.0
 * **BREAKING CHANGE:** All functions now take a `self` parameter. This means that without further action calls to declaration functions might be given an extra argument.
-    * To remove the self parameter from a single function add `this: void` to its declaration:     
+    * To remove the self parameter from a single function add `this: void` to its declaration:
         ```declare function foo(this: void, ...)```
     * To remove the self parameter from all methods or functions in a class/interface/namespace add `/** @noSelf */`:
         ```/** @noSelf */ interface Foo {```
     * To remove the self parameter from all functions in a file, add `/** @noSelfInFile */` at the top.
 
 ---
-    
+
 * **BREAKING CHANGE:** Directive `/** @luaIterator */` should now be put on types instead of on the functions returning them.
 
 ---
@@ -82,14 +82,14 @@
 * Fixed several bugs with functions and context parameters.
 
 ## 0.13.0
-* Reworked how functions are transpiled, see https://github.com/Perryvw/TypescriptToLua/wiki/Differences-Between-Functions-and-Methods
+* Reworked how functions are transpiled, see https://github.com/TypeScriptToLua/TypescriptToLua/wiki/Differences-Between-Functions-and-Methods
 * Improved handling of types extending Array.
 * Fixed several bugs with classes.
 * Fixed issues with inherited accessors.
 
 ## 0.12.0
 * Added detection of types extending Array.
-* Added new JSDoc-style compiler directives, deprecated the old `!` decorators, see https://github.com/Perryvw/TypescriptToLua/wiki/Compiler-Directives
+* Added new JSDoc-style compiler directives, deprecated the old `!` decorators, see https://github.com/TypeScriptToLua/TypescriptToLua/wiki/Compiler-Directives
 * Fixed bug with constructor default values.
 * The Lualib is no longer included when not used.
 * Fixed bug with unpack in LuaJIT.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "typescript-to-lua",
     "license": "MIT",
     "version": "0.16.1",
-    "repository": "https://github.com/Perryvw/TypescriptToLua",
+    "repository": "https://github.com/TypeScriptToLua/TypeScriptToLua",
     "keywords": [
         "typescript",
         "lua",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
     "name": "typescript-to-lua",
-    "license": "MIT",
     "version": "0.16.1",
+    "description": "A generic TypeScript to Lua transpiler. Write your code in TypeScript and publish Lua!",
     "repository": "https://github.com/TypeScriptToLua/TypeScriptToLua",
+    "license": "MIT",
     "keywords": [
         "typescript",
         "lua",

--- a/src/LuaPrinter.ts
+++ b/src/LuaPrinter.ts
@@ -46,7 +46,7 @@ export class LuaPrinter {
         let header = "";
 
         if (this.options.noHeader === undefined || this.options.noHeader === false) {
-            header += `--[[ Generated with https://github.com/Perryvw/TypescriptToLua ]]\n`;
+            header += `--[[ Generated with https://github.com/TypeScriptToLua/TypeScriptToLua ]]\n`;
         }
 
         if (luaLibFeatures) {


### PR DESCRIPTION
`description` field is used on [npm search page](https://www.npmjs.com/search?q=typescript-to-lua)