### PR TITLE
Improve Prettier DX

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,11 @@
+const isCI = require("is-ci");
+
+/** @type {import("prettier").Options} */
+module.exports = {
+    printWidth: 100,
+    tabWidth: 4,
+    trailingComma: "all",
+    proseWrap: "always",
+    endOfLine: isCI ? "lf" : "auto",
+    overrides: [{ files: ["**/*.md", "**/*.yml", "**/.*.yml"], options: { tabWidth: 2 } }],
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 const isCI = require("is-ci");
 
-/** @type {Partial<import('@jest/types').Config.DefaultOptions>} */
+/** @type {Partial<import("@jest/types").Config.DefaultOptions>} */
 module.exports = {
     testMatch: ["**/test/**/*.spec.ts"],
     collectCoverageFrom: ["<rootDir>/src/**/*", "!<rootDir>/src/lualib/**/*"],

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "pretest": "ts-node --transpile-only ./build_lualib.ts",
         "test": "jest",
         "lint": "npm run lint:tslint && npm run lint:prettier",
-        "lint:prettier": "prettier --check **/*.{js,ts,yml,json}",
+        "lint:prettier": "prettier --check **/*.{js,ts,yml,json} || (echo 'Run `npm run lint:prettier -- --write` or `yarn lint:prettier --write` to fix it.' && exit 1)",
         "lint:tslint": "tslint -p . && tslint -p test && tslint src/lualib/*.ts",
         "release-major": "npm version major",
         "release-minor": "npm version minor",

--- a/package.json
+++ b/package.json
@@ -34,25 +34,6 @@
     "bin": {
         "tstl": "./dist/tstl.js"
     },
-    "prettier": {
-        "endOfLine": "lf",
-        "printWidth": 100,
-        "proseWrap": "always",
-        "tabWidth": 4,
-        "trailingComma": "all",
-        "overrides": [
-            {
-                "files": [
-                    "**/*.md",
-                    "**/*.yml",
-                    "**/.*.yml"
-                ],
-                "options": {
-                    "tabWidth": 2
-                }
-            }
-        ]
-    },
     "engines": {
         "node": ">=8.5.0"
     },


### PR DESCRIPTION
* Added a message on Prettier check failure with instructions that show how to fix it. Tested in cmd, powershell, and (ba)sh.
* Disabled `endOfLine` locally, but left it enabled on CI. That way it doesn't cause initial warnings with `core.autocrlf=true` (default on Windows), yet prevents committing files with inconsistent line endings to the repo.