### PR TITLE
output cleanup

### DIFF
--- a/src/LuaAST.ts
+++ b/src/LuaAST.ts
@@ -592,7 +592,7 @@ export function createStringLiteral(value: string | ts.__String, tsOriginal?: ts
 export enum FunctionExpressionFlags {
     None = 0x0,
     Inline = 0x1, // Keep function on same line
-    Expression = 0x2, // Prefer assignment to expression syntax `foo = function()` instead of `function foo()`
+    Declaration = 0x2, // Prefer declaration syntax `function foo()` over assignment syntax `foo = function()`
 }
 
 export interface FunctionExpression extends Expression {
@@ -863,3 +863,16 @@ export function createTableIndexExpression(
 }
 
 export type IdentifierOrTableIndexExpression = Identifier | TableIndexExpression;
+
+export type FunctionDefinition = (VariableDeclarationStatement | AssignmentStatement) & {
+    right: [FunctionExpression];
+};
+
+export function isFunctionDefinition(statement: VariableDeclarationStatement | AssignmentStatement)
+    : statement is FunctionDefinition
+{
+    return statement.left.length === 1
+        && statement.right
+        && statement.right.length === 1
+        && isFunctionExpression(statement.right[0]);
+}

--- a/src/LuaAST.ts
+++ b/src/LuaAST.ts
@@ -882,3 +882,14 @@ export function isFunctionDefinition(statement: VariableDeclarationStatement | A
         && statement.right.length === 1
         && isFunctionExpression(statement.right[0]);
 }
+
+export type InlineFunctionExpression = FunctionExpression & {
+    body: { statements: [ReturnStatement]; };
+};
+
+export function isInlineFunctionExpression(expression: FunctionExpression) : expression is InlineFunctionExpression {
+    return expression.body.statements
+        && expression.body.statements.length === 1
+        && isReturnStatement(expression.body.statements[0])
+        && (expression.flags & FunctionExpressionFlags.Inline) !== 0;
+}

--- a/src/LuaAST.ts
+++ b/src/LuaAST.ts
@@ -121,11 +121,17 @@ export function cloneNode<T extends Node>(node: T): T {
     return Object.assign({}, node);
 }
 
+export function setNodePosition<T extends Node>(node: T, position: TextRange): T {
+    node.line = position.line;
+    node.column = position.column;
+
+    return node;
+}
+
 export function setNodeOriginal<T extends Node>(node: T, tsOriginal: ts.Node): T {
     const sourcePosition = getSourcePosition(tsOriginal);
     if (sourcePosition) {
-        node.line = sourcePosition.line;
-        node.column = sourcePosition.column;
+        setNodePosition(node, sourcePosition);
     }
 
     return node;

--- a/src/LuaAST.ts
+++ b/src/LuaAST.ts
@@ -575,20 +575,19 @@ export function createStringLiteral(value: string | ts.__String, tsOriginal?: ts
     return expression;
 }
 
-// There is no export function statement/declaration because those are just syntax sugar
-//
-// `function f () body end` becomes `f = function () body` end
-// `function t.a.b.c.f () body end` becomes `t.a.b.c.f = function () body end`
-// `local function f () body end` becomes `local f; f = function () body end` NOT `local f = function () body end`
-// See https://www.lua.org/manual/5.3/manual.html 3.4.11
-//
-// We should probably create helper functions to create the different export function declarations
+export enum FunctionExpressionFlags {
+    None = 0x0,
+    Inline = 0x1, // Keep function on same line
+    Expression = 0x2, // Prefer assignment to expression syntax `foo = function()` instead of `function foo()`
+}
+
 export interface FunctionExpression extends Expression {
     kind: SyntaxKind.FunctionExpression;
     params?: Identifier[];
     dots?: DotsLiteral;
     restParamName?: Identifier;
     body: Block;
+    flags: FunctionExpressionFlags;
 }
 
 export function isFunctionExpression(node: Node): node is FunctionExpression {
@@ -600,6 +599,7 @@ export function createFunctionExpression(
     params?: Identifier[],
     dots?: DotsLiteral,
     restParamName?: Identifier,
+    flags = FunctionExpressionFlags.None,
     tsOriginal?: ts.Node,
     parent?: Node
 ): FunctionExpression
@@ -613,6 +613,7 @@ export function createFunctionExpression(
     expression.dots = dots;
     setParent(restParamName, expression);
     expression.restParamName = restParamName;
+    expression.flags = flags;
     return expression;
 }
 

--- a/src/LuaPrinter.ts
+++ b/src/LuaPrinter.ts
@@ -337,28 +337,15 @@ export class LuaPrinter {
     }
 
     private printUnaryExpression(expression: tstl.UnaryExpression): string {
-        const operand = this.needsParentheses(expression.operand)
-            ? `(${this.printExpression(expression.operand)})`
-            : this.printExpression(expression.operand);
+        const operand = this.printExpression(expression.operand);
         return `${this.printOperator(expression.operator)}${operand}`;
     }
 
     private printBinaryExpression(expression: tstl.BinaryExpression): string {
-        const left = this.needsParentheses(expression.left)
-            ? `(${this.printExpression(expression.left)})`
-            : this.printExpression(expression.left);
-
-        const right = this.needsParentheses(expression.right)
-            ? `(${this.printExpression(expression.right)})`
-            : this.printExpression(expression.right);
-
+        const left = this.printExpression(expression.left);
+        const right = this.printExpression(expression.right);
         const operator = this.printOperator(expression.operator);
         return `${left} ${operator} ${right}`;
-    }
-
-    private needsParentheses(expression: tstl.Expression): boolean {
-        return tstl.isBinaryExpression(expression) || tstl.isUnaryExpression(expression)
-            || tstl.isFunctionExpression(expression);
     }
 
     private printParenthesizedExpression(expression: tstl.ParenthesizedExpression): string {
@@ -367,9 +354,7 @@ export class LuaPrinter {
 
     private printCallExpression(expression: tstl.CallExpression): string {
         const params = expression.params ? expression.params.map(e => this.printExpression(e)).join(", ") : "";
-        return this.needsParentheses(expression.expression)
-            ? `(${this.printExpression(expression.expression)})(${params})`
-            : `${this.printExpression(expression.expression)}(${params})`;
+        return `${this.printExpression(expression.expression)}(${params})`;
     }
 
     private printMethodCallExpression(expression: tstl.MethodCallExpression): string {

--- a/src/LuaPrinter.ts
+++ b/src/LuaPrinter.ts
@@ -468,14 +468,16 @@ export class LuaPrinter {
         if (expression.dots) {
             parameterChunks.push(this.printDotsLiteral(expression.dots));
         }
-        return ["(", ...this.joinChunks(", ", parameterChunks), ")"];
+
+        return this.joinChunks(", ", parameterChunks);
     }
 
     private printFunctionExpression(expression: tstl.FunctionExpression): SourceNode {
         const chunks: SourceChunk[] = [];
 
-        chunks.push("function");
+        chunks.push("function(");
         chunks.push(...this.printFunctionParameters(expression));
+        chunks.push(")");
 
         if (tstl.isInlineFunctionExpression(expression)) {
             const returnStatement = expression.body.statements[0];
@@ -505,8 +507,9 @@ export class LuaPrinter {
 
         chunks.push("function ");
         chunks.push(this.printExpression(statement.left[0]));
+        chunks.push("(");
         chunks.push(...this.printFunctionParameters(expression));
-        chunks.push("\n");
+        chunks.push(")\n");
 
         this.pushIndent();
         chunks.push(this.printBlock(expression.body));

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -34,6 +34,7 @@ interface Scope {
     referencedSymbols?: Set<tstl.SymbolId>;
     variableDeclarations?: tstl.VariableDeclarationStatement[];
     functionDefinitions?: Map<tstl.SymbolId, FunctionDefinitionInfo>;
+    loopContinued?: boolean;
 }
 
 export class LuaTransformer {
@@ -1925,7 +1926,7 @@ export class LuaTransformer {
         const scope = this.popScope();
         const scopeId = scope.id;
 
-        if (this.options.luaTarget === LuaTarget.Lua51) {
+        if (!scope.loopContinued) {
             return body;
         }
 
@@ -2246,8 +2247,10 @@ export class LuaTransformer {
             throw TSTLErrors.UnsupportedForTarget("Continue statement", this.options.luaTarget, statement);
         }
 
+        const scope = this.findScope(ScopeType.Loop);
+        scope.loopContinued = true;
         return tstl.createGotoStatement(
-            `__continue${this.findScope(ScopeType.Loop).id}`,
+            `__continue${scope.id}`,
             statement
         );
     }

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -4621,10 +4621,8 @@ export class LuaTransformer {
             if (symbols.some(s => this.shouldHoist(s, scope))) {
                 let assignment: tstl.AssignmentStatement | undefined;
                 if (declaration.right) {
-                    assignment = tstl.createAssignmentStatement(
-                        declaration.left,
-                        declaration.right
-                    );
+                    assignment = tstl.createAssignmentStatement(declaration.left, declaration.right);
+                    // Preserve position info for sourcemap
                     assignment.line = declaration.line;
                     assignment.column = declaration.column;
                 }

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -3078,6 +3078,10 @@ export class LuaTransformer {
     }
 
     public transformParenthesizedExpression(expression: ts.ParenthesizedExpression): tstl.Expression {
+        if (ts.isAssertionExpression(expression.expression)) {
+            // Strip parenthesis from casts
+            return this.transformExpression(expression.expression);
+        }
         return tstl.createParenthesizedExpression(
             this.transformExpression(expression.expression),
             expression

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -4622,9 +4622,7 @@ export class LuaTransformer {
                 let assignment: tstl.AssignmentStatement | undefined;
                 if (declaration.right) {
                     assignment = tstl.createAssignmentStatement(declaration.left, declaration.right);
-                    // Preserve position info for sourcemap
-                    assignment.line = declaration.line;
-                    assignment.column = declaration.column;
+                    tstl.setNodePosition(assignment, declaration); // Preserve position info for sourcemap
                 }
                 const i = result.indexOf(declaration);
                 if (i >= 0) {

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -3579,10 +3579,10 @@ export class LuaTransformer {
                     node.arguments.length === 1
                         ? this.createStringCall("find", node, caller, params[0])
                         : this.createStringCall(
-                                "find", node, caller, params[0],
-                                this.expressionPlusOne(params[1]),
-                                tstl.createBooleanLiteral(true)
-                            );
+                            "find", node, caller, params[0],
+                            this.expressionPlusOne(params[1]),
+                            tstl.createBooleanLiteral(true)
+                        );
 
                 return tstl.createParenthesizedExpression(
                     tstl.createBinaryExpression(

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -652,6 +652,9 @@ export class TSHelper {
         return match && match[0] === str;
     }
 
+    // Checks that a name is valid for use in lua function declaration syntax:
+    // 'foo.bar' => passes ('function foo.bar()' is valid)
+    // 'getFoo().bar' => fails ('function getFoo().bar()' would be illegal)
     public static isValidLuaFunctionDeclarationName(str: string): boolean {
         const match = str.match(/[a-zA-Z0-9_\.]+/);
         return match && match[0] === str;

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -652,6 +652,11 @@ export class TSHelper {
         return match && match[0] === str;
     }
 
+    public static isValidLuaFunctionDeclarationName(str: string): boolean {
+        const match = str.match(/[a-zA-Z0-9_\.]+/);
+        return match && match[0] === str;
+    }
+
     public static isFalsible(type: ts.Type, strictNullChecks: boolean): boolean {
         const falsibleFlags = ts.TypeFlags.Boolean
             | ts.TypeFlags.BooleanLiteral

--- a/test/translation/__snapshots__/transformation.spec.ts.snap
+++ b/test/translation/__snapshots__/transformation.spec.ts.snap
@@ -149,10 +149,7 @@ end"
 exports[`Transformation (do) 1`] = `
 "local e = 10;
 repeat
-    do
-        e = e - 1;
-    end
-    ::__continue1::
+    e = e - 1;
 until not (e > 0);"
 `;
 
@@ -224,7 +221,6 @@ exports[`Transformation (for) 1`] = `
 "do
     local i = 1;
     while i <= 100 do
-        ::__continue1::
         i = i + 1;
     end
 end"
@@ -232,7 +228,6 @@ end"
 
 exports[`Transformation (forIn) 1`] = `
 "for i in pairs({a = 1, b = 2, c = 3, d = 4}) do
-    ::__continue1::
 end"
 `;
 
@@ -240,7 +235,6 @@ exports[`Transformation (forOf) 1`] = `
 "local ____TS_array = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 for ____TS_index = 1, #____TS_array do
     local i = ____TS_array[____TS_index];
-    ::__continue1::
 end"
 `;
 
@@ -613,9 +607,6 @@ local test2 = 10;"
 exports[`Transformation (while) 1`] = `
 "local d = 10;
 while d > 0 do
-    do
-        d = d - 1;
-    end
-    ::__continue1::
+    d = d - 1;
 end"
 `;

--- a/test/translation/__snapshots__/transformation.spec.ts.snap
+++ b/test/translation/__snapshots__/transformation.spec.ts.snap
@@ -18,27 +18,27 @@ local nonEmptyTemplateString = \\"Level 0: \\\\n\\\\t \\" .. tostring(\\"Level 1
 `;
 
 exports[`Transformation (classExtension1) 1`] = `
-"MyClass.myFunction = function(self)
-end;"
+"function MyClass.myFunction(self)
+end"
 `;
 
 exports[`Transformation (classExtension2) 1`] = `
-"TestClass.myFunction = function(self)
-end;"
+"function TestClass.myFunction(self)
+end"
 `;
 
 exports[`Transformation (classExtension3) 1`] = `
-"RenamedTestClass.myFunction = function(self)
-end;
-RenamedMyClass.myFunction = function(self)
-end;"
+"function RenamedTestClass.myFunction(self)
+end
+function RenamedMyClass.myFunction(self)
+end"
 `;
 
 exports[`Transformation (classExtension4) 1`] = `
 "MyClass.test = \\"test\\";
 MyClass.testP = \\"testP\\";
-MyClass.myFunction = function(self)
-end;"
+function MyClass.myFunction(self)
+end"
 `;
 
 exports[`Transformation (classPureAbstract) 1`] = `
@@ -47,13 +47,13 @@ ClassB.__index = ClassB;
 ClassB.prototype = ClassB.prototype or {};
 ClassB.prototype.__index = ClassB.prototype;
 ClassB.prototype.constructor = ClassB;
-ClassB.new = function(...)
+function ClassB.new(...)
     local self = setmetatable({}, ClassB.prototype);
     self:____constructor(...);
     return self;
-end;
-ClassB.prototype.____constructor = function(self)
-end;"
+end
+function ClassB.prototype.____constructor(self)
+end"
 `;
 
 exports[`Transformation (continue) 1`] = `
@@ -224,8 +224,6 @@ exports[`Transformation (for) 1`] = `
 "do
     local i = 1;
     while i <= 100 do
-        do
-        end
         ::__continue1::
         i = i + 1;
     end
@@ -234,8 +232,6 @@ end"
 
 exports[`Transformation (forIn) 1`] = `
 "for i in pairs({a = 1, b = 2, c = 3, d = 4}) do
-    do
-    end
     ::__continue1::
 end"
 `;
@@ -244,16 +240,14 @@ exports[`Transformation (forOf) 1`] = `
 "local ____TS_array = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 for ____TS_index = 1, #____TS_array do
     local i = ____TS_array[____TS_index];
-    do
-    end
     ::__continue1::
 end"
 `;
 
 exports[`Transformation (functionRestArguments) 1`] = `
-"varargsFunction = function(self, a, ...)
+"function varargsFunction(self, a, ...)
     local b = ({...});
-end;"
+end"
 `;
 
 exports[`Transformation (getSetAccessors) 1`] = `
@@ -266,19 +260,19 @@ MyClass.prototype.__index = __TS__Index(MyClass.prototype);
 MyClass.prototype.____setters = {};
 MyClass.prototype.__newindex = __TS__NewIndex(MyClass.prototype);
 MyClass.prototype.constructor = MyClass;
-MyClass.new = function(...)
+function MyClass.new(...)
     local self = setmetatable({}, MyClass.prototype);
     self:____constructor(...);
     return self;
-end;
-MyClass.prototype.____constructor = function(self)
-end;
-MyClass.prototype.____getters.field = function(self)
+end
+function MyClass.prototype.____constructor(self)
+end
+function MyClass.prototype.____getters.field(self)
     return self._field + 4;
-end;
-MyClass.prototype.____setters.field = function(self, v)
+end
+function MyClass.prototype.____setters.field(self, v)
     self._field = v * 2;
-end;
+end
 local instance = MyClass.new();
 instance.field = 4;
 local b = instance.field;
@@ -296,16 +290,16 @@ MyClass.__index = MyClass;
 MyClass.prototype = MyClass.prototype or {};
 MyClass.prototype.__index = MyClass.prototype;
 MyClass.prototype.constructor = MyClass;
-MyClass.new = function(...)
+function MyClass.new(...)
     local self = setmetatable({}, MyClass.prototype);
     self:____constructor(...);
     return self;
-end;
-MyClass.prototype.____constructor = function(self)
-end;
-MyClass.prototype.varargsFunction = function(self, a, ...)
+end
+function MyClass.prototype.____constructor(self)
+end
+function MyClass.prototype.varargsFunction(self, a, ...)
     local b = ({...});
-end;"
+end"
 `;
 
 exports[`Transformation (modulesChangedVariableExport) 1`] = `
@@ -321,13 +315,13 @@ exports.TestClass.__index = exports.TestClass;
 exports.TestClass.prototype = exports.TestClass.prototype or {};
 exports.TestClass.prototype.__index = exports.TestClass.prototype;
 exports.TestClass.prototype.constructor = exports.TestClass;
-exports.TestClass.new = function(...)
+function exports.TestClass.new(...)
     local self = setmetatable({}, exports.TestClass.prototype);
     self:____constructor(...);
     return self;
-end;
-exports.TestClass.prototype.____constructor = function(self)
-end;
+end
+function exports.TestClass.prototype.____constructor(self)
+end
 return exports;"
 `;
 
@@ -338,28 +332,28 @@ exports.TestClass.__index = exports.TestClass;
 exports.TestClass.prototype = exports.TestClass.prototype or {};
 exports.TestClass.prototype.__index = exports.TestClass.prototype;
 exports.TestClass.prototype.constructor = exports.TestClass;
-exports.TestClass.new = function(...)
+function exports.TestClass.new(...)
     local self = setmetatable({}, exports.TestClass.prototype);
     self:____constructor(...);
     return self;
-end;
-exports.TestClass.prototype.____constructor = function(self)
-end;
-exports.TestClass.prototype.memberFunc = function(self)
-end;
+end
+function exports.TestClass.prototype.____constructor(self)
+end
+function exports.TestClass.prototype.memberFunc(self)
+end
 return exports;"
 `;
 
 exports[`Transformation (modulesFunctionExport) 1`] = `
 "local exports = exports or {};
-exports.publicFunc = function(self)
-end;
+function exports.publicFunc(self)
+end
 return exports;"
 `;
 
 exports[`Transformation (modulesFunctionNoExport) 1`] = `
-"publicFunc = function(self)
-end;"
+"function publicFunc(self)
+end"
 `;
 
 exports[`Transformation (modulesImportAll) 1`] = `"local Test = require(\\"test\\");"`;
@@ -406,8 +400,6 @@ exports[`Transformation (modulesNamespaceExport) 1`] = `
 "local exports = exports or {};
 exports.TestSpace = exports.TestSpace or {};
 local TestSpace = exports.TestSpace;
-do
-end
 return exports;"
 `;
 
@@ -433,26 +425,22 @@ do
     TestSpace.TestNestedSpace = TestSpace.TestNestedSpace or {};
     local TestNestedSpace = TestSpace.TestNestedSpace;
     do
-        TestNestedSpace.innerFunc = function(self)
-        end;
+        function TestNestedSpace.innerFunc(self)
+        end
     end
 end
 return exports;"
 `;
 
-exports[`Transformation (modulesNamespaceNoExport) 1`] = `
-"TestSpace = TestSpace or {};
-do
-end"
-`;
+exports[`Transformation (modulesNamespaceNoExport) 1`] = `"TestSpace = TestSpace or {};"`;
 
 exports[`Transformation (modulesNamespaceWithMemberExport) 1`] = `
 "local exports = exports or {};
 exports.TestSpace = exports.TestSpace or {};
 local TestSpace = exports.TestSpace;
 do
-    TestSpace.innerFunc = function(self)
-    end;
+    function TestSpace.innerFunc(self)
+    end
 end
 return exports;"
 `;
@@ -462,9 +450,8 @@ exports[`Transformation (modulesNamespaceWithMemberNoExport) 1`] = `
 exports.TestSpace = exports.TestSpace or {};
 local TestSpace = exports.TestSpace;
 do
-    local innerFunc;
-    innerFunc = function(self)
-    end;
+    local function innerFunc(self)
+    end
 end
 return exports;"
 `;
@@ -480,9 +467,8 @@ exports[`Transformation (modulesVariableNoExport) 1`] = `"local foo = \\"bar\\";
 exports[`Transformation (namespace) 1`] = `
 "myNamespace = myNamespace or {};
 do
-    local nsMember;
-    nsMember = function(self)
-    end;
+    local function nsMember(self)
+    end
 end"
 `;
 
@@ -492,30 +478,30 @@ MergedClass.__index = MergedClass;
 MergedClass.prototype = MergedClass.prototype or {};
 MergedClass.prototype.__index = MergedClass.prototype;
 MergedClass.prototype.constructor = MergedClass;
-MergedClass.new = function(...)
+function MergedClass.new(...)
     local self = setmetatable({}, MergedClass.prototype);
     self:____constructor(...);
     return self;
-end;
-MergedClass.prototype.____constructor = function(self)
-    self.propertyFunc = function(____)
+end
+function MergedClass.prototype.____constructor(self)
+    self.propertyFunc = function()
     end;
-end;
-MergedClass.staticMethodA = function(self)
-end;
-MergedClass.staticMethodB = function(self)
+end
+function MergedClass.staticMethodA(self)
+end
+function MergedClass.staticMethodB(self)
     self:staticMethodA();
-end;
-MergedClass.prototype.methodA = function(self)
-end;
-MergedClass.prototype.methodB = function(self)
+end
+function MergedClass.prototype.methodA(self)
+end
+function MergedClass.prototype.methodB(self)
     self:methodA();
     self:propertyFunc();
-end;
+end
 MergedClass = MergedClass or {};
 do
-    MergedClass.namespaceFunc = function(self)
-    end;
+    function MergedClass.namespaceFunc(self)
+    end
 end
 local mergedClass = MergedClass.new();
 mergedClass:methodB();
@@ -530,29 +516,26 @@ do
     myNamespace.myNestedNamespace = myNamespace.myNestedNamespace or {};
     local myNestedNamespace = myNamespace.myNestedNamespace;
     do
-        local nsMember;
-        nsMember = function(self)
-        end;
+        local function nsMember(self)
+        end
     end
 end"
 `;
 
 exports[`Transformation (namespacePhantom) 1`] = `
-"nsMember = function(self)
-end;"
+"function nsMember(self)
+end"
 `;
 
 exports[`Transformation (returnDefault) 1`] = `
-"myFunc = function(self)
+"function myFunc(self)
     return;
-end;"
+end"
 `;
 
 exports[`Transformation (shorthandPropertyAssignment) 1`] = `
 "local f;
-f = function(____, x)
-    return ({x = x});
-end;"
+f = function(____, x) return ({x = x}); end;"
 `;
 
 exports[`Transformation (tryCatch) 1`] = `
@@ -592,9 +575,9 @@ end"
 `;
 
 exports[`Transformation (tupleReturn) 1`] = `
-"tupleReturn = function(self)
+"function tupleReturn(self)
     return 0, \\"foobar\\";
-end;
+end
 tupleReturn(_G);
 noTupleReturn(_G);
 local a, b = tupleReturn(_G);
@@ -607,19 +590,19 @@ e = ({tupleReturn(_G)});
 f = noTupleReturn(_G);
 foo(_G, ({tupleReturn(_G)}));
 foo(_G, noTupleReturn(_G));
-tupleReturnFromVar = function(self)
+function tupleReturnFromVar(self)
     local r = {1, \\"baz\\"};
     return table.unpack(r);
-end;
-tupleReturnForward = function(self)
+end
+function tupleReturnForward(self)
     return tupleReturn(_G);
-end;
-tupleNoForward = function(self)
+end
+function tupleNoForward(self)
     return ({tupleReturn(_G)});
-end;
-tupleReturnUnpack = function(self)
+end
+function tupleReturnUnpack(self)
     return table.unpack(tupleNoForward(_G));
-end;"
+end"
 `;
 
 exports[`Transformation (typeAssert) 1`] = `

--- a/test/translation/__snapshots__/transformation.spec.ts.snap
+++ b/test/translation/__snapshots__/transformation.spec.ts.snap
@@ -227,12 +227,28 @@ end"
 `;
 
 exports[`Transformation (forIn) 1`] = `
-"for i in pairs({a = 1, b = 2, c = 3, d = 4}) do
+"for i in pairs({
+    a = 1,
+    b = 2,
+    c = 3,
+    d = 4,
+}) do
 end"
 `;
 
 exports[`Transformation (forOf) 1`] = `
-"local ____TS_array = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+"local ____TS_array = {
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+};
 for ____TS_index = 1, #____TS_array do
     local i = ____TS_array[____TS_index];
 end"
@@ -585,7 +601,10 @@ f = noTupleReturn(_G);
 foo(_G, ({tupleReturn(_G)}));
 foo(_G, noTupleReturn(_G));
 function tupleReturnFromVar(self)
-    local r = {1, \\"baz\\"};
+    local r = {
+        1,
+        \\"baz\\",
+    };
     return table.unpack(r);
 end
 function tupleReturnForward(self)

--- a/test/translation/__snapshots__/transformation.spec.ts.snap
+++ b/test/translation/__snapshots__/transformation.spec.ts.snap
@@ -14,7 +14,7 @@ local backQuoteInTemplateString = \\"\` \` \`\\";
 local escapedCharsInQuotes = \\"\\\\\\\\ \\\\0 \\\\b \\\\t \\\\n \\\\v \\\\f \\\\\\" \\\\' \`\\";
 local escapedCharsInDoubleQUotes = \\"\\\\\\\\ \\\\0 \\\\b \\\\t \\\\n \\\\v \\\\f \\\\\\" \\\\'\\";
 local escapedCharsInTemplateString = \\"\\\\\\\\ \\\\0 \\\\b \\\\t \\\\n \\\\v \\\\f \\\\\\" \\\\' \`\\";
-local nonEmptyTemplateString = \\"Level 0: \\\\n\\\\t \\" .. (tostring(\\"Level 1: \\\\n\\\\t\\\\t \\" .. (tostring(\\"Level 3: \\\\n\\\\t\\\\t\\\\t \\" .. (tostring(\\"Last level \\\\n --\\") .. \\" \\\\n --\\")) .. \\" \\\\n --\\")) .. \\" \\\\n --\\");"
+local nonEmptyTemplateString = \\"Level 0: \\\\n\\\\t \\" .. tostring(\\"Level 1: \\\\n\\\\t\\\\t \\" .. tostring(\\"Level 3: \\\\n\\\\t\\\\t\\\\t \\" .. tostring(\\"Last level \\\\n --\\") .. \\" \\\\n --\\") .. \\" \\\\n --\\") .. \\" \\\\n --\\";"
 `;
 
 exports[`Transformation (classExtension1) 1`] = `
@@ -94,7 +94,7 @@ exports[`Transformation (continueNested) 1`] = `
     local i = 0;
     while i < 5 do
         do
-            if (i % 2) == 0 then
+            if i % 2 == 0 then
                 goto __continue1;
             end
             do
@@ -121,7 +121,7 @@ exports[`Transformation (continueNestedConcurrent) 1`] = `
     local i = 0;
     while i < 5 do
         do
-            if (i % 2) == 0 then
+            if i % 2 == 0 then
                 goto __continue1;
             end
             do
@@ -560,7 +560,7 @@ exports[`Transformation (tryCatch) 1`] = `
     local ____TS_try, er = pcall(function()
         local a = 42;
     end);
-    if not ____TS_try then
+    if not (____TS_try) then
         local b = \\"fail\\";
     end
 end"
@@ -571,7 +571,7 @@ exports[`Transformation (tryCatchFinally) 1`] = `
     local ____TS_try, er = pcall(function()
         local a = 42;
     end);
-    if not ____TS_try then
+    if not (____TS_try) then
         local b = \\"fail\\";
     end
     do

--- a/test/unit/assignments/assignments.spec.ts
+++ b/test/unit/assignments/assignments.spec.ts
@@ -5,10 +5,10 @@ import * as util from "../../util";
 test.each([
     { inp: `"abc"`, out: `"abc"` },
     { inp: "3", out: "3" },
-    { inp: "[1,2,3]", out: "{1, 2, 3}" },
+    { inp: "[1,2,3]", out: "{\n    1,\n    2,\n    3,\n}" },
     { inp: "true", out: "true" },
     { inp: "false", out: "false" },
-    { inp: `{a:3,b:"4"}`, out: `{a = 3, b = "4"}` },
+    { inp: `{a:3,b:"4"}`, out: `{\n    a = 3,\n    b = "4",\n}` },
 ])("Const assignment (%p)", ({ inp, out }) => {
     const lua = util.transpileString(`const myvar = ${inp};`);
     expect(lua).toBe(`local myvar = ${out};`);
@@ -17,10 +17,10 @@ test.each([
 test.each([
     { inp: `"abc"`, out: `"abc"` },
     { inp: "3", out: "3" },
-    { inp: "[1,2,3]", out: "{1, 2, 3}" },
+    { inp: "[1,2,3]", out: "{\n    1,\n    2,\n    3,\n}" },
     { inp: "true", out: "true" },
     { inp: "false", out: "false" },
-    { inp: `{a:3,b:"4"}`, out: `{a = 3, b = "4"}` },
+    { inp: `{a:3,b:"4"}`, out: `{\n    a = 3,\n    b = "4",\n}` },
 ])("Let assignment (%p)", ({ inp, out }) => {
     const lua = util.transpileString(`let myvar = ${inp};`);
     expect(lua).toBe(`local myvar = ${out};`);
@@ -29,10 +29,10 @@ test.each([
 test.each([
     { inp: `"abc"`, out: `"abc"` },
     { inp: "3", out: "3" },
-    { inp: "[1,2,3]", out: "{1, 2, 3}" },
+    { inp: "[1,2,3]", out: "{\n    1,\n    2,\n    3,\n}" },
     { inp: "true", out: "true" },
     { inp: "false", out: "false" },
-    { inp: `{a:3,b:"4"}`, out: `{a = 3, b = "4"}` },
+    { inp: `{a:3,b:"4"}`, out: `{\n    a = 3,\n    b = "4",\n}` },
 ])("Var assignment (%p)", ({ inp, out }) => {
     const lua = util.transpileString(`var myvar = ${inp};`);
     expect(lua).toBe(`myvar = ${out};`);

--- a/test/unit/expressions.spec.ts
+++ b/test/unit/expressions.spec.ts
@@ -177,10 +177,10 @@ test.each(["a>>b", "a>>=b"])("Unsupported bitop 5.3 (%p)", input => {
 
 test.each([
     { input: "1+1", lua: "1 + 1;" },
-    { input: "-1+1", lua: "(-1) + 1;" },
-    { input: "1*30+4", lua: "(1 * 30) + 4;" },
+    { input: "-1+1", lua: "-1 + 1;" },
+    { input: "1*30+4", lua: "1 * 30 + 4;" },
     { input: "1*(3+4)", lua: "1 * (3 + 4);" },
-    { input: "1*(3+4*2)", lua: "1 * (3 + (4 * 2));" },
+    { input: "1*(3+4*2)", lua: "1 * (3 + 4 * 2);" },
 ])("Binary expressions ordering parentheses (%p)", ({ input, lua }) => {
     expect(util.transpileString(input)).toBe(lua);
 });

--- a/test/unit/expressions.spec.ts
+++ b/test/unit/expressions.spec.ts
@@ -181,6 +181,7 @@ test.each([
     { input: "1*30+4", lua: "1 * 30 + 4;" },
     { input: "1*(3+4)", lua: "1 * (3 + 4);" },
     { input: "1*(3+4*2)", lua: "1 * (3 + 4 * 2);" },
+    { input: "10-(4+5)", lua: "10 - (4 + 5);" },
 ])("Binary expressions ordering parentheses (%p)", ({ input, lua }) => {
     expect(util.transpileString(input)).toBe(lua);
 });

--- a/test/unit/loops.spec.ts
+++ b/test/unit/loops.spec.ts
@@ -763,21 +763,23 @@ test("forof forwarded lua iterator with tupleReturn", () => {
 });
 
 test.each([
-    "while (a < b) { i++; }",
-    "do { i++; } while (a < b)",
-    "for (let i = 0; i < 3; i++) {}",
-    "for (let a in b) {}",
-    "for (let a of b) {}",
+    "while (a < b) { i++; continue; }",
+    "do { i++; continue; } while (a < b)",
+    "for (let i = 0; i < 3; i++) { continue; }",
+    "for (let a in b) { continue; }",
+    "for (let a of b) { continue; }",
 ])("loop versions (%p)", loop => {
-    const lua51 = util.transpileString(loop, { luaTarget: LuaTarget.Lua51 });
-    const lua52 = util.transpileString(loop, { luaTarget: LuaTarget.Lua52 });
-    const lua53 = util.transpileString(loop, { luaTarget: LuaTarget.Lua53 });
-    const luajit = util.transpileString(loop, { luaTarget: LuaTarget.LuaJIT });
+    const lua51 = { luaTarget: LuaTarget.Lua51 };
+    const lua52 = { luaTarget: LuaTarget.Lua52 };
+    const lua53 = { luaTarget: LuaTarget.Lua53 };
+    const luajit = { luaTarget: LuaTarget.LuaJIT };
 
-    expect(lua51.indexOf("::__continue1::") !== -1).toBe(false); // No labels in 5.1
-    expect(lua52.indexOf("::__continue1::") !== -1).toBe(true); // Labels from 5.2 onwards
-    expect(lua53.indexOf("::__continue1::") !== -1).toBe(true);
-    expect(luajit.indexOf("::__continue1::") !== -1).toBe(true);
+    expect(() => util.transpileString(loop, lua51)).toThrowError(
+        TSTLErrors.UnsupportedForTarget("Continue statement", LuaTarget.Lua51, undefined)
+    );
+    expect(util.transpileString(loop, lua52).indexOf("::__continue1::") !== -1).toBe(true);
+    expect(util.transpileString(loop, lua53).indexOf("::__continue1::") !== -1).toBe(true);
+    expect(util.transpileString(loop, luajit).indexOf("::__continue1::") !== -1).toBe(true);
 });
 
 test("for dead code after return", () => {

--- a/test/unit/loops.spec.ts
+++ b/test/unit/loops.spec.ts
@@ -768,7 +768,7 @@ test.each([
     "for (let i = 0; i < 3; i++) { continue; }",
     "for (let a in b) { continue; }",
     "for (let a of b) { continue; }",
-])("loop versions (%p)", loop => {
+])("loop continue in different lua versions (%p)", loop => {
     const lua51 = { luaTarget: LuaTarget.Lua51 };
     const lua52 = { luaTarget: LuaTarget.Lua52 };
     const lua53 = { luaTarget: LuaTarget.Lua53 };

--- a/test/unit/loops.spec.ts
+++ b/test/unit/loops.spec.ts
@@ -775,7 +775,7 @@ test.each([
     const luajit = { luaTarget: LuaTarget.LuaJIT };
 
     expect(() => util.transpileString(loop, lua51)).toThrowError(
-        TSTLErrors.UnsupportedForTarget("Continue statement", LuaTarget.Lua51, undefined)
+        TSTLErrors.UnsupportedForTarget("Continue statement", LuaTarget.Lua51, undefined),
     );
     expect(util.transpileString(loop, lua52).indexOf("::__continue1::") !== -1).toBe(true);
     expect(util.transpileString(loop, lua53).indexOf("::__continue1::") !== -1).toBe(true);

--- a/test/unit/objectLiteral.spec.ts
+++ b/test/unit/objectLiteral.spec.ts
@@ -2,11 +2,11 @@ import * as util from "../util";
 const fs = require("fs");
 
 test.each([
-    { inp: `{a:3,b:"4"}`, out: `{a = 3, b = "4"};` },
-    { inp: `{"a":3,b:"4"}`, out: `{a = 3, b = "4"};` },
-    { inp: `{["a"]:3,b:"4"}`, out: `{a = 3, b = "4"};` },
-    { inp: `{["a"+123]:3,b:"4"}`, out: `{["a" .. 123] = 3, b = "4"};` },
-    { inp: `{[myFunc()]:3,b:"4"}`, out: `{[myFunc(_G)] = 3, b = "4"};` },
+    { inp: `{a:3,b:"4"}`, out: '{\n    a = 3,\n    b = "4",\n};' },
+    { inp: `{"a":3,b:"4"}`, out: '{\n    a = 3,\n    b = "4",\n};' },
+    { inp: `{["a"]:3,b:"4"}`, out: '{\n    a = 3,\n    b = "4",\n};' },
+    { inp: `{["a"+123]:3,b:"4"}`, out: '{\n    ["a" .. 123] = 3,\n    b = "4",\n};' },
+    { inp: `{[myFunc()]:3,b:"4"}`, out: '{\n    [myFunc(_G)] = 3,\n    b = "4",\n};' },
     { inp: `{x}`, out: `{x = x};` },
 ])("Object Literal (%p)", ({ inp, out }) => {
     const lua = util.transpileString(`const myvar = ${inp};`);

--- a/test/unit/spreadElement.spec.ts
+++ b/test/unit/spreadElement.spec.ts
@@ -15,23 +15,23 @@ test("Spread Element Lua 5.1", () => {
     // Cant test functional because our VM doesn't run on 5.1
     const options = { luaTarget: LuaTarget.Lua51, luaLibImport: LuaLibImportKind.None };
     const lua = util.transpileString(`[].push(...${JSON.stringify([1, 2, 3])});`, options);
-    expect(lua).toBe("__TS__ArrayPush({}, unpack({1, 2, 3}));");
+    expect(lua).toBe("__TS__ArrayPush({}, unpack({\n    1,\n    2,\n    3,\n}));");
 });
 
 test("Spread Element Lua 5.2", () => {
     const options = { luaTarget: LuaTarget.Lua52, luaLibImport: LuaLibImportKind.None };
     const lua = util.transpileString(`[...[0, 1, 2]]`, options);
-    expect(lua).toBe("{table.unpack({0, 1, 2})};");
+    expect(lua).toBe("{table.unpack({\n    0,\n    1,\n    2,\n})};");
 });
 
 test("Spread Element Lua 5.3", () => {
     const options = { luaTarget: LuaTarget.Lua53, luaLibImport: LuaLibImportKind.None };
     const lua = util.transpileString(`[...[0, 1, 2]]`, options);
-    expect(lua).toBe("{table.unpack({0, 1, 2})};");
+    expect(lua).toBe("{table.unpack({\n    0,\n    1,\n    2,\n})};");
 });
 
 test("Spread Element Lua JIT", () => {
     const options = { luaTarget: "JiT" as LuaTarget, luaLibImport: LuaLibImportKind.None };
     const lua = util.transpileString(`[...[0, 1, 2]]`, options);
-    expect(lua).toBe("{unpack({0, 1, 2})};");
+    expect(lua).toBe("{unpack({\n    0,\n    1,\n    2,\n})};");
 });


### PR DESCRIPTION
Removed wrapping all binary & unary expressions in parenthesis and fixed issues that arose. Also removed empty string literals from template strings.

I'd like to test this against some real code bases and see how fragile it is.
