### PR TITLE
String concat fix

### DIFF
--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -6,7 +6,6 @@ import * as tstl from "./LuaAST";
 import { LuaLibFeature } from "./LuaLib";
 import { ContextType, TSHelper as tsHelper } from "./TSHelper";
 import { TSTLErrors } from "./TSTLErrors";
-import { expression } from "@babel/template";
 
 export type StatementVisitResult = tstl.Statement | tstl.Statement[] | undefined;
 export type ExpressionVisitResult = tstl.Expression | undefined;

--- a/test/translation/__snapshots__/transformation.spec.ts.snap
+++ b/test/translation/__snapshots__/transformation.spec.ts.snap
@@ -14,7 +14,7 @@ local backQuoteInTemplateString = \\"\` \` \`\\";
 local escapedCharsInQuotes = \\"\\\\\\\\ \\\\0 \\\\b \\\\t \\\\n \\\\v \\\\f \\\\\\" \\\\' \`\\";
 local escapedCharsInDoubleQUotes = \\"\\\\\\\\ \\\\0 \\\\b \\\\t \\\\n \\\\v \\\\f \\\\\\" \\\\'\\";
 local escapedCharsInTemplateString = \\"\\\\\\\\ \\\\0 \\\\b \\\\t \\\\n \\\\v \\\\f \\\\\\" \\\\' \`\\";
-local nonEmptyTemplateString = \\"Level 0: \\\\n\\\\t \\" .. tostring(\\"Level 1: \\\\n\\\\t\\\\t \\" .. tostring(\\"Level 3: \\\\n\\\\t\\\\t\\\\t \\" .. tostring(\\"Last level \\\\n --\\") .. \\" \\\\n --\\") .. \\" \\\\n --\\") .. \\" \\\\n --\\";"
+local nonEmptyTemplateString = \\"Level 0: \\\\n\\\\t \\" .. \\"Level 1: \\\\n\\\\t\\\\t \\" .. \\"Level 3: \\\\n\\\\t\\\\t\\\\t \\" .. \\"Last level \\\\n --\\" .. \\" \\\\n --\\" .. \\" \\\\n --\\" .. \\" \\\\n --\\";"
 `;
 
 exports[`Transformation (classExtension1) 1`] = `

--- a/test/unit/string.spec.ts
+++ b/test/unit/string.spec.ts
@@ -37,9 +37,9 @@ test.each([
     { a: "test", b: 42, c: true },
     { a: false, b: 42, c: 12 },
 ])("Template Strings (%p)", ({ a, b, c }) => {
-    const a1 = typeof a === "string" ? "'" + a + "'" : a;
-    const b1 = typeof b === "string" ? "'" + b + "'" : b;
-    const c1 = typeof c === "string" ? "'" + c + "'" : c;
+    const a1 = typeof a === "string" ? `'${a}'` : a;
+    const b1 = typeof b === "string" ? `'${b}'` : b;
+    const c1 = typeof c === "string" ? `'${c}'` : c;
 
     const result = util.transpileAndExecute(`
         let a = ${a1};
@@ -59,9 +59,9 @@ test.each([
     { a: "test", b: 42, c: true },
     { a: false, b: 42, c: 12 },
 ])("String Concat Operator (%p)", ({ a, b, c }) => {
-    const a1 = typeof a === "string" ? "'" + a + "'" : a;
-    const b1 = typeof b === "string" ? "'" + b + "'" : b;
-    const c1 = typeof c === "string" ? "'" + c + "'" : c;
+    const a1 = typeof a === "string" ? `'${a}'` : a;
+    const b1 = typeof b === "string" ? `'${b}'` : b;
+    const c1 = typeof c === "string" ? `'${c}'` : c;
 
     const result = util.transpileAndExecute(`
         let a = ${a1};

--- a/test/unit/string.spec.ts
+++ b/test/unit/string.spec.ts
@@ -46,8 +46,7 @@ test.each([
         let b = ${b1};
         let c = ${c1};
         return \`${a} ${b} test ${c}\`;
-        `
-    );
+        `);
 
     expect(result).toBe(`${a} ${b} test ${c}`);
 });
@@ -69,8 +68,7 @@ test.each([
         let b = ${b1};
         let c = ${c1};
         return a + " " + b + " test " + c;
-        `
-    );
+        `);
 
     expect(result).toBe(`${a} ${b} test ${c}`);
 });

--- a/test/unit/string.spec.ts
+++ b/test/unit/string.spec.ts
@@ -34,13 +34,42 @@ test.each([
     { a: "test", b: "hello", c: "bye" },
     { a: "test", b: 42, c: "bye" },
     { a: "test", b: 42, c: 12 },
+    { a: "test", b: 42, c: true },
+    { a: false, b: 42, c: 12 },
 ])("Template Strings (%p)", ({ a, b, c }) => {
     const a1 = typeof a === "string" ? "'" + a + "'" : a;
     const b1 = typeof b === "string" ? "'" + b + "'" : b;
     const c1 = typeof c === "string" ? "'" + c + "'" : c;
 
-    const result = util.transpileAndExecute(
-        "let a = " + a1 + "; let b = " + b1 + "; let c = " + c1 + "; return `${a} ${b} test ${c}`;",
+    const result = util.transpileAndExecute(`
+        let a = ${a1};
+        let b = ${b1};
+        let c = ${c1};
+        return \`${a} ${b} test ${c}\`;
+        `
+    );
+
+    expect(result).toBe(`${a} ${b} test ${c}`);
+});
+
+test.each([
+    { a: 12, b: 23, c: 43 },
+    { a: "test", b: "hello", c: "bye" },
+    { a: "test", b: 42, c: "bye" },
+    { a: "test", b: 42, c: 12 },
+    { a: "test", b: 42, c: true },
+    { a: false, b: 42, c: 12 },
+])("String Concat Operator (%p)", ({ a, b, c }) => {
+    const a1 = typeof a === "string" ? "'" + a + "'" : a;
+    const b1 = typeof b === "string" ? "'" + b + "'" : b;
+    const c1 = typeof c === "string" ? "'" + c + "'" : c;
+
+    const result = util.transpileAndExecute(`
+        let a = ${a1};
+        let b = ${b1};
+        let c = ${c1};
+        return a + " " + b + " test " + c;
+        `
     );
 
     expect(result).toBe(`${a} ${b} test ${c}`);


### PR DESCRIPTION
fixes #504 

- wraps values that aren't guaranteed to be safe in a concat op with `tostring`
  - for now, safe values are string/number literals and other concat ops
- decision to wrap is also applied to template strings, which cleans them up a bit
- tests now include concatonating boolean values, which don't automatically coerce into strings
- a bit unrelated, but I also added the inline flag to `wrapInFunctionCall`, which is used for ternaries
