### PR TITLE
Removing "or" assignment from exports, class and namespace declarations

### DIFF
--- a/src/Decorator.ts
+++ b/src/Decorator.ts
@@ -21,8 +21,6 @@ export class Decorator {
                 return DecoratorKind.Phantom;
             case "tuplereturn":
                 return DecoratorKind.TupleReturn;
-            case "noclassor":
-                return DecoratorKind.NoClassOr;
             case "luaiterator":
                 return DecoratorKind.LuaIterator;
             case "noself":
@@ -52,7 +50,6 @@ export enum DecoratorKind {
     PureAbstract = "PureAbstract",
     Phantom = "Phantom",
     TupleReturn = "TupleReturn",
-    NoClassOr = "NoClassOr",
     LuaIterator = "LuaIterator",
     NoSelf = "NoSelf",
     NoSelfInFile = "NoSelfInFile",

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -121,7 +121,7 @@ export class LuaTransformer {
                 // local exports = {}
                 statements.unshift(
                     tstl.createVariableDeclarationStatement(
-                        tstl.createIdentifier("exports"),
+                        this.createExportsIdentifier(),
                         tstl.createTableExpression()
                     )
                 );
@@ -129,7 +129,7 @@ export class LuaTransformer {
                 // return exports
                 statements.push(
                     tstl.createReturnStatement(
-                        [tstl.createIdentifier("exports")]
+                        [this.createExportsIdentifier()]
                     )
                 );
             }
@@ -291,7 +291,7 @@ export class LuaTransformer {
             const body = tstl.createBlock(
                 [tstl.createAssignmentStatement(
                     tstl.createTableIndexExpression(
-                        tstl.createIdentifier("exports"),
+                        this.createExportsIdentifier(),
                         forKey
                     ),
                     forValue
@@ -4179,7 +4179,7 @@ export class LuaTransformer {
     public createExportedIdentifier(identifier: tstl.Identifier): tstl.TableIndexExpression {
         const exportTable = this.currentNamespace
             ? this.transformIdentifier(this.currentNamespace.name as ts.Identifier)
-            : tstl.createIdentifier("exports");
+            : this.createExportsIdentifier();
 
         return tstl.createTableIndexExpression(
             exportTable,
@@ -4302,6 +4302,10 @@ export class LuaTransformer {
 
     private createSelfIdentifier(tsOriginal?: ts.Node): tstl.Identifier {
         return tstl.createIdentifier("self", tsOriginal);
+    }
+
+    private createExportsIdentifier(): tstl.Identifier {
+        return tstl.createIdentifier("____exports");
     }
 
     private createLocalOrExportedOrGlobalDeclaration(

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -736,4 +736,20 @@ export class TSHelper {
             return [false, undefined];
         }
     }
+
+    public static moduleHasEmittedBody(statement: ts.ModuleDeclaration)
+        : statement is ts.ModuleDeclaration & {body: ts.ModuleBlock | ts.ModuleDeclaration}
+    {
+        if (statement.body) {
+            if (ts.isModuleBlock(statement.body)) {
+                // Ignore if body has no emitted statements
+                return statement.body.statements.findIndex(
+                    s => !ts.isInterfaceDeclaration(s) && !ts.isTypeAliasDeclaration(s)
+                ) !== -1;
+            } else if (ts.isModuleDeclaration(statement.body)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/test/translation/__snapshots__/transformation.spec.ts.snap
+++ b/test/translation/__snapshots__/transformation.spec.ts.snap
@@ -192,29 +192,29 @@ TestEnum.baz = \\"val3\\""
 `;
 
 exports[`Transformation (exportStatement) 1`] = `
-"local exports = {}
+"local ____exports = {}
 local xyz = 4
-exports.xyz = xyz
-exports.uwv = xyz
+____exports.xyz = xyz
+____exports.uwv = xyz
 do
     local __TSTL_export = require(\\"xyz\\")
     for ____exportKey, ____exportValue in pairs(__TSTL_export) do
-        exports[____exportKey] = ____exportValue
+        ____exports[____exportKey] = ____exportValue
     end
 end
 do
     local __TSTL_xyz = require(\\"xyz\\")
     local abc = __TSTL_xyz.abc
     local def = __TSTL_xyz.def
-    exports.abc = abc
-    exports.def = def
+    ____exports.abc = abc
+    ____exports.def = def
 end
 do
     local __TSTL_xyz = require(\\"xyz\\")
     local def = __TSTL_xyz.abc
-    exports.def = def
+    ____exports.def = def
 end
-return exports"
+return ____exports"
 `;
 
 exports[`Transformation (for) 1`] = `
@@ -313,52 +313,52 @@ end"
 `;
 
 exports[`Transformation (modulesChangedVariableExport) 1`] = `
-"local exports = {}
-exports.foo = 1
-return exports"
+"local ____exports = {}
+____exports.foo = 1
+return ____exports"
 `;
 
 exports[`Transformation (modulesClassExport) 1`] = `
-"local exports = {}
-exports.TestClass = {}
-exports.TestClass.__index = exports.TestClass
-exports.TestClass.prototype = {}
-exports.TestClass.prototype.__index = exports.TestClass.prototype
-exports.TestClass.prototype.constructor = exports.TestClass
-function exports.TestClass.new(...)
-    local self = setmetatable({}, exports.TestClass.prototype)
+"local ____exports = {}
+____exports.TestClass = {}
+____exports.TestClass.__index = ____exports.TestClass
+____exports.TestClass.prototype = {}
+____exports.TestClass.prototype.__index = ____exports.TestClass.prototype
+____exports.TestClass.prototype.constructor = ____exports.TestClass
+function ____exports.TestClass.new(...)
+    local self = setmetatable({}, ____exports.TestClass.prototype)
     self:____constructor(...)
     return self
 end
-function exports.TestClass.prototype.____constructor(self)
+function ____exports.TestClass.prototype.____constructor(self)
 end
-return exports"
+return ____exports"
 `;
 
 exports[`Transformation (modulesClassWithMemberExport) 1`] = `
-"local exports = {}
-exports.TestClass = {}
-exports.TestClass.__index = exports.TestClass
-exports.TestClass.prototype = {}
-exports.TestClass.prototype.__index = exports.TestClass.prototype
-exports.TestClass.prototype.constructor = exports.TestClass
-function exports.TestClass.new(...)
-    local self = setmetatable({}, exports.TestClass.prototype)
+"local ____exports = {}
+____exports.TestClass = {}
+____exports.TestClass.__index = ____exports.TestClass
+____exports.TestClass.prototype = {}
+____exports.TestClass.prototype.__index = ____exports.TestClass.prototype
+____exports.TestClass.prototype.constructor = ____exports.TestClass
+function ____exports.TestClass.new(...)
+    local self = setmetatable({}, ____exports.TestClass.prototype)
     self:____constructor(...)
     return self
 end
-function exports.TestClass.prototype.____constructor(self)
+function ____exports.TestClass.prototype.____constructor(self)
 end
-function exports.TestClass.prototype.memberFunc(self)
+function ____exports.TestClass.prototype.memberFunc(self)
 end
-return exports"
+return ____exports"
 `;
 
 exports[`Transformation (modulesFunctionExport) 1`] = `
-"local exports = {}
-function exports.publicFunc(self)
+"local ____exports = {}
+function ____exports.publicFunc(self)
 end
-return exports"
+return ____exports"
 `;
 
 exports[`Transformation (modulesFunctionNoExport) 1`] = `
@@ -407,15 +407,15 @@ local RenamedClass = __TSTL_space_module.TestClass"
 exports[`Transformation (modulesImportWithoutFromClause) 1`] = `"require(\\"test\\")"`;
 
 exports[`Transformation (modulesNamespaceExport) 1`] = `
-"local exports = {}
-exports.TestSpace = {}
-return exports"
+"local ____exports = {}
+____exports.TestSpace = {}
+return ____exports"
 `;
 
 exports[`Transformation (modulesNamespaceExportEnum) 1`] = `
-"local exports = {}
-exports.test = {}
-local test = exports.test
+"local ____exports = {}
+____exports.test = {}
+local test = ____exports.test
 do
     test.TestEnum = {}
     test.TestEnum.foo = \\"foo\\"
@@ -423,13 +423,13 @@ do
     test.TestEnum.bar = \\"bar\\"
     test.TestEnum.bar = \\"bar\\"
 end
-return exports"
+return ____exports"
 `;
 
 exports[`Transformation (modulesNamespaceNestedWithMemberExport) 1`] = `
-"local exports = {}
-exports.TestSpace = {}
-local TestSpace = exports.TestSpace
+"local ____exports = {}
+____exports.TestSpace = {}
+local TestSpace = ____exports.TestSpace
 do
     TestSpace.TestNestedSpace = {}
     local TestNestedSpace = TestSpace.TestNestedSpace
@@ -438,36 +438,36 @@ do
         end
     end
 end
-return exports"
+return ____exports"
 `;
 
 exports[`Transformation (modulesNamespaceNoExport) 1`] = `"TestSpace = {}"`;
 
 exports[`Transformation (modulesNamespaceWithMemberExport) 1`] = `
-"local exports = {}
-exports.TestSpace = {}
-local TestSpace = exports.TestSpace
+"local ____exports = {}
+____exports.TestSpace = {}
+local TestSpace = ____exports.TestSpace
 do
     function TestSpace.innerFunc(self)
     end
 end
-return exports"
+return ____exports"
 `;
 
 exports[`Transformation (modulesNamespaceWithMemberNoExport) 1`] = `
-"local exports = {}
-exports.TestSpace = {}
+"local ____exports = {}
+____exports.TestSpace = {}
 do
     local function innerFunc(self)
     end
 end
-return exports"
+return ____exports"
 `;
 
 exports[`Transformation (modulesVariableExport) 1`] = `
-"local exports = {}
-exports.foo = \\"bar\\"
-return exports"
+"local ____exports = {}
+____exports.foo = \\"bar\\"
+return ____exports"
 `;
 
 exports[`Transformation (modulesVariableNoExport) 1`] = `"local foo = \\"bar\\""`;

--- a/test/translation/__snapshots__/transformation.spec.ts.snap
+++ b/test/translation/__snapshots__/transformation.spec.ts.snap
@@ -42,9 +42,9 @@ end"
 `;
 
 exports[`Transformation (classPureAbstract) 1`] = `
-"ClassB = ClassB or {}
+"ClassB = {}
 ClassB.__index = ClassB
-ClassB.prototype = ClassB.prototype or {}
+ClassB.prototype = {}
 ClassB.prototype.__index = ClassB.prototype
 ClassB.prototype.constructor = ClassB
 function ClassB.new(...)
@@ -192,7 +192,7 @@ TestEnum.baz = \\"val3\\""
 `;
 
 exports[`Transformation (exportStatement) 1`] = `
-"local exports = exports or {}
+"local exports = {}
 local xyz = 4
 exports.xyz = xyz
 exports.uwv = xyz
@@ -262,9 +262,9 @@ end"
 
 exports[`Transformation (getSetAccessors) 1`] = `
 "require(\\"lualib_bundle\\");
-MyClass = MyClass or {}
+MyClass = {}
 MyClass.__index = MyClass
-MyClass.prototype = MyClass.prototype or {}
+MyClass.prototype = {}
 MyClass.prototype.____getters = {}
 MyClass.prototype.__index = __TS__Index(MyClass.prototype)
 MyClass.prototype.____setters = {}
@@ -295,9 +295,9 @@ a.abc = \\"def\\""
 `;
 
 exports[`Transformation (methodRestArguments) 1`] = `
-"MyClass = MyClass or {}
+"MyClass = {}
 MyClass.__index = MyClass
-MyClass.prototype = MyClass.prototype or {}
+MyClass.prototype = {}
 MyClass.prototype.__index = MyClass.prototype
 MyClass.prototype.constructor = MyClass
 function MyClass.new(...)
@@ -313,16 +313,16 @@ end"
 `;
 
 exports[`Transformation (modulesChangedVariableExport) 1`] = `
-"local exports = exports or {}
+"local exports = {}
 exports.foo = 1
 return exports"
 `;
 
 exports[`Transformation (modulesClassExport) 1`] = `
-"local exports = exports or {}
-exports.TestClass = exports.TestClass or {}
+"local exports = {}
+exports.TestClass = {}
 exports.TestClass.__index = exports.TestClass
-exports.TestClass.prototype = exports.TestClass.prototype or {}
+exports.TestClass.prototype = {}
 exports.TestClass.prototype.__index = exports.TestClass.prototype
 exports.TestClass.prototype.constructor = exports.TestClass
 function exports.TestClass.new(...)
@@ -336,10 +336,10 @@ return exports"
 `;
 
 exports[`Transformation (modulesClassWithMemberExport) 1`] = `
-"local exports = exports or {}
-exports.TestClass = exports.TestClass or {}
+"local exports = {}
+exports.TestClass = {}
 exports.TestClass.__index = exports.TestClass
-exports.TestClass.prototype = exports.TestClass.prototype or {}
+exports.TestClass.prototype = {}
 exports.TestClass.prototype.__index = exports.TestClass.prototype
 exports.TestClass.prototype.constructor = exports.TestClass
 function exports.TestClass.new(...)
@@ -355,7 +355,7 @@ return exports"
 `;
 
 exports[`Transformation (modulesFunctionExport) 1`] = `
-"local exports = exports or {}
+"local exports = {}
 function exports.publicFunc(self)
 end
 return exports"
@@ -407,15 +407,14 @@ local RenamedClass = __TSTL_space_module.TestClass"
 exports[`Transformation (modulesImportWithoutFromClause) 1`] = `"require(\\"test\\")"`;
 
 exports[`Transformation (modulesNamespaceExport) 1`] = `
-"local exports = exports or {}
-exports.TestSpace = exports.TestSpace or {}
-local TestSpace = exports.TestSpace
+"local exports = {}
+exports.TestSpace = {}
 return exports"
 `;
 
 exports[`Transformation (modulesNamespaceExportEnum) 1`] = `
-"local exports = exports or {}
-exports.test = exports.test or {}
+"local exports = {}
+exports.test = {}
 local test = exports.test
 do
     test.TestEnum = {}
@@ -428,11 +427,11 @@ return exports"
 `;
 
 exports[`Transformation (modulesNamespaceNestedWithMemberExport) 1`] = `
-"local exports = exports or {}
-exports.TestSpace = exports.TestSpace or {}
+"local exports = {}
+exports.TestSpace = {}
 local TestSpace = exports.TestSpace
 do
-    TestSpace.TestNestedSpace = TestSpace.TestNestedSpace or {}
+    TestSpace.TestNestedSpace = {}
     local TestNestedSpace = TestSpace.TestNestedSpace
     do
         function TestNestedSpace.innerFunc(self)
@@ -442,11 +441,11 @@ end
 return exports"
 `;
 
-exports[`Transformation (modulesNamespaceNoExport) 1`] = `"TestSpace = TestSpace or {}"`;
+exports[`Transformation (modulesNamespaceNoExport) 1`] = `"TestSpace = {}"`;
 
 exports[`Transformation (modulesNamespaceWithMemberExport) 1`] = `
-"local exports = exports or {}
-exports.TestSpace = exports.TestSpace or {}
+"local exports = {}
+exports.TestSpace = {}
 local TestSpace = exports.TestSpace
 do
     function TestSpace.innerFunc(self)
@@ -456,9 +455,8 @@ return exports"
 `;
 
 exports[`Transformation (modulesNamespaceWithMemberNoExport) 1`] = `
-"local exports = exports or {}
-exports.TestSpace = exports.TestSpace or {}
-local TestSpace = exports.TestSpace
+"local exports = {}
+exports.TestSpace = {}
 do
     local function innerFunc(self)
     end
@@ -467,7 +465,7 @@ return exports"
 `;
 
 exports[`Transformation (modulesVariableExport) 1`] = `
-"local exports = exports or {}
+"local exports = {}
 exports.foo = \\"bar\\"
 return exports"
 `;
@@ -475,7 +473,7 @@ return exports"
 exports[`Transformation (modulesVariableNoExport) 1`] = `"local foo = \\"bar\\""`;
 
 exports[`Transformation (namespace) 1`] = `
-"myNamespace = myNamespace or {}
+"myNamespace = {}
 do
     local function nsMember(self)
     end
@@ -483,9 +481,9 @@ end"
 `;
 
 exports[`Transformation (namespaceMerge) 1`] = `
-"MergedClass = MergedClass or {}
+"MergedClass = {}
 MergedClass.__index = MergedClass
-MergedClass.prototype = MergedClass.prototype or {}
+MergedClass.prototype = {}
 MergedClass.prototype.__index = MergedClass.prototype
 MergedClass.prototype.constructor = MergedClass
 function MergedClass.new(...)
@@ -508,7 +506,6 @@ function MergedClass.prototype.methodB(self)
     self:methodA()
     self:propertyFunc()
 end
-MergedClass = MergedClass or {}
 do
     function MergedClass.namespaceFunc(self)
     end
@@ -521,10 +518,9 @@ MergedClass:namespaceFunc()"
 `;
 
 exports[`Transformation (namespaceNested) 1`] = `
-"myNamespace = myNamespace or {}
+"myNamespace = {}
 do
-    myNamespace.myNestedNamespace = myNamespace.myNestedNamespace or {}
-    local myNestedNamespace = myNamespace.myNestedNamespace
+    local myNestedNamespace = {}
     do
         local function nsMember(self)
         end

--- a/test/translation/__snapshots__/transformation.spec.ts.snap
+++ b/test/translation/__snapshots__/transformation.spec.ts.snap
@@ -321,16 +321,17 @@ return ____exports"
 exports[`Transformation (modulesClassExport) 1`] = `
 "local ____exports = {}
 ____exports.TestClass = {}
-____exports.TestClass.__index = ____exports.TestClass
-____exports.TestClass.prototype = {}
-____exports.TestClass.prototype.__index = ____exports.TestClass.prototype
-____exports.TestClass.prototype.constructor = ____exports.TestClass
-function ____exports.TestClass.new(...)
-    local self = setmetatable({}, ____exports.TestClass.prototype)
+local TestClass = ____exports.TestClass
+TestClass.__index = TestClass
+TestClass.prototype = {}
+TestClass.prototype.__index = TestClass.prototype
+TestClass.prototype.constructor = TestClass
+function TestClass.new(...)
+    local self = setmetatable({}, TestClass.prototype)
     self:____constructor(...)
     return self
 end
-function ____exports.TestClass.prototype.____constructor(self)
+function TestClass.prototype.____constructor(self)
 end
 return ____exports"
 `;
@@ -338,18 +339,19 @@ return ____exports"
 exports[`Transformation (modulesClassWithMemberExport) 1`] = `
 "local ____exports = {}
 ____exports.TestClass = {}
-____exports.TestClass.__index = ____exports.TestClass
-____exports.TestClass.prototype = {}
-____exports.TestClass.prototype.__index = ____exports.TestClass.prototype
-____exports.TestClass.prototype.constructor = ____exports.TestClass
-function ____exports.TestClass.new(...)
-    local self = setmetatable({}, ____exports.TestClass.prototype)
+local TestClass = ____exports.TestClass
+TestClass.__index = TestClass
+TestClass.prototype = {}
+TestClass.prototype.__index = TestClass.prototype
+TestClass.prototype.constructor = TestClass
+function TestClass.new(...)
+    local self = setmetatable({}, TestClass.prototype)
     self:____constructor(...)
     return self
 end
-function ____exports.TestClass.prototype.____constructor(self)
+function TestClass.prototype.____constructor(self)
 end
-function ____exports.TestClass.prototype.memberFunc(self)
+function TestClass.prototype.memberFunc(self)
 end
 return ____exports"
 `;


### PR DESCRIPTION
fixes #509 

- exports, class, and namespaces are now initialized as `X = {}` instead of `X = X or {}`.
- `@noClassOr` has been removed as it no longer does anything
- namespaces are only initialized if they are not being merged into a previous declaration
- nested namespaces are now only exported if they have the `export` keyword
- exported nested namespaces no longer generate a local reference in the parent if it's not needed
