### PR TITLE
class name support

### DIFF
--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -613,6 +613,14 @@ export class LuaTransformer {
             );
         }
 
+        // className.name = className
+        result.push(
+            tstl.createAssignmentStatement(
+                tstl.createTableIndexExpression(tstl.cloneIdentifier(className), tstl.createStringLiteral("name")),
+                tstl.createStringLiteral(className.text)
+            )
+        );
+
         // className.____getters = {}
         if (statement.members.some(m => ts.isGetAccessor(m) && tsHelper.isStatic(m))) {
             const classGetters = tstl.createTableIndexExpression(
@@ -2751,8 +2759,10 @@ export class LuaTransformer {
     }
 
     public transformClassExpression(expression: ts.ClassExpression): ExpressionVisitResult {
-        const className = tstl.createAnnonymousIdentifier();
-        const classDeclaration =  this.transformClassDeclaration(expression as ts.ClassExpression, className);
+        const className = expression.name !== undefined
+            ? this.transformIdentifier(expression.name)
+            : tstl.createAnnonymousIdentifier();
+        const classDeclaration =  this.transformClassDeclaration(expression, className);
         return this.createImmediatelyInvokedFunctionExpression(classDeclaration, className, expression);
     }
 

--- a/test/translation/__snapshots__/transformation.spec.ts.snap
+++ b/test/translation/__snapshots__/transformation.spec.ts.snap
@@ -43,6 +43,7 @@ end"
 
 exports[`Transformation (classPureAbstract) 1`] = `
 "ClassB = {}
+ClassB.name = \\"ClassB\\"
 ClassB.__index = ClassB
 ClassB.prototype = {}
 ClassB.prototype.__index = ClassB.prototype
@@ -263,6 +264,7 @@ end"
 exports[`Transformation (getSetAccessors) 1`] = `
 "require(\\"lualib_bundle\\");
 MyClass = {}
+MyClass.name = \\"MyClass\\"
 MyClass.__index = MyClass
 MyClass.prototype = {}
 MyClass.prototype.____getters = {}
@@ -296,6 +298,7 @@ a.abc = \\"def\\""
 
 exports[`Transformation (methodRestArguments) 1`] = `
 "MyClass = {}
+MyClass.name = \\"MyClass\\"
 MyClass.__index = MyClass
 MyClass.prototype = {}
 MyClass.prototype.__index = MyClass.prototype
@@ -322,6 +325,7 @@ exports[`Transformation (modulesClassExport) 1`] = `
 "local ____exports = {}
 ____exports.TestClass = {}
 local TestClass = ____exports.TestClass
+TestClass.name = \\"TestClass\\"
 TestClass.__index = TestClass
 TestClass.prototype = {}
 TestClass.prototype.__index = TestClass.prototype
@@ -340,6 +344,7 @@ exports[`Transformation (modulesClassWithMemberExport) 1`] = `
 "local ____exports = {}
 ____exports.TestClass = {}
 local TestClass = ____exports.TestClass
+TestClass.name = \\"TestClass\\"
 TestClass.__index = TestClass
 TestClass.prototype = {}
 TestClass.prototype.__index = TestClass.prototype
@@ -484,6 +489,7 @@ end"
 
 exports[`Transformation (namespaceMerge) 1`] = `
 "MergedClass = {}
+MergedClass.name = \\"MergedClass\\"
 MergedClass.__index = MergedClass
 MergedClass.prototype = {}
 MergedClass.prototype.__index = MergedClass.prototype

--- a/test/unit/class.spec.ts
+++ b/test/unit/class.spec.ts
@@ -746,3 +746,54 @@ test("Class static instance of self", () => {
     `;
     expect(util.transpileAndExecute(code)).toBe("foobar");
 });
+
+test("Class name", () => {
+    const code = `
+        class Foo {}
+        return Foo.name;
+    `;
+    expect(util.transpileAndExecute(code)).toBe("Foo");
+});
+
+test("Class name via constructor", () => {
+    const code = `
+        class Foo {}
+        const foo = new Foo();
+        return foo.constructor.name;
+    `;
+    expect(util.transpileAndExecute(code)).toBe("Foo");
+});
+
+test("Class expression name", () => {
+    const code = `
+        const foo = class Foo {};
+        return foo.name;
+    `;
+    expect(util.transpileAndExecute(code)).toBe("Foo");
+});
+
+test("Class expression name via constructor", () => {
+    const code = `
+        const foo = class Foo {};
+        const bar = new foo();
+        return bar.constructor.name;
+    `;
+    expect(util.transpileAndExecute(code)).toBe("Foo");
+});
+
+test("Class annonymous expression name", () => {
+    const code = `
+        const foo = class {};
+        return foo.name;
+    `;
+    expect(util.transpileAndExecute(code)).toBe("____");
+});
+
+test("Class annonymous expression name via constructor", () => {
+    const code = `
+        const foo = class {};
+        const bar = new foo();
+        return bar.constructor.name;
+    `;
+    expect(util.transpileAndExecute(code)).toBe("____");
+});


### PR DESCRIPTION
fixes #513 

-name property accessible on classes and instance constructor property
-now using name of class expressions for variable and name property, if it's specified