### PR TITLE
Fixed merging module into interface

### DIFF
--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -1300,10 +1300,15 @@ export class LuaTransformer {
 
         const symbol = this.checker.getSymbolAtLocation(statement.name);
         const hasExports = symbol !== undefined && this.checker.getExportsOfModule(symbol).length > 0;
-        const isFirstDeclaration = symbol !== undefined
-            && symbol.declarations[0] === statement
-            // TS allows an empty namespace before a class of the same name
-            && symbol.declarations.findIndex(d => ts.isClassLike(d)) === -1;
+
+        // This is NOT the first declaration if:
+        // - declared as a module before this (ignore interfaces with same name)
+        // - declared as a class or function at all (TS requires these to be before module, unless module is empty)
+        const isFirstDeclaration =
+            symbol === undefined
+            || (symbol.declarations.findIndex(d => ts.isClassLike(d) || ts.isFunctionDeclaration(d)) === -1
+                && statement === symbol.declarations.find(ts.isModuleDeclaration));
+
         if (isFirstDeclaration) {
             const isExported = (ts.getCombinedModifierFlags(statement) & ts.ModifierFlags.Export) !== 0;
             if (isExported && this.currentNamespace) {

--- a/test/unit/modules.spec.ts
+++ b/test/unit/modules.spec.ts
@@ -63,3 +63,13 @@ test("Access this in module", () => {
     const code = `return M.bar();`;
     expect(util.transpileAndExecute(code, undefined, undefined, header)).toBe("foobar");
 });
+
+test("Module merged with interface", () => {
+    const header = `
+        interface Foo {}
+        module Foo {
+            export function bar() { return "foobar"; }
+        }`;
+    const code = `return Foo.bar();`;
+    expect(util.transpileAndExecute(code, undefined, undefined, header)).toBe("foobar");
+});


### PR DESCRIPTION
Found this edge case from #512 

```ts
interface Foo {}
namespace Foo {
    export function bar() { return "foobar"; }
}
```
=>
```lua
do
    function Foo.bar()
        return "foobar"
    end
end
```

The namespace wasn't considered the first declaration of `Foo`, so the namespace table was never created.