### PR TITLE
Improve string.replace implementation

### DIFF
--- a/src/lualib/StringReplace.ts
+++ b/src/lualib/StringReplace.ts
@@ -1,3 +1,22 @@
-function __TS__StringReplace(this: void, source: string, searchValue: string, replaceValue: string): string {
-    return string.gsub(source, searchValue, replaceValue)[0];
+function __TS__StringReplace(
+    this: void,
+    source: string,
+    searchValue: string,
+    replaceValue: string | ((substring: string) => string)
+): string {
+    [searchValue] = string.gsub(searchValue, "[%%%(%)%.%+%-%*%?%[%^%$]", "%%%1");
+
+    if (typeof replaceValue === "string") {
+        [replaceValue] = string.gsub(replaceValue, "[%%%(%)%.%+%-%*%?%[%^%$]", "%%%1");
+        const [result] = string.gsub(source, searchValue, replaceValue, 1);
+        return result;
+    } else {
+        const [result] = string.gsub(
+            source,
+            searchValue,
+            match => (replaceValue as (substring: string) => string)(match),
+            1
+        );
+        return result;
+    }
 }

--- a/src/lualib/declarations/string.d.ts
+++ b/src/lualib/declarations/string.d.ts
@@ -1,12 +1,15 @@
 /** @luaIterator */
-interface GMatchResult extends Array<string> { }
+interface GMatchResult extends Array<string> {}
 
 /** @noSelf */
 declare namespace string {
     /** @tupleReturn */
-    function gsub(source: string, searchValue: string, replaceValue: string): [string, number];
-    /** @tupleReturn */
-    function gsub(source: string, searchValue: string, replaceValue: (...groups: string[]) => string): [string, number];
+    function gsub(
+        source: string,
+        searchValue: string,
+        replaceValue: string | ((...groups: string[]) => string),
+        n?: number
+    ): [string, number];
 
     function gmatch(haystack: string, pattern: string): GMatchResult;
 }

--- a/test/unit/string.spec.ts
+++ b/test/unit/string.spec.ts
@@ -79,12 +79,25 @@ test.each([
     { inp: "hello test", searchValue: "hello", replaceValue: "" },
     { inp: "hello test", searchValue: "test", replaceValue: "" },
     { inp: "hello test", searchValue: "test", replaceValue: "world" },
+    { inp: "hello test", searchValue: "test", replaceValue: "%world" },
+    { inp: "hello %test", searchValue: "test", replaceValue: "world" },
+    { inp: "hello %test", searchValue: "%test", replaceValue: "world" },
+    { inp: "hello test", searchValue: "test", replaceValue: (): string => "a" },
+    { inp: "hello test", searchValue: "test", replaceValue: (): string => "%a" },
+    { inp: "aaa", searchValue: "a", replaceValue: "b" },
 ])("string.replace (%p)", ({ inp, searchValue, replaceValue }) => {
+    const replaceValueString =
+        typeof replaceValue === "string" ? JSON.stringify(replaceValue) : replaceValue.toString();
     const result = util.transpileAndExecute(
-        `return "${inp}".replace("${searchValue}", "${replaceValue}");`,
+        `return "${inp}".replace("${searchValue}", ${replaceValueString});`,
     );
 
-    expect(result).toBe(inp.replace(searchValue, replaceValue));
+    // https://github.com/Microsoft/TypeScript/issues/22378
+    if (typeof replaceValue === "string") {
+        expect(result).toBe(inp.replace(searchValue, replaceValue));
+    } else {
+        expect(result).toBe(inp.replace(searchValue, replaceValue));
+    }
 });
 
 test.each([


### PR DESCRIPTION
Breaking change.

Makes string.replace behave closer to ES:

- Escape patterns from `searchValue` and `replaceValue` (as a string)
- Support for function replacer
- Limit replacement count to 1

[Limitations wiki page](https://github.com/TypeScriptToLua/TypeScriptToLua/wiki/Limitations#stringreplace) has to be updated with a recommendation to use `string.gsub` if there is a need for extra functionality.

Optimization ideas for future:

- If `searchValue` or `replaceValue` is a string literal it may be escaped during transpilation
- If `searchValue` is a regexp literal has no magic and has only `g` flag it may be compiled to gsub without a limit