### PR TITLE
Array support in __TS__Iterator

### DIFF
--- a/src/lualib/Iterator.ts
+++ b/src/lualib/Iterator.ts
@@ -1,11 +1,19 @@
 function __TS__Iterator<T>(this: void, iterable: Iterable<T>): (this: void) => T {
-    const iterator = iterable[Symbol.iterator]();
-    return () => {
-        const result = iterator.next();
-        if (!result.done) {
-            return result.value;
-        } else {
-            return undefined;
-        }
-    };
+    if (iterable[Symbol.iterator]) {
+        const iterator = iterable[Symbol.iterator]();
+        return () => {
+            const result = iterator.next();
+            if (!result.done) {
+                return result.value;
+            } else {
+                return undefined;
+            }
+        };
+    } else {
+        let i = 0;
+        return () => {
+            i = i + 1;
+            return iterable[i];
+        };
+    }
 }

--- a/test/unit/loops.spec.ts
+++ b/test/unit/loops.spec.ts
@@ -504,6 +504,20 @@ test("forof destructuring with iterator and existing variables", () => {
     expect(result).toBe("0a1b2c");
 });
 
+test("forof with array typed as iterable", () => {
+    const code = `
+        function foo(): Iterable<string> {
+            return ["A", "B", "C"];
+        }
+        let result = "";
+        for (const x of foo()) {
+            result += x;
+        }
+        return result;
+    `;
+    expect(util.transpileAndExecute(code)).toBe("ABC");
+});
+
 test("forof lua iterator", () => {
     const code = `
         const arr = ["a", "b", "c"];


### PR DESCRIPTION
`__TS__Iterator` now performs standard array traversal if there is no `Symbol.iterator` property, so that arrays typed as generic Iterables will still work:
```ts
const arr: Iterable<string> = ["A", "B", "C"];
for (const x of arr) { ... }
```
