### PR TITLE
Fixed @tupleReturn on interface function properties

### DIFF
--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -218,10 +218,8 @@ export class TSHelper {
                 if (propertySymbol) {
                     functionType = checker.getTypeOfSymbolAtLocation(propertySymbol, declaration);
                 }
-                if (functionType === undefined) {
-                    functionType = checker.getTypeAtLocation(declaration);
-                }
-            } else {
+            }
+            if (functionType === undefined) {
                 functionType = checker.getTypeAtLocation(declaration);
             }
 

--- a/test/unit/tuples.spec.ts
+++ b/test/unit/tuples.spec.ts
@@ -64,6 +64,17 @@ test("Tuple Destruct", () => {
     expect(result).toBe(5);
 });
 
+test("Tuple Destruct Array Literal", () => {
+    const code = `
+        const [a,b,c] = [3,5,1];
+        return b;`;
+
+    const lua = util.transpileString(code);
+    expect(lua).not.toContain("unpack");
+    const result = util.executeLua(lua);
+    expect(result).toBe(5);
+});
+
 test("Tuple length", () => {
     const result = util.transpileAndExecute(
         `const tuple: [number, number, number] = [3,5,1];
@@ -74,95 +85,109 @@ test("Tuple length", () => {
 });
 
 test("Tuple Return Access", () => {
-    const result = util.transpileAndExecute(
-        `/** @tupleReturn */
+    const code = `
+        /** @tupleReturn */
         function tuple(): [number, number, number] { return [3,5,1]; }
-        return tuple()[2];`,
-    );
+        return tuple()[2];`;
 
+    const lua = util.transpileString(code);
+    expect(lua).not.toContain("unpack");
+    const result = util.executeLua(lua);
     expect(result).toBe(1);
 });
 
 test("Tuple Return Destruct Declaration", () => {
-    const result = util.transpileAndExecute(
-        `/** @tupleReturn */
+    const code = `
+        /** @tupleReturn */
         function tuple(): [number, number, number] { return [3,5,1]; }
         const [a,b,c] = tuple();
-        return b;`,
-    );
+        return b;`;
 
+    const lua = util.transpileString(code);
+    expect(lua).not.toContain("unpack");
+    const result = util.executeLua(lua);
     expect(result).toBe(5);
 });
 
 test("Tuple Return Destruct Assignment", () => {
-    const result = util.transpileAndExecute(
-        `/** @tupleReturn */
+    const code = `
+        /** @tupleReturn */
         function tuple(): [number, number] { return [3,6]; }
         let [a,b] = [1,2];
         [b,a] = tuple();
-        return a - b;`,
-    );
+        return a - b;`;
 
+    const lua = util.transpileString(code);
+    expect(lua).not.toContain("unpack");
+    const result = util.executeLua(lua);
     expect(result).toBe(3);
 });
 
 test("Tuple Static Method Return Destruct", () => {
-    const result = util.transpileAndExecute(
-        `class Test {
+    const code = `
+        class Test {
             /** @tupleReturn */
             static tuple(): [number, number, number] { return [3,5,1]; }
         }
         const [a,b,c] = Test.tuple();
-        return b;`,
-    );
+        return b;`;
 
+    const lua = util.transpileString(code);
+    expect(lua).not.toContain("unpack");
+    const result = util.executeLua(lua);
     expect(result).toBe(5);
 });
 
 test("Tuple Static Function Property Return Destruct", () => {
-    const result = util.transpileAndExecute(
-        `class Test {
+    const code = `
+        class Test {
             /** @tupleReturn */
             static tuple: () => [number, number, number] = () => [3,5,1];
         }
         const [a,b,c] = Test.tuple();
-        return b;`,
-    );
+        return b;`;
 
+    const lua = util.transpileString(code);
+    expect(lua).not.toContain("unpack");
+    const result = util.executeLua(lua);
     expect(result).toBe(5);
 });
 
 test("Tuple Non-Static Method Return Destruct", () => {
-    const result = util.transpileAndExecute(
-        `class Test {
+    const code = `
+        class Test {
             /** @tupleReturn */
             tuple(): [number, number, number] { return [3,5,1]; }
         }
         const t = new Test();
         const [a,b,c] = t.tuple();
-        return b;`,
-    );
+        return b;`;
 
+    const lua = util.transpileString(code);
+    expect(lua).not.toContain("unpack");
+    const result = util.executeLua(lua);
     expect(result).toBe(5);
 });
 
 test("Tuple Non-Static Function Property Return Destruct", () => {
-    const result = util.transpileAndExecute(
-        `class Test {
+    const code = `
+        class Test {
             /** @tupleReturn */
             tuple: () => [number, number, number] = () => [3,5,1];
         }
         const t = new Test();
         const [a,b,c] = t.tuple();
-        return b;`,
-    );
+        return b;`;
 
+    const lua = util.transpileString(code);
+    expect(lua).not.toContain("unpack");
+    const result = util.executeLua(lua);
     expect(result).toBe(5);
 });
 
 test("Tuple Interface Method Return Destruct", () => {
-    const result = util.transpileAndExecute(
-        `interface Test {
+    const code = `
+        interface Test {
             /** @tupleReturn */
             tuple(): [number, number, number];
         }
@@ -170,15 +195,17 @@ test("Tuple Interface Method Return Destruct", () => {
             tuple() { return [3,5,1]; }
         };
         const [a,b,c] = t.tuple();
-        return b;`,
-    );
+        return b;`;
 
+    const lua = util.transpileString(code);
+    expect(lua).not.toContain("unpack");
+    const result = util.executeLua(lua);
     expect(result).toBe(5);
 });
 
 test("Tuple Interface Function Property Return Destruct", () => {
-    const result = util.transpileAndExecute(
-        `interface Test {
+    const code = `
+        interface Test {
             /** @tupleReturn */
             tuple: () => [number, number, number];
         }
@@ -186,35 +213,41 @@ test("Tuple Interface Function Property Return Destruct", () => {
             tuple: () => [3,5,1]
         };
         const [a,b,c] = t.tuple();
-        return b;`,
-    );
+        return b;`;
 
+    const lua = util.transpileString(code);
+    expect(lua).not.toContain("unpack");
+    const result = util.executeLua(lua);
     expect(result).toBe(5);
 });
 
 test("Tuple Object Literal Method Return Destruct", () => {
-    const result = util.transpileAndExecute(
-        `const t = {
+    const code = `
+        const t = {
             /** @tupleReturn */
             tuple() { return [3,5,1]; }
         };
         const [a,b,c] = t.tuple();
-        return b;`,
-    );
+        return b;`;
 
+    const lua = util.transpileString(code);
+    expect(lua).not.toContain("unpack");
+    const result = util.executeLua(lua);
     expect(result).toBe(5);
 });
 
 test("Tuple Object Literal Function Property Return Destruct", () => {
-    const result = util.transpileAndExecute(
-        `const t = {
+    const code = `
+        const t = {
             /** @tupleReturn */
             tuple: () => [3,5,1]
         };
         const [a,b,c] = t.tuple();
-        return b;`,
-    );
+        return b;`;
 
+    const lua = util.transpileString(code);
+    expect(lua).not.toContain("unpack");
+    const result = util.executeLua(lua);
     expect(result).toBe(5);
 });
 

--- a/test/unit/tuples.spec.ts
+++ b/test/unit/tuples.spec.ts
@@ -119,6 +119,19 @@ test("Tuple Static Method Return Destruct", () => {
     expect(result).toBe(5);
 });
 
+test("Tuple Static Function Property Return Destruct", () => {
+    const result = util.transpileAndExecute(
+        `class Test {
+            /** @tupleReturn */
+            static tuple: () => [number, number, number] = () => [3,5,1];
+        }
+        const [a,b,c] = Test.tuple();
+        return b;`,
+    );
+
+    expect(result).toBe(5);
+});
+
 test("Tuple Non-Static Method Return Destruct", () => {
     const result = util.transpileAndExecute(
         `class Test {
@@ -126,6 +139,78 @@ test("Tuple Non-Static Method Return Destruct", () => {
             tuple(): [number, number, number] { return [3,5,1]; }
         }
         const t = new Test();
+        const [a,b,c] = t.tuple();
+        return b;`,
+    );
+
+    expect(result).toBe(5);
+});
+
+test("Tuple Non-Static Function Property Return Destruct", () => {
+    const result = util.transpileAndExecute(
+        `class Test {
+            /** @tupleReturn */
+            tuple: () => [number, number, number] = () => [3,5,1];
+        }
+        const t = new Test();
+        const [a,b,c] = t.tuple();
+        return b;`,
+    );
+
+    expect(result).toBe(5);
+});
+
+test("Tuple Interface Method Return Destruct", () => {
+    const result = util.transpileAndExecute(
+        `interface Test {
+            /** @tupleReturn */
+            tuple(): [number, number, number];
+        }
+        const t: Test = {
+            tuple() { return [3,5,1]; }
+        };
+        const [a,b,c] = t.tuple();
+        return b;`,
+    );
+
+    expect(result).toBe(5);
+});
+
+test("Tuple Interface Function Property Return Destruct", () => {
+    const result = util.transpileAndExecute(
+        `interface Test {
+            /** @tupleReturn */
+            tuple: () => [number, number, number];
+        }
+        const t: Test = {
+            tuple: () => [3,5,1]
+        };
+        const [a,b,c] = t.tuple();
+        return b;`,
+    );
+
+    expect(result).toBe(5);
+});
+
+test("Tuple Object Literal Method Return Destruct", () => {
+    const result = util.transpileAndExecute(
+        `const t = {
+            /** @tupleReturn */
+            tuple() { return [3,5,1]; }
+        };
+        const [a,b,c] = t.tuple();
+        return b;`,
+    );
+
+    expect(result).toBe(5);
+});
+
+test("Tuple Object Literal Function Property Return Destruct", () => {
+    const result = util.transpileAndExecute(
+        `const t = {
+            /** @tupleReturn */
+            tuple: () => [3,5,1]
+        };
         const [a,b,c] = t.tuple();
         return b;`,
     );

--- a/test/unit/tuples.spec.ts
+++ b/test/unit/tuples.spec.ts
@@ -75,6 +75,19 @@ test("Tuple Destruct Array Literal", () => {
     expect(result).toBe(5);
 });
 
+test("Tuple Destruct Array Literal Extra Values", () => {
+    const code = `
+        let result = "";
+        const set = () => { result = "bar"; };
+        const [a] = ["foo", set()];
+        return a + result;`;
+
+    const lua = util.transpileString(code);
+    expect(lua).not.toContain("unpack");
+    const result = util.executeLua(lua);
+    expect(result).toBe("foobar");
+});
+
 test("Tuple length", () => {
     const result = util.transpileAndExecute(
         `const tuple: [number, number, number] = [3,5,1];


### PR DESCRIPTION
fixes #578 

Also fixed detection of @tupleReturn on object literal methods/function-properties that are assigned to interaces:
```ts
interface Foo {
    /** @tupleReturn **/
    method(): [number, number];

    /** @tupleReturn **/
    funcProp: () => [number, number];
}
const foo: Foo = {
    method() { return [3, 4]; }, // Should not wrap return value
    funcProp: () => [3, 4], // Also should not wrap return value
};
```
