### PR TITLE
Remove new from luaKeywords

### DIFF
--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -40,7 +40,7 @@ interface Scope {
 
 export class LuaTransformer {
     public luaKeywords: Set<string> = new Set([
-        "and", "break", "do", "else", "elseif", "end", "false", "for", "function", "if", "in", "local", "new", "nil",
+        "and", "break", "do", "else", "elseif", "end", "false", "for", "function", "if", "in", "local", "nil",
         "not", "or", "repeat", "return", "self", "then", "until", "while",
     ]);
 


### PR DESCRIPTION
`new` is not a Lua keyword

```lua
local new = 0
print(new)
```

Output: `0`

[Busted](https://olivinelabs.com/busted/) (a Lua testing framework) uses this keyword in `spy.new(...)`.

It is possible to use `new` as a property name in TS.

```ts
const object = {
    new: () => {}
};
object.new();
```

At the moment TSTL thinks it is a keyword and disallows this from working.