### PR TITLE
fix for parenthesis stripping

### DIFF
--- a/src/LuaPrinter.ts
+++ b/src/LuaPrinter.ts
@@ -610,8 +610,25 @@ export class LuaPrinter {
         return this.createSourceNode(expression, chunks);
     }
 
+    private canStripParenthesis(expression: tstl.Expression): boolean {
+        return (
+            tstl.isParenthesizedExpression(expression) ||
+            tstl.isTableIndexExpression(expression) ||
+            tstl.isCallExpression(expression) ||
+            tstl.isMethodCallExpression(expression) ||
+            tstl.isIdentifier(expression) ||
+            tstl.isNilLiteral(expression) ||
+            tstl.isNumericLiteral(expression) ||
+            tstl.isBooleanLiteral(expression)
+        );
+    }
+
     public printParenthesizedExpression(expression: tstl.ParenthesizedExpression): SourceNode {
-        return this.createSourceNode(expression, ["(", this.printExpression(expression.innerExpression), ")"]);
+        const innerExpression = this.printExpression(expression.innerExpression);
+        if (this.canStripParenthesis(expression.innerExpression)) {
+            return this.createSourceNode(expression, innerExpression);
+        }
+        return this.createSourceNode(expression, ["(", innerExpression, ")"]);
     }
 
     public printCallExpression(expression: tstl.CallExpression): SourceNode {

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -3432,11 +3432,6 @@ export class LuaTransformer {
     }
 
     public transformParenthesizedExpression(expression: ts.ParenthesizedExpression): ExpressionVisitResult {
-        if (ts.isAssertionExpression(expression.expression)) {
-            // Strip parenthesis from casts
-            return this.transformExpression(expression.expression);
-        }
-
         return tstl.createParenthesizedExpression(this.transformExpression(expression.expression), expression);
     }
 

--- a/test/translation/__snapshots__/transformation.spec.ts.snap
+++ b/test/translation/__snapshots__/transformation.spec.ts.snap
@@ -580,7 +580,7 @@ exports[`Transformation (tryCatch) 1`] = `
     local ____TS_try, er = pcall(function()
         local a = 42
     end)
-    if not (____TS_try) then
+    if not ____TS_try then
         local b = \\"fail\\"
     end
 end"
@@ -591,7 +591,7 @@ exports[`Transformation (tryCatchFinally) 1`] = `
     local ____TS_try, er = pcall(function()
         local a = 42
     end)
-    if not (____TS_try) then
+    if not ____TS_try then
         local b = \\"fail\\"
     end
     do

--- a/test/unit/expressions.spec.ts
+++ b/test/unit/expressions.spec.ts
@@ -581,3 +581,12 @@ test.each([
     const lua = util.transpileString(code, undefined, false);
     expect(lua).toMatch(/\(.+\)/);
 });
+
+test("not operator precedence (%p)", () => {
+    const code = `
+        const a = true;
+        const b = false;
+        return !a && b;`;
+
+    expect(util.transpileAndExecute(code)).toBe(false);
+});

--- a/test/unit/expressions.spec.ts
+++ b/test/unit/expressions.spec.ts
@@ -527,3 +527,57 @@ test.each([
     `;
     expect(util.transpileAndExecute(code)).toBe(1);
 });
+
+test("binary expression with 'as' type assertion wrapped in parenthesis", () => {
+    expect(util.transpileAndExecute("return 2 * (3 - 2 as number);")).toBe(2);
+});
+
+test.each([
+    "(x as any).foo;",
+    "(y.x as any).foo;",
+    "(y['x'] as any).foo;",
+    "(z() as any).foo;",
+    "(y.z() as any).foo;",
+    "(<any>x).foo;",
+    "(<any>y.x).foo;",
+    "(<any>y['x']).foo;",
+    "(<any>z()).foo;",
+    "(<any>y.z()).foo;",
+    "(x as unknown as any).foo;",
+    "(<unknown>x as any).foo;",
+    "((x as unknown) as any).foo;",
+    "((<unknown>x) as any).foo;",
+])("'as' type assertion should strip parenthesis (%p)", expression => {
+    const code = `
+        declare let x: unknown;
+        declare let y: { x: unknown; z(this: void): unknown; };
+        declare function z(this: void): unknown;
+        ${expression}`;
+
+    const lua = util.transpileString(code, undefined, false);
+    expect(lua).not.toMatch(/\(.+\)/);
+});
+
+test.each([
+    "(x + 1 as any).foo;",
+    "(!x as any).foo;",
+    "(x ** 2 as any).foo;",
+    "(x < 2 as any).foo;",
+    "(x in y as any).foo;",
+    "(<any>x + 1).foo;",
+    "(<any>!x).foo;",
+    "(x + 1 as unknown as any).foo;",
+    "((x + 1 as unknown) as any).foo;",
+    "(!x as unknown as any).foo;",
+    "((!x as unknown) as any).foo;",
+    "(<unknown>!x as any).foo;",
+    "((<unknown>!x) as any).foo;",
+])("'as' type assertion should not strip parenthesis (%p)", expression => {
+    const code = `
+        declare let x: number;
+        declare let y: {};
+        ${expression}`;
+
+    const lua = util.transpileString(code, undefined, false);
+    expect(lua).toMatch(/\(.+\)/);
+});


### PR DESCRIPTION
- logic moved to printer
- decision to strip is now explicit based on inner expression type to avoid surprises

fixes #619