### PR TITLE
typeof improvements

### DIFF
--- a/src/LuaLib.ts
+++ b/src/LuaLib.ts
@@ -55,6 +55,7 @@ export enum LuaLibFeature {
     StringStartsWith = "StringStartsWith",
     Symbol = "Symbol",
     SymbolRegistry = "SymbolRegistry",
+    TypeOf = "TypeOf",
 }
 
 const luaLibDependencies: { [lib in LuaLibFeature]?: LuaLibFeature[] } = {

--- a/src/lualib/TypeOf.ts
+++ b/src/lualib/TypeOf.ts
@@ -1,0 +1,12 @@
+declare function type(this: void, value: unknown): string;
+
+function __TS__TypeOf(this: void, value: unknown): string {
+    const luaType = type(value);
+    if (luaType === "table") {
+        return "object";
+    } else if (luaType === "nil") {
+        return "undefined";
+    } else {
+        return luaType;
+    }
+}

--- a/test/unit/typechecking.spec.ts
+++ b/test/unit/typechecking.spec.ts
@@ -142,50 +142,42 @@ test("instanceof Symbol.hasInstance", () => {
 });
 
 test.each([
-    { expression: "{}", operator: "===", compareTo: "object", expectResult: "TRUE" },
-    { expression: "{}", operator: "!==", compareTo: "object", expectResult: "FALSE" },
-    { expression: "{}", operator: "==", compareTo: "object", expectResult: "TRUE" },
-    { expression: "{}", operator: "!=", compareTo: "object", expectResult: "FALSE" },
-    { expression: "{}", operator: "<=", compareTo: "object", expectResult: "TRUE" },
-    { expression: "{}", operator: "<", compareTo: "object", expectResult: "FALSE" },
-    { expression: "undefined", operator: "===", compareTo: "undefined", expectResult: "TRUE" },
-    { expression: "() => {}", operator: "===", compareTo: "function", expectResult: "TRUE" },
-    { expression: "1", operator: "===", compareTo: "number", expectResult: "TRUE" },
-    { expression: "true", operator: "===", compareTo: "boolean", expectResult: "TRUE" },
-    { expression: `"foo"`, operator: "===", compareTo: "string", expectResult: "TRUE" },
+    { expression: "{}", operator: "===", compareTo: "object", expectResult: true },
+    { expression: "{}", operator: "!==", compareTo: "object", expectResult: false },
+    { expression: "{}", operator: "==", compareTo: "object", expectResult: true },
+    { expression: "{}", operator: "!=", compareTo: "object", expectResult: false },
+    { expression: "{}", operator: "<=", compareTo: "object", expectResult: true },
+    { expression: "{}", operator: "<", compareTo: "object", expectResult: false },
+    { expression: "undefined", operator: "===", compareTo: "undefined", expectResult: true },
+    { expression: "() => {}", operator: "===", compareTo: "function", expectResult: true },
+    { expression: "1", operator: "===", compareTo: "number", expectResult: true },
+    { expression: "true", operator: "===", compareTo: "boolean", expectResult: true },
+    { expression: `"foo"`, operator: "===", compareTo: "string", expectResult: true },
 ])("typeof literal comparison (%p)", ({ expression, operator, compareTo, expectResult }) => {
     const code = `
         let val = ${expression};
-        if (typeof val ${operator} "${compareTo}") {
-            return "TRUE";
-        } else {
-            return "FALSE";
-        }`;
+        return typeof val ${operator} "${compareTo}";`;
 
     expect(util.transpileAndExecute(code)).toBe(expectResult);
 });
 
 test.each([
-    { expression: "{}", operator: "===", compareTo: "object", expectResult: "TRUE" },
-    { expression: "{}", operator: "!==", compareTo: "object", expectResult: "FALSE" },
-    { expression: "{}", operator: "==", compareTo: "object", expectResult: "TRUE" },
-    { expression: "{}", operator: "!=", compareTo: "object", expectResult: "FALSE" },
-    { expression: "{}", operator: "<=", compareTo: "object", expectResult: "TRUE" },
-    { expression: "{}", operator: "<", compareTo: "object", expectResult: "FALSE" },
-    { expression: "undefined", operator: "===", compareTo: "undefined", expectResult: "TRUE" },
-    { expression: "() => {}", operator: "===", compareTo: "function", expectResult: "TRUE" },
-    { expression: "1", operator: "===", compareTo: "number", expectResult: "TRUE" },
-    { expression: "true", operator: "===", compareTo: "boolean", expectResult: "TRUE" },
-    { expression: `"foo"`, operator: "===", compareTo: "string", expectResult: "TRUE" },
+    { expression: "{}", operator: "===", compareTo: "object", expectResult: true },
+    { expression: "{}", operator: "!==", compareTo: "object", expectResult: false },
+    { expression: "{}", operator: "==", compareTo: "object", expectResult: true },
+    { expression: "{}", operator: "!=", compareTo: "object", expectResult: false },
+    { expression: "{}", operator: "<=", compareTo: "object", expectResult: true },
+    { expression: "{}", operator: "<", compareTo: "object", expectResult: false },
+    { expression: "undefined", operator: "===", compareTo: "undefined", expectResult: true },
+    { expression: "() => {}", operator: "===", compareTo: "function", expectResult: true },
+    { expression: "1", operator: "===", compareTo: "number", expectResult: true },
+    { expression: "true", operator: "===", compareTo: "boolean", expectResult: true },
+    { expression: `"foo"`, operator: "===", compareTo: "string", expectResult: true },
 ])("typeof non-literal comparison (%p)", ({ expression, operator, compareTo, expectResult }) => {
     const code = `
         let val = ${expression};
         let compareTo = "${compareTo}";
-        if (typeof val ${operator} compareTo) {
-            return "TRUE";
-        } else {
-            return "FALSE";
-        }`;
+        return typeof val ${operator} compareTo;`;
 
     expect(util.transpileAndExecute(code)).toBe(expectResult);
 });

--- a/test/unit/typechecking.spec.ts
+++ b/test/unit/typechecking.spec.ts
@@ -40,7 +40,7 @@ test("typeof function", () => {
 test.each(["null", "undefined"])("typeof undefined (%p)", inp => {
     const result = util.transpileAndExecute(`return typeof ${inp};`);
 
-    expect(result).toBe("nil");
+    expect(result).toBe("undefined");
 });
 
 test("instanceof", () => {
@@ -139,4 +139,53 @@ test("instanceof Symbol.hasInstance", () => {
     `);
 
     expect(result).toBe(true);
+});
+
+test.each([
+    { expression: "{}", operator: "===", compareTo: "object", expectResult: "TRUE" },
+    { expression: "{}", operator: "!==", compareTo: "object", expectResult: "FALSE" },
+    { expression: "{}", operator: "==", compareTo: "object", expectResult: "TRUE" },
+    { expression: "{}", operator: "!=", compareTo: "object", expectResult: "FALSE" },
+    { expression: "{}", operator: "<=", compareTo: "object", expectResult: "TRUE" },
+    { expression: "{}", operator: "<", compareTo: "object", expectResult: "FALSE" },
+    { expression: "undefined", operator: "===", compareTo: "undefined", expectResult: "TRUE" },
+    { expression: "() => {}", operator: "===", compareTo: "function", expectResult: "TRUE" },
+    { expression: "1", operator: "===", compareTo: "number", expectResult: "TRUE" },
+    { expression: "true", operator: "===", compareTo: "boolean", expectResult: "TRUE" },
+    { expression: `"foo"`, operator: "===", compareTo: "string", expectResult: "TRUE" },
+])("typeof literal comparison (%p)", ({ expression, operator, compareTo, expectResult }) => {
+    const code = `
+        let val = ${expression};
+        if (typeof val ${operator} "${compareTo}") {
+            return "TRUE";
+        } else {
+            return "FALSE";
+        }`;
+
+    expect(util.transpileAndExecute(code)).toBe(expectResult);
+});
+
+test.each([
+    { expression: "{}", operator: "===", compareTo: "object", expectResult: "TRUE" },
+    { expression: "{}", operator: "!==", compareTo: "object", expectResult: "FALSE" },
+    { expression: "{}", operator: "==", compareTo: "object", expectResult: "TRUE" },
+    { expression: "{}", operator: "!=", compareTo: "object", expectResult: "FALSE" },
+    { expression: "{}", operator: "<=", compareTo: "object", expectResult: "TRUE" },
+    { expression: "{}", operator: "<", compareTo: "object", expectResult: "FALSE" },
+    { expression: "undefined", operator: "===", compareTo: "undefined", expectResult: "TRUE" },
+    { expression: "() => {}", operator: "===", compareTo: "function", expectResult: "TRUE" },
+    { expression: "1", operator: "===", compareTo: "number", expectResult: "TRUE" },
+    { expression: "true", operator: "===", compareTo: "boolean", expectResult: "TRUE" },
+    { expression: `"foo"`, operator: "===", compareTo: "string", expectResult: "TRUE" },
+])("typeof non-literal comparison (%p)", ({ expression, operator, compareTo, expectResult }) => {
+    const code = `
+        let val = ${expression};
+        let compareTo = "${compareTo}";
+        if (typeof val ${operator} compareTo) {
+            return "TRUE";
+        } else {
+            return "FALSE";
+        }`;
+
+    expect(util.transpileAndExecute(code)).toBe(expectResult);
 });


### PR DESCRIPTION
closes #613 
fixes #612 

typeof is now transpiled into a lib function, except in cases where it is directly compared to a string literal, in which case lua's `type()` is used and the literal is changed (if needed).
