### PR TITLE
@forRange directive

### DIFF
--- a/src/Decorator.ts
+++ b/src/Decorator.ts
@@ -29,6 +29,8 @@ export class Decorator {
                 return DecoratorKind.NoSelf;
             case "noselfinfile":
                 return DecoratorKind.NoSelfInFile;
+            case "forrange":
+                return DecoratorKind.ForRange;
         }
 
         return undefined;
@@ -61,4 +63,5 @@ export enum DecoratorKind {
     LuaTable = "LuaTable",
     NoSelf = "NoSelf",
     NoSelfInFile = "NoSelfInFile",
+    ForRange = "ForRange",
 }

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -184,12 +184,8 @@ export class TSHelper {
         return TSHelper.getCustomDecorators(type, checker).has(DecoratorKind.LuaIterator);
     }
 
-    public static isForRangeCall(node: ts.Node, checker: ts.TypeChecker): boolean {
-        if (!ts.isCallExpression(node)) {
-            return false;
-        }
-
-        const type = checker.getTypeAtLocation(node.expression);
+    public static isForRangeType(node: ts.Node, checker: ts.TypeChecker): boolean {
+        const type = checker.getTypeAtLocation(node);
         return TSHelper.getCustomDecorators(type, checker).has(DecoratorKind.ForRange);
     }
 

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -184,6 +184,15 @@ export class TSHelper {
         return TSHelper.getCustomDecorators(type, checker).has(DecoratorKind.LuaIterator);
     }
 
+    public static isForRangeCall(node: ts.Node, checker: ts.TypeChecker): boolean {
+        if (!ts.isCallExpression(node)) {
+            return false;
+        }
+
+        const type = checker.getTypeAtLocation(node.expression);
+        return TSHelper.getCustomDecorators(type, checker).has(DecoratorKind.ForRange);
+    }
+
     public static isTupleReturnCall(node: ts.Node, checker: ts.TypeChecker): boolean {
         if (ts.isCallExpression(node)) {
             const signature = checker.getResolvedSignature(node);

--- a/src/TSTLErrors.ts
+++ b/src/TSTLErrors.ts
@@ -204,4 +204,8 @@ export class TSTLErrors {
             node
         );
     };
+
+    public static InvalidForRangeCall = (node: ts.Node, message: string) => {
+        return new TranspileError(`Invalid @forRange call: ${message}`, node);
+    };
 }

--- a/test/unit/loops.spec.ts
+++ b/test/unit/loops.spec.ts
@@ -824,7 +824,7 @@ test("invalid non-ambient @forRange function", () => {
     expect(() => util.transpileString(code)).toThrow(
         TSTLErrors.InvalidForRangeCall(
             ts.createEmptyStatement(),
-            "@forRange function cannot have an implementation. Did you forget a 'declare'?"
+            "@forRange function can only be used as an iterable in a for...of loop."
         ).message
     );
 });
@@ -887,15 +887,22 @@ test("invalid @forRange return type", () => {
     );
 });
 
-test("invalid @forRange call", () => {
+test.each([
+    "const range = luaRange(1, 10);",
+    "console.log(luaRange);",
+    "luaRange.call(null, 0, 0, 0);",
+    "let array = [0, luaRange, 1];",
+    "const call: any; call(luaRange);",
+    "for (const i of [...luaRange(1, 10)]) {}",
+])("invalid @forRange reference (%p)", statement => {
     const code = `
         /** @forRange **/ declare function luaRange(i: number, j: number, k?: number): number[];
-        const range = luaRange(1, 10);`;
+        ${statement}`;
 
     expect(() => util.transpileString(code)).toThrow(
         TSTLErrors.InvalidForRangeCall(
             ts.createEmptyStatement(),
-            "Cannot call a @forRange function outside of a for...of loop."
+            "@forRange function can only be used as an iterable in a for...of loop."
         ).message
     );
 });


### PR DESCRIPTION
This new directive is used to create lua numeric for loops by using an ambient function declaration which can be used in TS for...of loops.

```ts
/** @forRange **/
declare function luaForRange(start: number, limit: number, step?: number): Iterable<number>;

for (const i of luaForRange(1, 10, 2)) {
    console.log(i);
}
```
=>
```lua
for i = 1, 10, 2 do
    print(i)
end
```

An error will be thrown if the function:
- doesn't take 2-3 number arguments, or it returns something other than a number iterable/array
- doesn't declare a single control variable
- is non-ambient
- is referenced outside of a for...of loop
