### PR TITLE
Preventing __TS__TypeOf from being output if it is not used.

### DIFF
--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -2674,17 +2674,29 @@ export class LuaTransformer {
     }
 
     protected transformComparisonExpression(expression: ts.BinaryExpression): ExpressionVisitResult {
-        const left = this.transformExpression(expression.left);
-        const right = this.transformExpression(expression.right);
+        let left: tstl.Expression | undefined;
+        let right: tstl.Expression | undefined;
         const operator = expression.operatorToken.kind;
 
         // Custom handling for 'typeof(foo) === "type"'
-        if (ts.isTypeOfExpression(expression.left) && tstl.isStringLiteral(right)) {
-            return this.transformTypeOfLiteralComparison(expression.left, right, operator, expression);
-        } else if (ts.isTypeOfExpression(expression.right) && tstl.isStringLiteral(left)) {
-            return this.transformTypeOfLiteralComparison(expression.right, left, operator, expression);
+        if (ts.isTypeOfExpression(expression.left)) {
+            right = this.transformExpression(expression.right);
+            if (tstl.isStringLiteral(right)) {
+                return this.transformTypeOfLiteralComparison(expression.left, right, operator, expression);
+            }
+        } else if (ts.isTypeOfExpression(expression.right)) {
+            left = this.transformExpression(expression.left);
+            if (tstl.isStringLiteral(left)) {
+                return this.transformTypeOfLiteralComparison(expression.right, left, operator, expression);
+            }
         }
 
+        if (!left) {
+            left = this.transformExpression(expression.left);
+        }
+        if (!right) {
+            right = this.transformExpression(expression.right);
+        }
         return this.transformBinaryOperation(left, right, operator, expression);
     }
 

--- a/test/unit/typechecking.spec.ts
+++ b/test/unit/typechecking.spec.ts
@@ -158,6 +158,7 @@ test.each([
         let val = ${expression};
         return typeof val ${operator} "${compareTo}";`;
 
+    expect(util.transpileString(code)).not.toMatch("__TS__TypeOf");
     expect(util.transpileAndExecute(code)).toBe(expectResult);
 });
 
@@ -179,5 +180,6 @@ test.each([
         let compareTo = "${compareTo}";
         return typeof val ${operator} compareTo;`;
 
+    expect(util.transpileString(code)).toMatch("__TS__TypeOf");
     expect(util.transpileAndExecute(code)).toBe(expectResult);
 });


### PR DESCRIPTION
Bugfix to my previous PR. The typeof lib function was being output in the lua even when it was optimized out. To prevent this, the expression is not transformed before being checked for optimizability.
