### PR TITLE
Optimized Rest Parameter -> Spread Operator

### DIFF
--- a/src/Decorator.ts
+++ b/src/Decorator.ts
@@ -29,8 +29,8 @@ export class Decorator {
                 return DecoratorKind.NoSelf;
             case "noselfinfile":
                 return DecoratorKind.NoSelfInFile;
-            case "elipsisforward":
-                return DecoratorKind.ElipsisForward;
+            case "vararg":
+                return DecoratorKind.VarArg;
         }
 
         return undefined;
@@ -63,5 +63,5 @@ export enum DecoratorKind {
     LuaTable = "LuaTable",
     NoSelf = "NoSelf",
     NoSelfInFile = "NoSelfInFile",
-    ElipsisForward = "ElipsisForward",
+    VarArg = "VarArg",
 }

--- a/src/Decorator.ts
+++ b/src/Decorator.ts
@@ -29,6 +29,8 @@ export class Decorator {
                 return DecoratorKind.NoSelf;
             case "noselfinfile":
                 return DecoratorKind.NoSelfInFile;
+            case "elipsisforward":
+                return DecoratorKind.ElipsisForward;
         }
 
         return undefined;
@@ -61,4 +63,5 @@ export enum DecoratorKind {
     LuaTable = "LuaTable",
     NoSelf = "NoSelf",
     NoSelfInFile = "NoSelfInFile",
+    ElipsisForward = "ElipsisForward",
 }

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -5252,7 +5252,9 @@ export class LuaTransformer {
                 if (declaration && identifier.pos < declaration.pos) {
                     throw TSTLErrors.ReferencedBeforeDeclaration(identifier);
                 }
-            } else if (symbolId !== undefined) {
+            }
+
+            if (symbolId !== undefined) {
                 //Mark symbol as seen in all current scopes
                 for (const scope of this.scopeStack) {
                     if (!scope.referencedSymbols) {

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -4660,8 +4660,9 @@ export class LuaTransformer {
                     "@elipsesForward can only be used on a function, and called in a spread expression."
                 );
             } else if (
-                callExpression.arguments.length !== 1 ||
-                !tsHelper.isRestParameter(callExpression.arguments[0], this.checker)
+                callExpression.arguments.length > 1 ||
+                (callExpression.arguments.length === 1 &&
+                    !tsHelper.isRestParameter(callExpression.arguments[0], this.checker))
             ) {
                 throw TSTLErrors.InvalidElipsisForward(
                     callExpression,

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -196,6 +196,15 @@ export class TSHelper {
         return declarations.some(d => ts.isParameter(d) && d.dotDotDotToken !== undefined);
     }
 
+    public static hasParameter(
+        parameters: ts.NodeArray<ts.ParameterDeclaration>,
+        parameter: ts.Node,
+        checker: ts.TypeChecker
+    ): boolean {
+        const symbol = checker.getSymbolAtLocation(parameter);
+        return symbol !== undefined && parameters.some(p => symbol === checker.getSymbolAtLocation(p.name));
+    }
+
     public static isTupleReturnCall(node: ts.Node, checker: ts.TypeChecker): boolean {
         if (ts.isCallExpression(node)) {
             const signature = checker.getResolvedSignature(node);

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -196,9 +196,9 @@ export class TSHelper {
         return declarations.some(d => ts.isParameter(d) && d.dotDotDotToken !== undefined);
     }
 
-    public static isElipsisForwardType(node: ts.Node, checker: ts.TypeChecker): boolean {
+    public static isVarArgType(node: ts.Node, checker: ts.TypeChecker): boolean {
         const type = checker.getTypeAtLocation(node);
-        return type !== undefined && TSHelper.getCustomDecorators(type, checker).has(DecoratorKind.ElipsisForward);
+        return type !== undefined && TSHelper.getCustomDecorators(type, checker).has(DecoratorKind.VarArg);
     }
 
     public static isTupleReturnCall(node: ts.Node, checker: ts.TypeChecker): boolean {

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -184,6 +184,18 @@ export class TSHelper {
         return TSHelper.getCustomDecorators(type, checker).has(DecoratorKind.LuaIterator);
     }
 
+    public static isRestParameter(node: ts.Node, checker: ts.TypeChecker): boolean {
+        const symbol = checker.getSymbolAtLocation(node);
+        if (!symbol) {
+            return false;
+        }
+        const declarations = symbol.getDeclarations();
+        if (!declarations) {
+            return false;
+        }
+        return declarations.some(d => ts.isParameter(d) && d.dotDotDotToken !== undefined);
+    }
+
     public static isTupleReturnCall(node: ts.Node, checker: ts.TypeChecker): boolean {
         if (ts.isCallExpression(node)) {
             const signature = checker.getResolvedSignature(node);

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -196,13 +196,9 @@ export class TSHelper {
         return declarations.some(d => ts.isParameter(d) && d.dotDotDotToken !== undefined);
     }
 
-    public static hasParameter(
-        parameters: ts.NodeArray<ts.ParameterDeclaration>,
-        parameter: ts.Node,
-        checker: ts.TypeChecker
-    ): boolean {
-        const symbol = checker.getSymbolAtLocation(parameter);
-        return symbol !== undefined && parameters.some(p => symbol === checker.getSymbolAtLocation(p.name));
+    public static isElipsisForwardType(node: ts.Node, checker: ts.TypeChecker): boolean {
+        const type = checker.getTypeAtLocation(node);
+        return type !== undefined && TSHelper.getCustomDecorators(type, checker).has(DecoratorKind.ElipsisForward);
     }
 
     public static isTupleReturnCall(node: ts.Node, checker: ts.TypeChecker): boolean {

--- a/src/TSTLErrors.ts
+++ b/src/TSTLErrors.ts
@@ -204,4 +204,8 @@ export class TSTLErrors {
             node
         );
     };
+
+    public static InvalidElipsisForward = (node: ts.Node, message: string) => {
+        return new TranspileError(`Invalid use of @elipsisForward: ${message}`, node);
+    };
 }

--- a/test/translation/__snapshots__/transformation.spec.ts.snap
+++ b/test/translation/__snapshots__/transformation.spec.ts.snap
@@ -256,6 +256,7 @@ end"
 exports[`Transformation (functionRestArguments) 1`] = `
 "function varargsFunction(self, a, ...)
     local b = ({...})
+    local c = b
 end"
 `;
 
@@ -319,7 +320,6 @@ end
 function MyClass.prototype.____constructor(self)
 end
 function MyClass.prototype.varargsFunction(self, a, ...)
-    local b = ({...})
 end"
 `;
 

--- a/test/translation/transformation/functionRestArguments.ts
+++ b/test/translation/transformation/functionRestArguments.ts
@@ -1,1 +1,3 @@
-function varargsFunction(a: string, ...b: string[]): void {}
+function varargsFunction(a: string, ...b: string[]): void {
+    const c = b;
+}

--- a/test/unit/functions.spec.ts
+++ b/test/unit/functions.spec.ts
@@ -516,6 +516,20 @@ test("Function rest parameter", () => {
     expect(util.transpileAndExecute(code)).toBe("BCD");
 });
 
+test("Function nested rest parameter", () => {
+    const code = `
+        function foo(a: unknown, ...b: string[]) {
+            function bar() {
+                return b.join("");
+            }
+            return bar();
+        }
+        return foo("A", "B", "C", "D");
+    `;
+
+    expect(util.transpileAndExecute(code)).toBe("BCD");
+});
+
 test("Function rest forward", () => {
     const code = `
         function foo(a: unknown, ...b: string[]) {
@@ -529,5 +543,20 @@ test("Function rest forward", () => {
     `;
 
     expect(util.transpileString(code)).not.toMatch("b = ({...})");
+    expect(util.transpileAndExecute(code)).toBe("BCD");
+});
+
+test("Function nested rest forward", () => {
+    const code = `
+        function foo(a: unknown, ...b: string[]) {
+            function bar() {
+                const c = [...b];
+                return c.join("");
+            }
+            return bar();
+        }
+        return foo("A", "B", "C", "D");
+    `;
+
     expect(util.transpileAndExecute(code)).toBe("BCD");
 });

--- a/test/unit/functions.spec.ts
+++ b/test/unit/functions.spec.ts
@@ -504,3 +504,30 @@ test("Function rest binding pattern", () => {
 
     expect(result).toBe("defxyzabc");
 });
+
+test("Function rest parameter", () => {
+    const code = `
+        function foo(a: unknown, ...b: string[]) {
+            return b.join("");
+        }
+        return foo("A", "B", "C", "D");
+    `;
+
+    expect(util.transpileAndExecute(code)).toBe("BCD");
+});
+
+test("Function rest forward", () => {
+    const code = `
+        function foo(a: unknown, ...b: string[]) {
+            const c = [...b];
+            return c.join("");
+        }
+        function bar(a: unknown, ...b: string[]) {
+            return foo(a, ...b);
+        }
+        return bar("A", "B", "C", "D");
+    `;
+
+    expect(util.transpileString(code)).not.toMatch("b = ({...})");
+    expect(util.transpileAndExecute(code)).toBe("BCD");
+});

--- a/test/unit/functions.spec.ts
+++ b/test/unit/functions.spec.ts
@@ -633,7 +633,7 @@ test.each(["unknown", "unknown[]", "Array<[]>", "Iterable<unknown>"])(
     }
 );
 
-test.each(["", "a, 0", "a, 0, 1"])("invalid @elipsisForward argument count (%p)", args => {
+test.each(["a, 0", "a, 0, 1"])("invalid @elipsisForward argument count (%p)", args => {
     const code = `
         /** @elipsisForward */ declare function elipsisForward(...args: unknown[]): unknown[];
         function foo(...a: unknown[]) {
@@ -646,4 +646,20 @@ test.each(["", "a, 0", "a, 0, 1"])("invalid @elipsisForward argument count (%p)"
             "@elipsesForward function can only be passed a single rest parameter."
         ).message
     );
+});
+
+test.each([{}, { noHoisting: true }])("@elipsisForward with no argument", compilerOptions => {
+    const tsHeader = `
+        /** @elipsisForward */ declare function elipsisForward(args?: unknown): unknown[];
+    `;
+    const code = `
+        function foo(a: unknown, ...b: unknown[]) {
+            const c = [...elipsisForward()];
+            return c.join("");
+        }
+        return foo("A", "B", "C", "D");
+    `;
+
+    expect(util.transpileString(tsHeader + code)).not.toMatch("b = ({...})");
+    expect(util.transpileAndExecute(code, compilerOptions, undefined, tsHeader)).toBe("BCD");
 });

--- a/test/unit/functions.spec.ts
+++ b/test/unit/functions.spec.ts
@@ -505,7 +505,7 @@ test("Function rest binding pattern", () => {
     expect(result).toBe("defxyzabc");
 });
 
-test("Function rest parameter", () => {
+test.each([{}, { noHoisting: true }])("Function rest parameter", compilerOptions => {
     const code = `
         function foo(a: unknown, ...b: string[]) {
             return b.join("");
@@ -513,10 +513,10 @@ test("Function rest parameter", () => {
         return foo("A", "B", "C", "D");
     `;
 
-    expect(util.transpileAndExecute(code)).toBe("BCD");
+    expect(util.transpileAndExecute(code, compilerOptions)).toBe("BCD");
 });
 
-test("Function nested rest parameter", () => {
+test.each([{}, { noHoisting: true }])("Function nested rest parameter", compilerOptions => {
     const code = `
         function foo(a: unknown, ...b: string[]) {
             function bar() {
@@ -527,10 +527,10 @@ test("Function nested rest parameter", () => {
         return foo("A", "B", "C", "D");
     `;
 
-    expect(util.transpileAndExecute(code)).toBe("BCD");
+    expect(util.transpileAndExecute(code, compilerOptions)).toBe("BCD");
 });
 
-test("Function nested rest spread", () => {
+test.each([{}, { noHoisting: true }])("Function nested rest spread", compilerOptions => {
     const code = `
         function foo(a: unknown, ...b: string[]) {
             function bar() {
@@ -542,10 +542,10 @@ test("Function nested rest spread", () => {
         return foo("A", "B", "C", "D");
     `;
 
-    expect(util.transpileAndExecute(code)).toBe("BCD");
+    expect(util.transpileAndExecute(code, compilerOptions)).toBe("BCD");
 });
 
-test("@elipsisForward", () => {
+test.each([{}, { noHoisting: true }])("@elipsisForward", compilerOptions => {
     const tsHeader = `
         /** @elipsisForward */ declare function elipsisForward(args: unknown): unknown[];
     `;
@@ -561,7 +561,23 @@ test("@elipsisForward", () => {
     `;
 
     expect(util.transpileString(tsHeader + code)).not.toMatch("b = ({...})");
-    expect(util.transpileAndExecute(code, undefined, undefined, tsHeader)).toBe("BCD");
+    expect(util.transpileAndExecute(code, compilerOptions, undefined, tsHeader)).toBe("BCD");
+});
+
+test.each([{}, { noHoisting: true }])("@elipsisForward mixed with rest spread", compilerOptions => {
+    const tsHeader = `
+        /** @elipsisForward */ declare function elipsisForward(args: unknown): unknown[];
+    `;
+    const code = `
+        function foo(a: unknown, ...b: unknown[]) {
+            const c = [...elipsisForward(b)];
+            const d = [...b];
+            return c.join("") + d.join("");
+        }
+        return foo("A", "B", "C", "D");
+    `;
+
+    expect(util.transpileAndExecute(code, compilerOptions, undefined, tsHeader)).toBe("BCDBCD");
 });
 
 test("invalid non-ambient @elipsisForward", () => {


### PR DESCRIPTION
When a rest parameter is referenced with a spread operator, the transformed code packs and unpacks it:
```ts
function foo(this: void, ...args: unknown[]) {
    console.log(...args);
}
```
=>
```lua
function foo(...)
    local args = ({...})
    print(unpack(args))
end
```

~~This PR optimizes this so that the elipsis operator is used instead.~~ It also prevents generation of the temp local if it is not needed in the function.

*Update*
Due to issues with the optimization being applied inside generated IIFE's, this PR has been updated to instead provide an explicit `@elipsisForward` directive to apply this optimization.

```ts
/** @elipsisForward */
declare function elipsisForward<A extends unknown[]>(args?: A): A;

function foo(this: void, ...args: unknown[]) {
    console.log(...elipsisForward(args));
}
```
=>
```lua
function foo(...)
    print(...)
end
```

The new directive can only be used on a function, and that function can only be used in a spread expression, and passed a rest argument.

You can also pass no argument, which is useful for accessing the file-scope elipsis:
```ts
const arg = [...elipsisForward()];
```
=>
```lua
local arg = {...}
```