### PR TITLE
More source map stuff

### DIFF
--- a/src/CompilerOptions.ts
+++ b/src/CompilerOptions.ts
@@ -1,7 +1,7 @@
 import * as ts from "typescript";
 
 type KnownKeys<T> = { [K in keyof T]: string extends K ? never : number extends K ? never : K } extends {
-    [_ in keyof T]: infer U;
+    [_ in keyof T]: infer U
 }
     ? U
     : never;

--- a/src/CompilerOptions.ts
+++ b/src/CompilerOptions.ts
@@ -1,7 +1,7 @@
 import * as ts from "typescript";
 
 type KnownKeys<T> = { [K in keyof T]: string extends K ? never : number extends K ? never : K } extends {
-    [_ in keyof T]: infer U
+    [_ in keyof T]: infer U;
 }
     ? U
     : never;

--- a/src/LuaAST.ts
+++ b/src/LuaAST.ts
@@ -830,6 +830,7 @@ export function createMethodCallExpression(
 export interface Identifier extends Expression {
     kind: SyntaxKind.Identifier;
     text: string;
+    originalName?: string;
     symbolId?: SymbolId;
 }
 
@@ -841,16 +842,18 @@ export function createIdentifier(
     text: string | ts.__String,
     tsOriginal?: ts.Node,
     symbolId?: SymbolId,
+    originalName?: string,
     parent?: Node
 ): Identifier {
     const expression = createNode(SyntaxKind.Identifier, tsOriginal, parent) as Identifier;
     expression.text = text as string;
     expression.symbolId = symbolId;
+    expression.originalName = originalName;
     return expression;
 }
 
 export function cloneIdentifier(identifier: Identifier, tsOriginal?: ts.Node): Identifier {
-    return createIdentifier(identifier.text, tsOriginal, identifier.symbolId);
+    return createIdentifier(identifier.text, tsOriginal, identifier.symbolId, identifier.originalName);
 }
 
 export function createAnonymousIdentifier(tsOriginal?: ts.Node, parent?: Node): Identifier {

--- a/src/LuaPrinter.ts
+++ b/src/LuaPrinter.ts
@@ -274,7 +274,7 @@ export class LuaPrinter {
             }
         }
 
-        return this.concatNodes(...chunks);
+        return this.createSourceNode(statement, chunks);
     }
 
     public printVariableAssignmentStatement(statement: tstl.AssignmentStatement): SourceNode {

--- a/src/LuaPrinter.ts
+++ b/src/LuaPrinter.ts
@@ -157,12 +157,12 @@ export class LuaPrinter {
         return this.concatNodes(this.currentIndent, input);
     }
 
-    protected createSourceNode(node: tstl.Node, chunks: SourceChunk | SourceChunk[]): SourceNode {
+    protected createSourceNode(node: tstl.Node, chunks: SourceChunk | SourceChunk[], name?: string): SourceNode {
         const originalPos = tstl.getOriginalPos(node);
 
         return originalPos !== undefined && originalPos.line !== undefined && originalPos.column !== undefined
-            ? new SourceNode(originalPos.line + 1, originalPos.column, this.sourceFile, chunks)
-            : new SourceNode(null, null, this.sourceFile, chunks); // tslint:disable-line:no-null-keyword
+            ? new SourceNode(originalPos.line + 1, originalPos.column, this.sourceFile, chunks, name)
+            : new SourceNode(null, null, this.sourceFile, chunks, name); // tslint:disable-line:no-null-keyword
     }
 
     protected concatNodes(...chunks: SourceChunk[]): SourceNode {
@@ -661,7 +661,11 @@ export class LuaPrinter {
     }
 
     public printIdentifier(expression: tstl.Identifier): SourceNode {
-        return this.createSourceNode(expression, expression.text);
+        return this.createSourceNode(
+            expression,
+            expression.text,
+            expression.originalName !== expression.text ? expression.originalName : undefined
+        );
     }
 
     public printTableIndexExpression(expression: tstl.TableIndexExpression): SourceNode {
@@ -734,12 +738,15 @@ export class LuaPrinter {
             }
             if (
                 currentMapping.generated.line === generatedLine &&
-                currentMapping.generated.column === generatedColumn
+                currentMapping.generated.column === generatedColumn &&
+                currentMapping.name === sourceNode.name
             ) {
                 return false;
             }
             return (
-                currentMapping.original.line !== sourceNode.line || currentMapping.original.column !== sourceNode.column
+                currentMapping.original.line !== sourceNode.line ||
+                currentMapping.original.column !== sourceNode.column ||
+                currentMapping.name !== sourceNode.name
             );
         };
 
@@ -749,6 +756,7 @@ export class LuaPrinter {
                     source: sourceNode.source,
                     original: { line: sourceNode.line, column: sourceNode.column },
                     generated: { line: generatedLine, column: generatedColumn },
+                    name: sourceNode.name,
                 };
                 map.addMapping(currentMapping);
             }

--- a/src/LuaPrinter.ts
+++ b/src/LuaPrinter.ts
@@ -516,13 +516,13 @@ export class LuaPrinter {
                 ...this.joinChunks(", ", returnStatement.expressions.map(e => this.printExpression(e))),
             ];
             chunks.push(this.createSourceNode(returnStatement, returnNode));
-            chunks.push(" end");
+            chunks.push(this.createSourceNode(expression, " end"));
         } else {
             chunks.push("\n");
             this.pushIndent();
             chunks.push(this.printBlock(expression.body));
             this.popIndent();
-            chunks.push(this.indent("end"));
+            chunks.push(this.indent(this.createSourceNode(expression, "end")));
         }
 
         return this.createSourceNode(expression, chunks);
@@ -541,7 +541,7 @@ export class LuaPrinter {
         this.pushIndent();
         chunks.push(this.printBlock(expression.body));
         this.popIndent();
-        chunks.push(this.indent("end"));
+        chunks.push(this.indent(this.createSourceNode(statement, "end")));
 
         return this.createSourceNode(expression, chunks);
     }

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -1229,6 +1229,8 @@ export class LuaTransformer {
 
         const block: tstl.Block = tstl.createBlock(bodyWithFieldInitializers);
 
+        const constructorWasGenerated = statement.pos === -1;
+
         const result = tstl.createAssignmentStatement(
             this.createConstructorName(className),
             tstl.createFunctionExpression(
@@ -1238,7 +1240,7 @@ export class LuaTransformer {
                 restParamName,
                 tstl.FunctionExpressionFlags.Declaration
             ),
-            statement.pos >= 0 ? statement : classDeclaration // Map to class declaration if constructor was generated
+            constructorWasGenerated ? classDeclaration : statement
         );
 
         return result;

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -625,7 +625,12 @@ export class LuaTransformer {
 
         let localClassName: tstl.Identifier;
         if (this.isUnsafeName(className.text)) {
-            localClassName = tstl.createIdentifier(this.createSafeName(className.text), undefined, className.symbolId);
+            localClassName = tstl.createIdentifier(
+                this.createSafeName(className.text),
+                undefined,
+                className.symbolId,
+                className.text
+            );
             tstl.setNodePosition(localClassName, className);
         } else {
             localClassName = className;
@@ -1550,7 +1555,8 @@ export class LuaTransformer {
             return tstl.createIdentifier(
                 this.createSafeName(declaration.name.text),
                 declaration.name,
-                moduleSymbol && this.symbolIds.get(moduleSymbol)
+                moduleSymbol && this.symbolIds.get(moduleSymbol),
+                declaration.name.text
             );
         }
         return this.transformIdentifier(declaration.name as ts.Identifier);
@@ -4688,7 +4694,7 @@ export class LuaTransformer {
             : this.getIdentifierText(identifier);
 
         const symbolId = this.getIdentifierSymbolId(identifier);
-        return tstl.createIdentifier(text, identifier, symbolId);
+        return tstl.createIdentifier(text, identifier, symbolId, this.getIdentifierText(identifier));
     }
 
     protected transformIdentifierExpression(expression: ts.Identifier): tstl.Expression {
@@ -4917,7 +4923,7 @@ export class LuaTransformer {
     }
 
     protected createSelfIdentifier(tsOriginal?: ts.Node): tstl.Identifier {
-        return tstl.createIdentifier("self", tsOriginal);
+        return tstl.createIdentifier("self", tsOriginal, undefined, "this");
     }
 
     protected createExportsIdentifier(): tstl.Identifier {

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -1065,7 +1065,8 @@ export class LuaTransformer {
             tstl.createCallExpression(tstl.createIdentifier("setmetatable"), [
                 tstl.createTableExpression(),
                 createClassPrototype(),
-            ])
+            ]),
+            statement
         );
         newFuncStatements.push(assignSelf);
 
@@ -1073,12 +1074,13 @@ export class LuaTransformer {
         const callConstructor = tstl.createExpressionStatement(
             tstl.createMethodCallExpression(this.createSelfIdentifier(), tstl.createIdentifier("____constructor"), [
                 tstl.createDotsLiteral(),
-            ])
+            ]),
+            statement
         );
         newFuncStatements.push(callConstructor);
 
         // return self
-        const returnSelf = tstl.createReturnStatement([this.createSelfIdentifier()]);
+        const returnSelf = tstl.createReturnStatement([this.createSelfIdentifier()], statement);
         newFuncStatements.push(returnSelf);
 
         // function localClassName.new(construct, ...) ... end
@@ -1091,7 +1093,8 @@ export class LuaTransformer {
                 tstl.createDotsLiteral(),
                 undefined,
                 tstl.FunctionExpressionFlags.Declaration
-            )
+            ),
+            statement
         );
         result.push(newFunc);
 
@@ -1133,7 +1136,8 @@ export class LuaTransformer {
                     this.createSelfIdentifier(),
                     getterName,
                     tstl.createNilLiteral(),
-                ])
+                ]),
+                classDeclaration.members.find(ts.isConstructorDeclaration) || classDeclaration
             );
             statements.push(resetGetter);
         }
@@ -1234,7 +1238,7 @@ export class LuaTransformer {
                 restParamName,
                 tstl.FunctionExpressionFlags.Declaration
             ),
-            statement
+            statement.pos >= 0 ? statement : classDeclaration
         );
 
         return result;

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -1238,7 +1238,7 @@ export class LuaTransformer {
                 restParamName,
                 tstl.FunctionExpressionFlags.Declaration
             ),
-            statement.pos >= 0 ? statement : classDeclaration
+            statement.pos >= 0 ? statement : classDeclaration // Map to class declaration if constructor was generated
         );
 
         return result;

--- a/test/unit/sourcemaps.spec.ts
+++ b/test/unit/sourcemaps.spec.ts
@@ -70,7 +70,11 @@ test.each([
     },
     {
         typeScriptSource: `
-            class Bar extends Foo {}
+            class Bar extends Foo {
+                constructor() {
+                    super();
+                }
+            }
         `,
 
         assertPatterns: [
@@ -83,7 +87,26 @@ test.each([
             { luaPattern: "Bar.____super = Foo", typeScriptPattern: "Foo {" },
             { luaPattern: "setmetatable(Bar,", typeScriptPattern: "Foo {" },
             { luaPattern: "setmetatable(Bar.prototype,", typeScriptPattern: "Foo {" },
+            { luaPattern: "function Bar.new", typeScriptPattern: "class Bar" },
+            { luaPattern: "function Bar.prototype.____constructor", typeScriptPattern: "constructor" },
         ],
+    },
+    {
+        typeScriptSource: `
+            class Foo {
+            }
+        `,
+
+        assertPatterns: [{ luaPattern: "function Foo.prototype.____constructor", typeScriptPattern: "class Foo" }],
+    },
+    {
+        typeScriptSource: `
+            class Foo {
+                bar = "baz";
+            }
+        `,
+
+        assertPatterns: [{ luaPattern: "function Foo.prototype.____constructor", typeScriptPattern: "class Foo" }],
     },
     {
         typeScriptSource: `

--- a/test/unit/sourcemaps.spec.ts
+++ b/test/unit/sourcemaps.spec.ts
@@ -162,6 +162,30 @@ test("Source map has correct source root", async () => {
     expect(sourceMap.sourceRoot).toBe(".");
 });
 
+test.each([
+    { code: `const type = "foobar";`, name: "type" },
+    { code: `const and = "foobar";`, name: "and" },
+    { code: `const $$$ = "foobar";`, name: "$$$" },
+    { code: `const foo = { bar() { console.log(this); } };`, name: "this" },
+    { code: `function foo($$$: unknown) {}`, name: "$$$" },
+    { code: `class $$$ {}`, name: "$$$" },
+    { code: `namespace $$$ { const foo = "bar"; }`, name: "$$$" },
+])("Source map has correct name mappings (%p)", async ({ code, name }) => {
+    const { file } = util.transpileStringResult(code);
+
+    if (!util.expectToBeDefined(file.lua) || !util.expectToBeDefined(file.sourceMap)) return;
+
+    const consumer = await new SourceMapConsumer(file.sourceMap);
+    const typescriptPosition = lineAndColumnOf(code, name);
+    let mappedName: string | undefined;
+    consumer.eachMapping(mapping => {
+        if (mapping.originalLine === typescriptPosition.line && mapping.originalColumn === typescriptPosition.column) {
+            mappedName = mapping.name;
+        }
+    });
+    expect(mappedName).toBe(name);
+});
+
 test("sourceMapTraceback saves sourcemap in _G", () => {
     // Arrange
     const typeScriptSource = `

--- a/test/unit/sourcemaps.spec.ts
+++ b/test/unit/sourcemaps.spec.ts
@@ -33,6 +33,7 @@ test.each([
             { luaPattern: "function abc(", typeScriptPattern: "function abc() {" },
             { luaPattern: "function def(", typeScriptPattern: "function def() {" },
             { luaPattern: "return abc(", typeScriptPattern: "return abc(" },
+            { luaPattern: "end", typeScriptPattern: "function def() {" },
         ],
     },
     {


### PR DESCRIPTION
- function `end` is now mapped to the function declaration, since lua debuggers step on that line when returning
- class `new` and generated constructors now map to the class declaration
- added support for mapped names for translating `self`->`this` and variables which were lua identifiers or had invalid characters
