### PR TITLE
Fix noResolution for named imports

### DIFF
--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -1,7 +1,7 @@
 import * as path from "path";
 import * as ts from "typescript";
 import { CompilerOptions, LuaTarget } from "./CompilerOptions";
-import { DecoratorKind } from "./Decorator";
+import { Decorator, DecoratorKind } from "./Decorator";
 import * as tstl from "./LuaAST";
 import { LuaLibFeature } from "./LuaLib";
 import { ContextType, TSHelper as tsHelper } from "./TSHelper";
@@ -360,17 +360,10 @@ export class LuaTransformer {
         let shouldResolve = true;
         const moduleOwnerSymbol = this.checker.getSymbolAtLocation(statement.moduleSpecifier);
         if (moduleOwnerSymbol) {
-            for (const declaration of moduleOwnerSymbol.declarations) {
-                if (tsHelper.isNonNamespaceModuleDeclaration(declaration)) {
-                    const type = this.checker.getTypeAtLocation(declaration);
-                    if (type) {
-                        const decorators = tsHelper.getCustomDecorators(type, this.checker);
-                        if (decorators.has(DecoratorKind.NoResolution)) {
-                            shouldResolve = false;
-                            break;
-                        }
-                    }
-                }
+            const decMap = new Map<DecoratorKind, Decorator>();
+            tsHelper.collectCustomDecorators(moduleOwnerSymbol, this.checker, decMap);
+            if (decMap.has(DecoratorKind.NoResolution)) {
+                shouldResolve = false;
             }
         }
 

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -360,9 +360,9 @@ export class LuaTransformer {
         let shouldResolve = true;
         const moduleOwnerSymbol = this.checker.getSymbolAtLocation(statement.moduleSpecifier);
         if (moduleOwnerSymbol) {
-            const decMap = new Map<DecoratorKind, Decorator>();
-            tsHelper.collectCustomDecorators(moduleOwnerSymbol, this.checker, decMap);
-            if (decMap.has(DecoratorKind.NoResolution)) {
+            const decorators = new Map<DecoratorKind, Decorator>();
+            tsHelper.collectCustomDecorators(moduleOwnerSymbol, this.checker, decorators);
+            if (decorators.has(DecoratorKind.NoResolution)) {
                 shouldResolve = false;
             }
         }

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -131,10 +131,6 @@ export class TSHelper {
         return !((ts.getCombinedModifierFlags(node) & ts.ModifierFlags.Ambient) === 0);
     }
 
-    public static isNonNamespaceModuleDeclaration(node: ts.Node): node is ts.ModuleDeclaration {
-        return ts.isModuleDeclaration(node) && (node.flags & ts.NodeFlags.Namespace) === 0;
-    }
-
     public static isStatic(node: ts.Node): boolean {
         return node.modifiers !== undefined && node.modifiers.some(m => m.kind === ts.SyntaxKind.StaticKeyword);
     }

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -358,27 +358,6 @@ export class TSHelper {
         return directivesMap;
     }
 
-    public static getImportSpecifierModuleDeclaration(
-        node: ts.ImportSpecifier,
-        checker: ts.TypeChecker
-    ): ts.ModuleDeclaration | undefined {
-        const symbol = checker.getSymbolAtLocation(node.name);
-        if (symbol) {
-            const originalSymbol = checker.getAliasedSymbol(symbol);
-            if (originalSymbol.declarations) {
-                for (const declaration of originalSymbol.declarations) {
-                    const parentAmbientModule = this.findFirstNodeAbove(
-                        declaration,
-                        this.isNonNamespaceModuleDeclaration
-                    );
-                    if (parentAmbientModule) {
-                        return parentAmbientModule;
-                    }
-                }
-            }
-        }
-    }
-
     // Search up until finding a node satisfying the callback
     public static findFirstNodeAbove<T extends ts.Node>(
         node: ts.Node,

--- a/test/unit/require.spec.ts
+++ b/test/unit/require.spec.ts
@@ -151,6 +151,21 @@ test.each([
         mainCode: "import { y } from 'fake'; y;",
         expectedPath: "src.fake",
     },
+    {
+        declarationStatement: `
+            declare module 'fake' {}
+        `,
+        mainCode: "import 'fake';",
+        expectedPath: "src.fake",
+    },
+    {
+        declarationStatement: `
+            /** @noResolution */
+            declare module 'fake' {}
+        `,
+        mainCode: "import 'fake';",
+        expectedPath: "fake",
+    },
 ])("noResolution prevents any module path resolution behaviour", ({ declarationStatement, mainCode, expectedPath }) => {
     const lua = util.transpileString({
         "src/main.ts": mainCode,


### PR DESCRIPTION
Closes #635

`@noResolution` should still only be applicable to ambient modules.

If a module is merged with another and one has a `@noResolution`, no path resolution will be performed.

```ts
/** @noResolution */
declare module "module" {}
declare module "module" {
    export const x: number;
}
// ✔ will stay "module"
import { x } from "module";
```
