### PR TITLE
Fixed super calls across classes in merged namespace

### DIFF
--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -3568,11 +3568,15 @@ export class LuaTransformer {
         }
 
         const extendsExpression = typeNode.expression;
-        let baseClassName: tstl.AssignmentLeftHandSideExpression;
+        let baseClassName: tstl.AssignmentLeftHandSideExpression | undefined;
         if (ts.isIdentifier(extendsExpression)) {
-            // Use "baseClassName" if base is a simple identifier
-            baseClassName = this.transformIdentifier(extendsExpression);
-        } else {
+            const symbol = this.checker.getSymbolAtLocation(extendsExpression);
+            if (symbol && !this.isSymbolExported(symbol)) {
+                // Use "baseClassName" if base is a simple identifier
+                baseClassName = this.transformIdentifier(extendsExpression);
+            }
+        }
+        if (!baseClassName) {
             if (classDeclaration.name === undefined) {
                 throw TSTLErrors.MissingClassName(expression);
             }

--- a/test/unit/class.spec.ts
+++ b/test/unit/class.spec.ts
@@ -198,6 +198,27 @@ test("SubclassConstructor", () => {
     expect(result).toBe(11);
 });
 
+test("Subclass constructor across merged namespace", () => {
+    const tsHeader = `
+        namespace NS {
+            export class Super {
+                prop: string;
+                constructor() {
+                    this.prop = "foo";
+                }
+            }
+        }
+        namespace NS {
+            export class Sub extends Super {
+                constructor() {
+                    super();
+                }
+            }
+        }`;
+
+    expect(util.transpileAndExecute("return (new NS.Sub()).prop", undefined, undefined, tsHeader)).toBe("foo");
+});
+
 test("classSuper", () => {
     const result = util.transpileAndExecute(
         `class a {


### PR DESCRIPTION
fixes #634 

`super` calls will now use the long form (`MyClass.____super.prototype.____constructor()`) when the base class is an exported identifier. This fixes issues where the short form referenced a local that was not actually in scope (due to namespace merging).