### PR TITLE
Tagged template literals support

### DIFF
--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -4674,7 +4674,7 @@ export class LuaTransformer {
         const signatureDeclaration = signature && signature.getDeclaration();
         const useSelfParameter =
             signatureDeclaration &&
-            tsHelper.getDeclarationContextType(signatureDeclaration, this.checker) !== ContextType.Void;
+            tsHelper.getDeclarationContextType(signatureDeclaration, this.checker) !== tsHelper.ContextType.Void;
         const context = useSelfParameter ? (this.isStrict ? ts.createNull() : ts.createIdentifier("_G")) : undefined;
 
         // Argument evaluation.

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -4682,11 +4682,11 @@ export class LuaTransformer {
 
         // Assign raw strings to the "raw" property of the string table.
         const tableParameterIndex = useSelfParameter ? 1 : 0;
-        const tableLiteralExpression =
-            parameters[tableParameterIndex].kind === tstl.SyntaxKind.TableExpression
-                ? (parameters[tableParameterIndex] as tstl.TableExpression)
-                : undefined;
-        if (tableLiteralExpression && tableLiteralExpression.fields) {
+        const [tableLiteralExpression] = this.filterUndefinedAndCast(
+            [parameters[tableParameterIndex]],
+            tstl.isTableExpression
+        );
+        if (tableLiteralExpression.fields) {
             const rawStringArray = tstl.createTableExpression(
                 rawStrings.map(stringLiteral =>
                     tstl.createTableFieldExpression(tstl.createStringLiteral(stringLiteral))

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -4683,7 +4683,6 @@ export class LuaTransformer {
         // Assign raw strings to the "raw" property of the string table.
         const tableParameterIndex = useSelfParameter ? 1 : 0;
         const tableLiteralExpression =
-            parameters.length > tableParameterIndex &&
             parameters[tableParameterIndex].kind === tstl.SyntaxKind.TableExpression
                 ? (parameters[tableParameterIndex] as tstl.TableExpression)
                 : undefined;

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -758,6 +758,15 @@ export class TSHelper {
         return declarations.length > 0 ? declarations.reduce((p, c) => (p.pos < c.pos ? p : c)) : undefined;
     }
 
+    public static getRawLiteral(node: ts.LiteralLikeNode): string {
+        let text = node.getText();
+        const isLast =
+            node.kind === ts.SyntaxKind.NoSubstitutionTemplateLiteral || node.kind === ts.SyntaxKind.TemplateTail;
+        text = text.substring(1, text.length - (isLast ? 1 : 2));
+        text = text.replace(/\r\n?/g, "\n").replace(/\\/g, "\\\\");
+        return text;
+    }
+
     public static isFirstDeclaration(node: ts.VariableDeclaration, checker: ts.TypeChecker): boolean {
         const symbol = checker.getSymbolAtLocation(node.name);
         if (!symbol) {

--- a/test/unit/taggedTemplateLiterals.spec.ts
+++ b/test/unit/taggedTemplateLiterals.spec.ts
@@ -42,6 +42,21 @@ const testCases = [
         joinRawResult: "hello \\u00A9",
     },
     {
+        callExpression: "func`hello $ { }`",
+        joinAllResult: "hello $ { }",
+        joinRawResult: "hello $ { }",
+    },
+    {
+        callExpression: "func`hello { ${'brackets'} }`",
+        joinAllResult: "hello { brackets }",
+        joinRawResult: "hello {  }",
+    },
+    {
+        callExpression: "func`hello \\``",
+        joinAllResult: "hello `",
+        joinRawResult: "hello \\`",
+    },
+    {
         callExpression: "obj.func`hello ${'propertyAccessExpression'}`",
         joinAllResult: "hello propertyAccessExpression",
         joinRawResult: "hello ",

--- a/test/unit/taggedTemplateLiterals.spec.ts
+++ b/test/unit/taggedTemplateLiterals.spec.ts
@@ -1,47 +1,59 @@
 import * as util from "../util";
 
-test.each([
+const testCases = [
     {
         callExpression: "func``",
-        expectedResult: "",
+        joinAllResult: "",
+        joinRawResult: "",
     },
     {
         callExpression: "func`hello`",
-        expectedResult: "hello",
+        joinAllResult: "hello",
+        joinRawResult: "hello",
     },
     {
         callExpression: "func`hello ${1} ${2} ${3}`",
-        expectedResult: "hello 1 2 3",
+        joinAllResult: "hello 1 2 3",
+        joinRawResult: "hello   ",
     },
     {
         callExpression: "func`hello ${(() => 'iife')()}`",
-        expectedResult: "hello iife",
+        joinAllResult: "hello iife",
+        joinRawResult: "hello ",
     },
     {
         callExpression: "func`hello ${1 + 2 + 3} arithmetic`",
-        expectedResult: "hello 6 arithmetic",
+        joinAllResult: "hello 6 arithmetic",
+        joinRawResult: "hello  arithmetic",
     },
     {
         callExpression: "func`begin ${'middle'} end`",
-        expectedResult: "begin middle end",
+        joinAllResult: "begin middle end",
+        joinRawResult: "begin  end",
     },
     {
         callExpression: "func`hello ${func`hello`}`",
-        expectedResult: "hello hello",
+        joinAllResult: "hello hello",
+        joinRawResult: "hello ",
     },
     {
         callExpression: "func`hello \\u00A9`",
-        expectedResult: "hello ©",
+        joinAllResult: "hello ©",
+        joinRawResult: "hello \\u00A9",
     },
     {
         callExpression: "obj.func`hello ${'propertyAccessExpression'}`",
-        expectedResult: "hello propertyAccessExpression",
+        joinAllResult: "hello propertyAccessExpression",
+        joinRawResult: "hello ",
     },
     {
         callExpression: "obj['func']`hello ${'elementAccessExpression'}`",
-        expectedResult: "hello elementAccessExpression",
+        joinAllResult: "hello elementAccessExpression",
+        joinRawResult: "hello ",
     },
-])("TaggedTemplateLiteral call (%p)", ({ callExpression, expectedResult }) => {
+];
+
+test.each(testCases)("TaggedTemplateLiteral call (%p)", ({ callExpression, joinAllResult }) => {
     const result = util.transpileAndExecute(`
             function func(strings: TemplateStringsArray, ...expressions: any[]) {
                 const toJoin = [];
@@ -61,7 +73,21 @@ test.each([
             return ${callExpression};
         `);
 
-    expect(result).toBe(expectedResult);
+    expect(result).toBe(joinAllResult);
+});
+
+test.each(testCases)("TaggedTemplateLiteral raw preservation (%p)", ({ callExpression, joinRawResult }) => {
+    const result = util.transpileAndExecute(`
+            function func(strings: TemplateStringsArray, ...expressions: any[]) {
+                return strings.raw.join("");
+            }
+            const obj = {
+                func
+            };
+            return ${callExpression};
+        `);
+
+    expect(result).toBe(joinRawResult);
 });
 
 test("TaggedTemplateLiteral no self parameter", () => {

--- a/test/unit/taggedTemplateLiterals.spec.ts
+++ b/test/unit/taggedTemplateLiterals.spec.ts
@@ -30,6 +30,10 @@ test.each([
         expectedResult: "hello hello",
     },
     {
+        callExpression: "func`hello \\u00A9`",
+        expectedResult: "hello ©",
+    },
+    {
         callExpression: "obj.func`hello ${'propertyAccessExpression'}`",
         expectedResult: "hello propertyAccessExpression",
     },

--- a/test/unit/taggedTemplateLiterals.spec.ts
+++ b/test/unit/taggedTemplateLiterals.spec.ts
@@ -105,13 +105,19 @@ test.each(testCases)("TaggedTemplateLiteral raw preservation (%p)", ({ callExpre
     expect(result).toBe(joinRawResult);
 });
 
-test("TaggedTemplateLiteral no self parameter", () => {
-    const result = util.transpileAndExecute(`
+test.each(["func`noSelfParameter`", "obj.func`noSelfParameter`", "obj[`func`]`noSelfParameter`"])(
+    "TaggedTemplateLiteral no self parameter",
+    callExpression => {
+        const result = util.transpileAndExecute(`
             function func(this: void, strings: TemplateStringsArray, ...expressions: any[]) {
                 return strings.join("");
             }
-            return func\`noSelfParameter\`;
+            const obj = {
+                func
+            };
+            return ${callExpression};
         `);
 
-    expect(result).toBe("noSelfParameter");
-});
+        expect(result).toBe("noSelfParameter");
+    }
+);

--- a/test/unit/taggedTemplateLiterals.spec.ts
+++ b/test/unit/taggedTemplateLiterals.spec.ts
@@ -1,0 +1,72 @@
+import * as util from "../util";
+
+test.each([
+    {
+        callExpression: "func``",
+        expectedResult: "",
+    },
+    {
+        callExpression: "func`hello`",
+        expectedResult: "hello",
+    },
+    {
+        callExpression: "func`hello ${1} ${2} ${3}`",
+        expectedResult: "hello 1 2 3",
+    },
+    {
+        callExpression: "func`hello ${(() => 'iife')()}`",
+        expectedResult: "hello iife",
+    },
+    {
+        callExpression: "func`hello ${1 + 2 + 3} arithmetic`",
+        expectedResult: "hello 6 arithmetic",
+    },
+    {
+        callExpression: "func`begin ${'middle'} end`",
+        expectedResult: "begin middle end",
+    },
+    {
+        callExpression: "func`hello ${func`hello`}`",
+        expectedResult: "hello hello",
+    },
+    {
+        callExpression: "obj.func`hello ${'propertyAccessExpression'}`",
+        expectedResult: "hello propertyAccessExpression",
+    },
+    {
+        callExpression: "obj['func']`hello ${'elementAccessExpression'}`",
+        expectedResult: "hello elementAccessExpression",
+    },
+])("TaggedTemplateLiteral call (%p)", ({ callExpression, expectedResult }) => {
+    const result = util.transpileAndExecute(`
+            function func(strings: TemplateStringsArray, ...expressions: any[]) {
+                const toJoin = [];
+                for (let i = 0; i < strings.length; ++i) {
+                    if (strings[i]) {
+                        toJoin.push(strings[i]);
+                    }
+                    if (expressions[i]) {
+                        toJoin.push(expressions[i]);
+                    }
+                }
+                return toJoin.join("");
+            }
+            const obj = {
+                func
+            };
+            return ${callExpression};
+        `);
+
+    expect(result).toBe(expectedResult);
+});
+
+test("TaggedTemplateLiteral no self parameter", () => {
+    const result = util.transpileAndExecute(`
+            function func(this: void, strings: TemplateStringsArray, ...expressions: any[]) {
+                return strings.join("");
+            }
+            return func\`noSelfParameter\`;
+        `);
+
+    expect(result).toBe("noSelfParameter");
+});


### PR DESCRIPTION
Closes #611

[Raw strings](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#Raw_strings) are usable too.

Equivalent output code does look hard to read.

```ts
function func(strings: TemplateStringsArray, ...expressions: any[]) {}

func`\u00A9 ${4}`;
```

```lua
--[[ Generated with https://github.com/TypeScriptToLua/TypeScriptToLua ]]
function func(self, strings, ...)
end
func(_G, {
    "© ",
    "",
    raw = {
        "\\u00A9 ",
        "",
    },
}, 4)

```