### PR TITLE
Omitted expression support

### DIFF
--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -2683,6 +2683,8 @@ export class LuaTransformer {
                 return this.transformArrayLiteral(expression as ts.ArrayLiteralExpression);
             case ts.SyntaxKind.ObjectLiteralExpression:
                 return this.transformObjectLiteral(expression as ts.ObjectLiteralExpression);
+            case ts.SyntaxKind.OmittedExpression:
+                return this.transformOmittedExpression(expression as ts.OmittedExpression);
             case ts.SyntaxKind.DeleteExpression:
                 return this.transformDeleteExpression(expression as ts.DeleteExpression);
             case ts.SyntaxKind.FunctionExpression:
@@ -3464,6 +3466,10 @@ export class LuaTransformer {
         });
 
         return tstl.createTableExpression(properties, expression);
+    }
+
+    public transformOmittedExpression(node: ts.OmittedExpression): ExpressionVisitResult {
+        return tstl.createNilLiteral(node);
     }
 
     public transformDeleteExpression(expression: ts.DeleteExpression): ExpressionVisitResult {

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -2909,9 +2909,14 @@ export class LuaTransformer {
 
         if (ts.isArrayLiteralExpression(expression.left)) {
             // Destructuring assignment
+            const omittedExpressionAssignmentIdentifier = tstl.createAnonymousIdentifier();
             const left =
                 expression.left.elements.length > 0
-                    ? expression.left.elements.map(e => this.transformExpression(e))
+                    ? expression.left.elements.map(e =>
+                          ts.isOmittedExpression(e)
+                              ? omittedExpressionAssignmentIdentifier
+                              : this.transformExpression(e)
+                      )
                     : [tstl.createAnonymousIdentifier(expression.left)];
             let right: tstl.Expression[];
             if (ts.isArrayLiteralExpression(expression.right)) {

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -793,6 +793,19 @@ export function isEnumMember(
     }
 }
 
+export function isWithinLiteralAssignmentStatement(node: ts.Node): boolean {
+    if (!node.parent) {
+        return false;
+    }
+    if (ts.isArrayLiteralExpression(node.parent) || ts.isObjectLiteralExpression(node.parent)) {
+        return isWithinLiteralAssignmentStatement(node.parent);
+    } else if (ts.isBinaryExpression(node.parent) && node.parent.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
 export function moduleHasEmittedBody(
     statement: ts.ModuleDeclaration
 ): statement is ts.ModuleDeclaration & { body: ts.ModuleBlock | ts.ModuleDeclaration } {

--- a/test/unit/array.spec.ts
+++ b/test/unit/array.spec.ts
@@ -191,3 +191,12 @@ test.each([
     `;
     expect(() => util.transpileAndExecute(code)).toThrowError(`invalid array length: ${result}`);
 });
+
+test("Array OmittedExpression", () => {
+    const result = util.transpileAndExecute(
+        `const myarray = [1, , 2];
+        return myarray[2];`
+    );
+
+    expect(result).toBe(2);
+});

--- a/test/unit/array.spec.ts
+++ b/test/unit/array.spec.ts
@@ -192,14 +192,11 @@ test.each([
     expect(() => util.transpileAndExecute(code)).toThrowError(`invalid array length: ${result}`);
 });
 
-test.each([{ index: 0, expectedResult: 1 }, { index: 1, expectedResult: undefined }, { index: 2, expectedResult: 2 }])(
-    "Array with OmittedExpression",
-    ({ index, expectedResult }) => {
-        const result = util.transpileAndExecute(
-            `const myarray = [1, , 2];
+test.each([0, 1, 2])("Array with OmittedExpression", index => {
+    const result = util.transpileAndExecute(
+        `const myarray = [1, , 2];
         return myarray[${index}];`
-        );
+    );
 
-        expect(result).toBe(expectedResult);
-    }
-);
+    expect(result).toBe([1, , 2][index]);
+});

--- a/test/unit/array.spec.ts
+++ b/test/unit/array.spec.ts
@@ -192,20 +192,14 @@ test.each([
     expect(() => util.transpileAndExecute(code)).toThrowError(`invalid array length: ${result}`);
 });
 
-test("Array OmittedExpression", () => {
-    const result = util.transpileAndExecute(
-        `const myarray = [,];
-        return myarray[0];`
-    );
+test.each([{ index: 0, expectedResult: 1 }, { index: 1, expectedResult: undefined }, { index: 2, expectedResult: 2 }])(
+    "Array with OmittedExpression",
+    ({ index, expectedResult }) => {
+        const result = util.transpileAndExecute(
+            `const myarray = [1, , 2];
+        return myarray[${index}];`
+        );
 
-    expect(result).toBe(undefined);
-});
-
-test("Part of Array can be an OmittedExpression", () => {
-    const result = util.transpileAndExecute(
-        `const myarray = [1, , 2];
-        return myarray[2];`
-    );
-
-    expect(result).toBe(2);
-});
+        expect(result).toBe(expectedResult);
+    }
+);

--- a/test/unit/array.spec.ts
+++ b/test/unit/array.spec.ts
@@ -194,6 +194,15 @@ test.each([
 
 test("Array OmittedExpression", () => {
     const result = util.transpileAndExecute(
+        `const myarray = [,];
+        return myarray[0];`
+    );
+
+    expect(result).toBe(undefined);
+});
+
+test("Part of Array can be an OmittedExpression", () => {
+    const result = util.transpileAndExecute(
         `const myarray = [1, , 2];
         return myarray[2];`
     );

--- a/test/unit/array.spec.ts
+++ b/test/unit/array.spec.ts
@@ -200,3 +200,13 @@ test.each([0, 1, 2])("Array with OmittedExpression", index => {
 
     expect(result).toBe([1, , 2][index]);
 });
+
+test("OmittedExpression in Array Binding Assignment Statement", () => {
+    const result = util.transpileAndExecute(
+        `let a, c;
+        [a, , c] = [1, 2, 3];
+        return a + c;`
+    );
+
+    expect(result).toBe(4);
+});


### PR DESCRIPTION
Closes #603

Allows OmittedExpressions to be used in an array.

```ts
const array = [0, , 2];
```

```lua
local array = {0, nil, 2}
```

It is important to note that Lua will stop iterating through an array when it reaches `nil`.

These OmittedExpressions can also be used in array binding assignment statements:

```ts
let a, c;
[a, , c] = [0, 1, 2];
```