### PR TITLE
Non-module namespace merge

### DIFF
--- a/test/translation/__snapshots__/transformation.spec.ts.snap
+++ b/test/translation/__snapshots__/transformation.spec.ts.snap
@@ -552,7 +552,7 @@ MergedClass:namespaceFunc()"
 exports[`Transformation (namespaceNested) 1`] = `
 "myNamespace = myNamespace or {}
 do
-    local myNestedNamespace = myNestedNamespace or {}
+    local myNestedNamespace = {}
     do
         local function nsMember(self)
         end

--- a/test/translation/__snapshots__/transformation.spec.ts.snap
+++ b/test/translation/__snapshots__/transformation.spec.ts.snap
@@ -471,7 +471,7 @@ end
 return ____exports"
 `;
 
-exports[`Transformation (modulesNamespaceNoExport) 1`] = `"TestSpace = {}"`;
+exports[`Transformation (modulesNamespaceNoExport) 1`] = `"TestSpace = TestSpace or {}"`;
 
 exports[`Transformation (modulesNamespaceWithMemberExport) 1`] = `
 "local ____exports = {}
@@ -503,7 +503,7 @@ return ____exports"
 exports[`Transformation (modulesVariableNoExport) 1`] = `"local foo = \\"bar\\""`;
 
 exports[`Transformation (namespace) 1`] = `
-"myNamespace = {}
+"myNamespace = myNamespace or {}
 do
     local function nsMember(self)
     end
@@ -537,6 +537,7 @@ function MergedClass.prototype.methodB(self)
     self:methodA()
     self:propertyFunc()
 end
+MergedClass = MergedClass or {}
 do
     function MergedClass.namespaceFunc(self)
     end
@@ -549,9 +550,9 @@ MergedClass:namespaceFunc()"
 `;
 
 exports[`Transformation (namespaceNested) 1`] = `
-"myNamespace = {}
+"myNamespace = myNamespace or {}
 do
-    local myNestedNamespace = {}
+    local myNestedNamespace = myNestedNamespace or {}
     do
         local function nsMember(self)
         end

--- a/test/unit/modules.spec.ts
+++ b/test/unit/modules.spec.ts
@@ -176,7 +176,7 @@ test("module merged across files", () => {
             }
         }
     `;
-    const { transpiledFiles } = util.transpileStringsAsProject({"testA.ts": testA, "testB.ts": testB});
+    const { transpiledFiles } = util.transpileStringsAsProject({ "testA.ts": testA, "testB.ts": testB });
     const lua = transpiledFiles.map(f => f.lua).join("\n") + "\nreturn NS.Inner.foo .. NS.Inner.bar";
     expect(util.executeLua(lua)).toBe("foobar");
 });

--- a/test/unit/modules.spec.ts
+++ b/test/unit/modules.spec.ts
@@ -160,3 +160,23 @@ test("Module merged with interface", () => {
     const code = `return Foo.bar();`;
     expect(util.transpileAndExecute(code, undefined, undefined, header)).toBe("foobar");
 });
+
+test("module merged across files", () => {
+    const testA = `
+        namespace NS {
+            export namespace Inner {
+                export const foo = "foo";
+            }
+        }
+    `;
+    const testB = `
+        namespace NS {
+            export namespace Inner {
+                export const bar = "bar";
+            }
+        }
+    `;
+    const { transpiledFiles } = util.transpileStringsAsProject({"testA.ts": testA, "testB.ts": testB});
+    const lua = transpiledFiles.map(f => f.lua).join("\n") + "\nreturn NS.Inner.foo .. NS.Inner.bar";
+    expect(util.executeLua(lua)).toBe("foobar");
+});

--- a/test/util.ts
+++ b/test/util.ts
@@ -20,10 +20,10 @@ export function transpileString(
     return file.lua.trim();
 }
 
-export function transpileStringResult(
-    input: string | Record<string, string>,
+export function transpileStringsAsProject(
+    input: Record<string, string>,
     options: tstl.CompilerOptions = {}
-): Required<tstl.TranspileStringResult> {
+): tstl.TranspileResult {
     const optionsWithDefaults = {
         luaTarget: tstl.LuaTarget.Lua53,
         noHeader: true,
@@ -34,9 +34,16 @@ export function transpileStringResult(
         ...options,
     };
 
-    const { diagnostics, transpiledFiles } = tstl.transpileVirtualProject(
+    return tstl.transpileVirtualProject(input, optionsWithDefaults);
+}
+
+export function transpileStringResult(
+    input: string | Record<string, string>,
+    options: tstl.CompilerOptions = {}
+): Required<tstl.TranspileStringResult> {
+    const { diagnostics, transpiledFiles } = transpileStringsAsProject(
         typeof input === "string" ? { "main.ts": input } : input,
-        optionsWithDefaults
+        options
     );
 
     const file = transpiledFiles.find(({ fileName }) => /\bmain\.[a-z]+$/.test(fileName));


### PR DESCRIPTION
fixes #641 

When namespaces with the same name are declared in non-module files, TS assumes they'll be merged somehow (the example in the bug wouldn't work as you can't import non-modules, but there are other ways they code could be merged).

This fixes that case by using an `or` assignment when a namespace is declared in a non-module file.
```lua
NS = NS or {}
```