### PR TITLE
Preserve newlines in template literals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
             "dev": true,
             "requires": {
-                "@babel/highlight": "^7.0.0"
+                "@babel/highlight": "7.0.0"
             }
         },
         "@babel/core": {
@@ -19,20 +19,20 @@
             "integrity": "sha512-Dzl7U0/T69DFOTwqz/FJdnOSWS57NpjNfCwMKHABr589Lg8uX1RrlBIJ7L5Dubt/xkLsx0xH5EBFzlBVes1ayA==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@babel/generator": "^7.4.0",
-                "@babel/helpers": "^7.4.0",
-                "@babel/parser": "^7.4.0",
-                "@babel/template": "^7.4.0",
-                "@babel/traverse": "^7.4.0",
-                "@babel/types": "^7.4.0",
-                "convert-source-map": "^1.1.0",
-                "debug": "^4.1.0",
-                "json5": "^2.1.0",
-                "lodash": "^4.17.11",
-                "resolve": "^1.3.2",
-                "semver": "^5.4.1",
-                "source-map": "^0.5.0"
+                "@babel/code-frame": "7.0.0",
+                "@babel/generator": "7.4.0",
+                "@babel/helpers": "7.4.2",
+                "@babel/parser": "7.4.2",
+                "@babel/template": "7.4.0",
+                "@babel/traverse": "7.4.0",
+                "@babel/types": "7.4.0",
+                "convert-source-map": "1.6.0",
+                "debug": "4.1.1",
+                "json5": "2.1.0",
+                "lodash": "4.17.11",
+                "resolve": "1.11.0",
+                "semver": "5.5.0",
+                "source-map": "0.5.7"
             },
             "dependencies": {
                 "@babel/generator": {
@@ -41,11 +41,11 @@
                     "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
                     "dev": true,
                     "requires": {
-                        "@babel/types": "^7.4.0",
-                        "jsesc": "^2.5.1",
-                        "lodash": "^4.17.11",
-                        "source-map": "^0.5.0",
-                        "trim-right": "^1.0.1"
+                        "@babel/types": "7.4.0",
+                        "jsesc": "2.5.2",
+                        "lodash": "4.17.11",
+                        "source-map": "0.5.7",
+                        "trim-right": "1.0.1"
                     }
                 },
                 "@babel/helper-split-export-declaration": {
@@ -54,7 +54,7 @@
                     "integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
                     "dev": true,
                     "requires": {
-                        "@babel/types": "^7.4.0"
+                        "@babel/types": "7.4.0"
                     }
                 },
                 "@babel/parser": {
@@ -69,9 +69,9 @@
                     "integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
                     "dev": true,
                     "requires": {
-                        "@babel/code-frame": "^7.0.0",
-                        "@babel/parser": "^7.4.0",
-                        "@babel/types": "^7.4.0"
+                        "@babel/code-frame": "7.0.0",
+                        "@babel/parser": "7.4.2",
+                        "@babel/types": "7.4.0"
                     }
                 },
                 "@babel/traverse": {
@@ -80,15 +80,15 @@
                     "integrity": "sha512-/DtIHKfyg2bBKnIN+BItaIlEg5pjAnzHOIQe5w+rHAw/rg9g0V7T4rqPX8BJPfW11kt3koyjAnTNwCzb28Y1PA==",
                     "dev": true,
                     "requires": {
-                        "@babel/code-frame": "^7.0.0",
-                        "@babel/generator": "^7.4.0",
-                        "@babel/helper-function-name": "^7.1.0",
-                        "@babel/helper-split-export-declaration": "^7.4.0",
-                        "@babel/parser": "^7.4.0",
-                        "@babel/types": "^7.4.0",
-                        "debug": "^4.1.0",
-                        "globals": "^11.1.0",
-                        "lodash": "^4.17.11"
+                        "@babel/code-frame": "7.0.0",
+                        "@babel/generator": "7.4.0",
+                        "@babel/helper-function-name": "7.1.0",
+                        "@babel/helper-split-export-declaration": "7.4.0",
+                        "@babel/parser": "7.4.2",
+                        "@babel/types": "7.4.0",
+                        "debug": "4.1.1",
+                        "globals": "11.11.0",
+                        "lodash": "4.17.11"
                     }
                 },
                 "@babel/types": {
@@ -97,9 +97,9 @@
                     "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
                     "dev": true,
                     "requires": {
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.17.11",
-                        "to-fast-properties": "^2.0.0"
+                        "esutils": "2.0.2",
+                        "lodash": "4.17.11",
+                        "to-fast-properties": "2.0.0"
                     }
                 },
                 "source-map": {
@@ -116,11 +116,11 @@
             "integrity": "sha512-f3QCuPppXxtZOEm5GWPra/uYUjmNQlu9pbAD8D/9jze4pTY83rTtB1igTBSwvkeNlC5gR24zFFkz+2WHLFQhqQ==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.3.2",
-                "jsesc": "^2.5.1",
-                "lodash": "^4.17.10",
-                "source-map": "^0.5.0",
-                "trim-right": "^1.0.1"
+                "@babel/types": "7.3.2",
+                "jsesc": "2.5.2",
+                "lodash": "4.17.11",
+                "source-map": "0.5.7",
+                "trim-right": "1.0.1"
             },
             "dependencies": {
                 "source-map": {
@@ -137,9 +137,9 @@
             "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
             "dev": true,
             "requires": {
-                "@babel/helper-get-function-arity": "^7.0.0",
-                "@babel/template": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/helper-get-function-arity": "7.0.0",
+                "@babel/template": "7.2.2",
+                "@babel/types": "7.3.2"
             }
         },
         "@babel/helper-get-function-arity": {
@@ -148,7 +148,7 @@
             "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "7.3.2"
             }
         },
         "@babel/helper-plugin-utils": {
@@ -163,7 +163,7 @@
             "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "7.3.2"
             }
         },
         "@babel/helpers": {
@@ -172,9 +172,9 @@
             "integrity": "sha512-gQR1eQeroDzFBikhrCccm5Gs2xBjZ57DNjGbqTaHo911IpmSxflOQWMAHPw/TXk8L3isv7s9lYzUkexOeTQUYg==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.4.0",
-                "@babel/traverse": "^7.4.0",
-                "@babel/types": "^7.4.0"
+                "@babel/template": "7.4.0",
+                "@babel/traverse": "7.4.0",
+                "@babel/types": "7.4.0"
             },
             "dependencies": {
                 "@babel/generator": {
@@ -183,11 +183,11 @@
                     "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
                     "dev": true,
                     "requires": {
-                        "@babel/types": "^7.4.0",
-                        "jsesc": "^2.5.1",
-                        "lodash": "^4.17.11",
-                        "source-map": "^0.5.0",
-                        "trim-right": "^1.0.1"
+                        "@babel/types": "7.4.0",
+                        "jsesc": "2.5.2",
+                        "lodash": "4.17.11",
+                        "source-map": "0.5.7",
+                        "trim-right": "1.0.1"
                     }
                 },
                 "@babel/helper-split-export-declaration": {
@@ -196,7 +196,7 @@
                     "integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
                     "dev": true,
                     "requires": {
-                        "@babel/types": "^7.4.0"
+                        "@babel/types": "7.4.0"
                     }
                 },
                 "@babel/parser": {
@@ -211,9 +211,9 @@
                     "integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
                     "dev": true,
                     "requires": {
-                        "@babel/code-frame": "^7.0.0",
-                        "@babel/parser": "^7.4.0",
-                        "@babel/types": "^7.4.0"
+                        "@babel/code-frame": "7.0.0",
+                        "@babel/parser": "7.4.2",
+                        "@babel/types": "7.4.0"
                     }
                 },
                 "@babel/traverse": {
@@ -222,15 +222,15 @@
                     "integrity": "sha512-/DtIHKfyg2bBKnIN+BItaIlEg5pjAnzHOIQe5w+rHAw/rg9g0V7T4rqPX8BJPfW11kt3koyjAnTNwCzb28Y1PA==",
                     "dev": true,
                     "requires": {
-                        "@babel/code-frame": "^7.0.0",
-                        "@babel/generator": "^7.4.0",
-                        "@babel/helper-function-name": "^7.1.0",
-                        "@babel/helper-split-export-declaration": "^7.4.0",
-                        "@babel/parser": "^7.4.0",
-                        "@babel/types": "^7.4.0",
-                        "debug": "^4.1.0",
-                        "globals": "^11.1.0",
-                        "lodash": "^4.17.11"
+                        "@babel/code-frame": "7.0.0",
+                        "@babel/generator": "7.4.0",
+                        "@babel/helper-function-name": "7.1.0",
+                        "@babel/helper-split-export-declaration": "7.4.0",
+                        "@babel/parser": "7.4.2",
+                        "@babel/types": "7.4.0",
+                        "debug": "4.1.1",
+                        "globals": "11.11.0",
+                        "lodash": "4.17.11"
                     }
                 },
                 "@babel/types": {
@@ -239,9 +239,9 @@
                     "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
                     "dev": true,
                     "requires": {
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.17.11",
-                        "to-fast-properties": "^2.0.0"
+                        "esutils": "2.0.2",
+                        "lodash": "4.17.11",
+                        "to-fast-properties": "2.0.0"
                     }
                 },
                 "source-map": {
@@ -258,9 +258,9 @@
             "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
             "dev": true,
             "requires": {
-                "chalk": "^2.0.0",
-                "esutils": "^2.0.2",
-                "js-tokens": "^4.0.0"
+                "chalk": "2.4.2",
+                "esutils": "2.0.2",
+                "js-tokens": "4.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -269,7 +269,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.2"
                     }
                 },
                 "chalk": {
@@ -278,9 +278,9 @@
                     "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.5.0"
                     }
                 },
                 "js-tokens": {
@@ -295,7 +295,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -312,7 +312,7 @@
             "integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.0.0"
+                "@babel/helper-plugin-utils": "7.0.0"
             }
         },
         "@babel/template": {
@@ -321,9 +321,9 @@
             "integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@babel/parser": "^7.2.2",
-                "@babel/types": "^7.2.2"
+                "@babel/code-frame": "7.0.0",
+                "@babel/parser": "7.3.2",
+                "@babel/types": "7.3.2"
             }
         },
         "@babel/traverse": {
@@ -332,15 +332,15 @@
             "integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@babel/generator": "^7.2.2",
-                "@babel/helper-function-name": "^7.1.0",
-                "@babel/helper-split-export-declaration": "^7.0.0",
-                "@babel/parser": "^7.2.3",
-                "@babel/types": "^7.2.2",
-                "debug": "^4.1.0",
-                "globals": "^11.1.0",
-                "lodash": "^4.17.10"
+                "@babel/code-frame": "7.0.0",
+                "@babel/generator": "7.3.2",
+                "@babel/helper-function-name": "7.1.0",
+                "@babel/helper-split-export-declaration": "7.0.0",
+                "@babel/parser": "7.3.2",
+                "@babel/types": "7.3.2",
+                "debug": "4.1.1",
+                "globals": "11.11.0",
+                "lodash": "4.17.11"
             }
         },
         "@babel/types": {
@@ -349,9 +349,9 @@
             "integrity": "sha512-3Y6H8xlUlpbGR+XvawiH0UXehqydTmNmEpozWcXymqwcrwYAl5KMvKtQ+TF6f6E08V6Jur7v/ykdDSF+WDEIXQ==",
             "dev": true,
             "requires": {
-                "esutils": "^2.0.2",
-                "lodash": "^4.17.10",
-                "to-fast-properties": "^2.0.0"
+                "esutils": "2.0.2",
+                "lodash": "4.17.11",
+                "to-fast-properties": "2.0.0"
             }
         },
         "@cnakazawa/watch": {
@@ -360,8 +360,8 @@
             "integrity": "sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==",
             "dev": true,
             "requires": {
-                "exec-sh": "^0.3.2",
-                "minimist": "^1.2.0"
+                "exec-sh": "0.3.2",
+                "minimist": "1.2.0"
             }
         },
         "@jest/console": {
@@ -370,9 +370,9 @@
             "integrity": "sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==",
             "dev": true,
             "requires": {
-                "@jest/source-map": "^24.3.0",
-                "chalk": "^2.0.1",
-                "slash": "^2.0.0"
+                "@jest/source-map": "24.3.0",
+                "chalk": "2.4.2",
+                "slash": "2.0.0"
             }
         },
         "@jest/core": {
@@ -381,33 +381,33 @@
             "integrity": "sha512-R9rhAJwCBQzaRnrRgAdVfnglUuATXdwTRsYqs6NMdVcAl5euG8LtWDe+fVkN27YfKVBW61IojVsXKaOmSnqd/A==",
             "dev": true,
             "requires": {
-                "@jest/console": "^24.7.1",
-                "@jest/reporters": "^24.8.0",
-                "@jest/test-result": "^24.8.0",
-                "@jest/transform": "^24.8.0",
-                "@jest/types": "^24.8.0",
-                "ansi-escapes": "^3.0.0",
-                "chalk": "^2.0.1",
-                "exit": "^0.1.2",
-                "graceful-fs": "^4.1.15",
-                "jest-changed-files": "^24.8.0",
-                "jest-config": "^24.8.0",
-                "jest-haste-map": "^24.8.0",
-                "jest-message-util": "^24.8.0",
-                "jest-regex-util": "^24.3.0",
-                "jest-resolve-dependencies": "^24.8.0",
-                "jest-runner": "^24.8.0",
-                "jest-runtime": "^24.8.0",
-                "jest-snapshot": "^24.8.0",
-                "jest-util": "^24.8.0",
-                "jest-validate": "^24.8.0",
-                "jest-watcher": "^24.8.0",
-                "micromatch": "^3.1.10",
-                "p-each-series": "^1.0.0",
-                "pirates": "^4.0.1",
-                "realpath-native": "^1.1.0",
-                "rimraf": "^2.5.4",
-                "strip-ansi": "^5.0.0"
+                "@jest/console": "24.7.1",
+                "@jest/reporters": "24.8.0",
+                "@jest/test-result": "24.8.0",
+                "@jest/transform": "24.8.0",
+                "@jest/types": "24.8.0",
+                "ansi-escapes": "3.2.0",
+                "chalk": "2.4.2",
+                "exit": "0.1.2",
+                "graceful-fs": "4.1.15",
+                "jest-changed-files": "24.8.0",
+                "jest-config": "24.8.0",
+                "jest-haste-map": "24.8.0",
+                "jest-message-util": "24.8.0",
+                "jest-regex-util": "24.3.0",
+                "jest-resolve-dependencies": "24.8.0",
+                "jest-runner": "24.8.0",
+                "jest-runtime": "24.8.0",
+                "jest-snapshot": "24.8.0",
+                "jest-util": "24.8.0",
+                "jest-validate": "24.8.0",
+                "jest-watcher": "24.8.0",
+                "micromatch": "3.1.10",
+                "p-each-series": "1.0.0",
+                "pirates": "4.0.1",
+                "realpath-native": "1.1.0",
+                "rimraf": "2.6.3",
+                "strip-ansi": "5.2.0"
             },
             "dependencies": {
                 "@jest/console": {
@@ -416,9 +416,9 @@
                     "integrity": "sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==",
                     "dev": true,
                     "requires": {
-                        "@jest/source-map": "^24.3.0",
-                        "chalk": "^2.0.1",
-                        "slash": "^2.0.0"
+                        "@jest/source-map": "24.3.0",
+                        "chalk": "2.4.2",
+                        "slash": "2.0.0"
                     }
                 },
                 "@jest/fake-timers": {
@@ -427,9 +427,9 @@
                     "integrity": "sha512-2M4d5MufVXwi6VzZhJ9f5S/wU4ud2ck0kxPof1Iz3zWx6Y+V2eJrES9jEktB6O3o/oEyk+il/uNu9PvASjWXQw==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "jest-message-util": "^24.8.0",
-                        "jest-mock": "^24.8.0"
+                        "@jest/types": "24.8.0",
+                        "jest-message-util": "24.8.0",
+                        "jest-mock": "24.8.0"
                     }
                 },
                 "@jest/test-result": {
@@ -438,9 +438,9 @@
                     "integrity": "sha512-+YdLlxwizlfqkFDh7Mc7ONPQAhA4YylU1s529vVM1rsf67vGZH/2GGm5uO8QzPeVyaVMobCQ7FTxl38QrKRlng==",
                     "dev": true,
                     "requires": {
-                        "@jest/console": "^24.7.1",
-                        "@jest/types": "^24.8.0",
-                        "@types/istanbul-lib-coverage": "^2.0.0"
+                        "@jest/console": "24.7.1",
+                        "@jest/types": "24.8.0",
+                        "@types/istanbul-lib-coverage": "2.0.1"
                     }
                 },
                 "@jest/transform": {
@@ -449,20 +449,20 @@
                     "integrity": "sha512-xBMfFUP7TortCs0O+Xtez2W7Zu1PLH9bvJgtraN1CDST6LBM/eTOZ9SfwS/lvV8yOfcDpFmwf9bq5cYbXvqsvA==",
                     "dev": true,
                     "requires": {
-                        "@babel/core": "^7.1.0",
-                        "@jest/types": "^24.8.0",
-                        "babel-plugin-istanbul": "^5.1.0",
-                        "chalk": "^2.0.1",
-                        "convert-source-map": "^1.4.0",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "graceful-fs": "^4.1.15",
-                        "jest-haste-map": "^24.8.0",
-                        "jest-regex-util": "^24.3.0",
-                        "jest-util": "^24.8.0",
-                        "micromatch": "^3.1.10",
-                        "realpath-native": "^1.1.0",
-                        "slash": "^2.0.0",
-                        "source-map": "^0.6.1",
+                        "@babel/core": "7.4.0",
+                        "@jest/types": "24.8.0",
+                        "babel-plugin-istanbul": "5.1.1",
+                        "chalk": "2.4.2",
+                        "convert-source-map": "1.6.0",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "graceful-fs": "4.1.15",
+                        "jest-haste-map": "24.8.0",
+                        "jest-regex-util": "24.3.0",
+                        "jest-util": "24.8.0",
+                        "micromatch": "3.1.10",
+                        "realpath-native": "1.1.0",
+                        "slash": "2.0.0",
+                        "source-map": "0.6.1",
                         "write-file-atomic": "2.4.1"
                     }
                 },
@@ -472,9 +472,9 @@
                     "integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^1.1.1",
-                        "@types/yargs": "^12.0.9"
+                        "@types/istanbul-lib-coverage": "2.0.1",
+                        "@types/istanbul-reports": "1.1.1",
+                        "@types/yargs": "12.0.10"
                     }
                 },
                 "@types/istanbul-lib-coverage": {
@@ -495,7 +495,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.2"
                     }
                 },
                 "chalk": {
@@ -504,9 +504,9 @@
                     "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.5.0"
                     }
                 },
                 "expect": {
@@ -515,12 +515,12 @@
                     "integrity": "sha512-/zYvP8iMDrzaaxHVa724eJBCKqSHmO0FA7EDkBiRHxg6OipmMn1fN+C8T9L9K8yr7UONkOifu6+LLH+z76CnaA==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "ansi-styles": "^3.2.0",
-                        "jest-get-type": "^24.8.0",
-                        "jest-matcher-utils": "^24.8.0",
-                        "jest-message-util": "^24.8.0",
-                        "jest-regex-util": "^24.3.0"
+                        "@jest/types": "24.8.0",
+                        "ansi-styles": "3.2.1",
+                        "jest-get-type": "24.8.0",
+                        "jest-matcher-utils": "24.8.0",
+                        "jest-message-util": "24.8.0",
+                        "jest-regex-util": "24.3.0"
                     }
                 },
                 "jest-diff": {
@@ -529,10 +529,10 @@
                     "integrity": "sha512-wxetCEl49zUpJ/bvUmIFjd/o52J+yWcoc5ZyPq4/W1LUKGEhRYDIbP1KcF6t+PvqNrGAFk4/JhtxDq/Nnzs66g==",
                     "dev": true,
                     "requires": {
-                        "chalk": "^2.0.1",
-                        "diff-sequences": "^24.3.0",
-                        "jest-get-type": "^24.8.0",
-                        "pretty-format": "^24.8.0"
+                        "chalk": "2.4.2",
+                        "diff-sequences": "24.3.0",
+                        "jest-get-type": "24.8.0",
+                        "pretty-format": "24.8.0"
                     }
                 },
                 "jest-get-type": {
@@ -547,18 +547,18 @@
                     "integrity": "sha512-ZBPRGHdPt1rHajWelXdqygIDpJx8u3xOoLyUBWRW28r3tagrgoepPrzAozW7kW9HrQfhvmiv1tncsxqHJO1onQ==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "anymatch": "^2.0.0",
-                        "fb-watchman": "^2.0.0",
-                        "fsevents": "^1.2.7",
-                        "graceful-fs": "^4.1.15",
-                        "invariant": "^2.2.4",
-                        "jest-serializer": "^24.4.0",
-                        "jest-util": "^24.8.0",
-                        "jest-worker": "^24.6.0",
-                        "micromatch": "^3.1.10",
-                        "sane": "^4.0.3",
-                        "walker": "^1.0.7"
+                        "@jest/types": "24.8.0",
+                        "anymatch": "2.0.0",
+                        "fb-watchman": "2.0.0",
+                        "fsevents": "1.2.9",
+                        "graceful-fs": "4.1.15",
+                        "invariant": "2.2.4",
+                        "jest-serializer": "24.4.0",
+                        "jest-util": "24.8.0",
+                        "jest-worker": "24.6.0",
+                        "micromatch": "3.1.10",
+                        "sane": "4.1.0",
+                        "walker": "1.0.7"
                     }
                 },
                 "jest-matcher-utils": {
@@ -567,10 +567,10 @@
                     "integrity": "sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==",
                     "dev": true,
                     "requires": {
-                        "chalk": "^2.0.1",
-                        "jest-diff": "^24.8.0",
-                        "jest-get-type": "^24.8.0",
-                        "pretty-format": "^24.8.0"
+                        "chalk": "2.4.2",
+                        "jest-diff": "24.8.0",
+                        "jest-get-type": "24.8.0",
+                        "pretty-format": "24.8.0"
                     }
                 },
                 "jest-message-util": {
@@ -579,14 +579,14 @@
                     "integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
                     "dev": true,
                     "requires": {
-                        "@babel/code-frame": "^7.0.0",
-                        "@jest/test-result": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "@types/stack-utils": "^1.0.1",
-                        "chalk": "^2.0.1",
-                        "micromatch": "^3.1.10",
-                        "slash": "^2.0.0",
-                        "stack-utils": "^1.0.1"
+                        "@babel/code-frame": "7.0.0",
+                        "@jest/test-result": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "@types/stack-utils": "1.0.1",
+                        "chalk": "2.4.2",
+                        "micromatch": "3.1.10",
+                        "slash": "2.0.0",
+                        "stack-utils": "1.0.2"
                     }
                 },
                 "jest-mock": {
@@ -595,7 +595,7 @@
                     "integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0"
+                        "@jest/types": "24.8.0"
                     }
                 },
                 "jest-resolve": {
@@ -604,11 +604,11 @@
                     "integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "browser-resolve": "^1.11.3",
-                        "chalk": "^2.0.1",
-                        "jest-pnp-resolver": "^1.2.1",
-                        "realpath-native": "^1.1.0"
+                        "@jest/types": "24.8.0",
+                        "browser-resolve": "1.11.3",
+                        "chalk": "2.4.2",
+                        "jest-pnp-resolver": "1.2.1",
+                        "realpath-native": "1.1.0"
                     }
                 },
                 "jest-snapshot": {
@@ -617,18 +617,18 @@
                     "integrity": "sha512-5ehtWoc8oU9/cAPe6fez6QofVJLBKyqkY2+TlKTOf0VllBB/mqUNdARdcjlZrs9F1Cv+/HKoCS/BknT0+tmfPg==",
                     "dev": true,
                     "requires": {
-                        "@babel/types": "^7.0.0",
-                        "@jest/types": "^24.8.0",
-                        "chalk": "^2.0.1",
-                        "expect": "^24.8.0",
-                        "jest-diff": "^24.8.0",
-                        "jest-matcher-utils": "^24.8.0",
-                        "jest-message-util": "^24.8.0",
-                        "jest-resolve": "^24.8.0",
-                        "mkdirp": "^0.5.1",
-                        "natural-compare": "^1.4.0",
-                        "pretty-format": "^24.8.0",
-                        "semver": "^5.5.0"
+                        "@babel/types": "7.3.2",
+                        "@jest/types": "24.8.0",
+                        "chalk": "2.4.2",
+                        "expect": "24.8.0",
+                        "jest-diff": "24.8.0",
+                        "jest-matcher-utils": "24.8.0",
+                        "jest-message-util": "24.8.0",
+                        "jest-resolve": "24.8.0",
+                        "mkdirp": "0.5.1",
+                        "natural-compare": "1.4.0",
+                        "pretty-format": "24.8.0",
+                        "semver": "5.5.0"
                     }
                 },
                 "jest-util": {
@@ -637,18 +637,18 @@
                     "integrity": "sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==",
                     "dev": true,
                     "requires": {
-                        "@jest/console": "^24.7.1",
-                        "@jest/fake-timers": "^24.8.0",
-                        "@jest/source-map": "^24.3.0",
-                        "@jest/test-result": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "callsites": "^3.0.0",
-                        "chalk": "^2.0.1",
-                        "graceful-fs": "^4.1.15",
-                        "is-ci": "^2.0.0",
-                        "mkdirp": "^0.5.1",
-                        "slash": "^2.0.0",
-                        "source-map": "^0.6.0"
+                        "@jest/console": "24.7.1",
+                        "@jest/fake-timers": "24.8.0",
+                        "@jest/source-map": "24.3.0",
+                        "@jest/test-result": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "callsites": "3.0.0",
+                        "chalk": "2.4.2",
+                        "graceful-fs": "4.1.15",
+                        "is-ci": "2.0.0",
+                        "mkdirp": "0.5.1",
+                        "slash": "2.0.0",
+                        "source-map": "0.6.1"
                     }
                 },
                 "jest-worker": {
@@ -657,8 +657,8 @@
                     "integrity": "sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==",
                     "dev": true,
                     "requires": {
-                        "merge-stream": "^1.0.1",
-                        "supports-color": "^6.1.0"
+                        "merge-stream": "1.0.1",
+                        "supports-color": "6.1.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -667,7 +667,7 @@
                             "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
                             "dev": true,
                             "requires": {
-                                "has-flag": "^3.0.0"
+                                "has-flag": "3.0.0"
                             }
                         }
                     }
@@ -678,10 +678,10 @@
                     "integrity": "sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "ansi-regex": "^4.0.0",
-                        "ansi-styles": "^3.2.0",
-                        "react-is": "^16.8.4"
+                        "@jest/types": "24.8.0",
+                        "ansi-regex": "4.1.0",
+                        "ansi-styles": "3.2.1",
+                        "react-is": "16.8.4"
                     }
                 },
                 "source-map": {
@@ -696,7 +696,7 @@
                     "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^4.1.0"
+                        "ansi-regex": "4.1.0"
                     }
                 },
                 "supports-color": {
@@ -705,7 +705,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -716,10 +716,10 @@
             "integrity": "sha512-vlGt2HLg7qM+vtBrSkjDxk9K0YtRBi7HfRFaDxoRtyi+DyVChzhF20duvpdAnKVBV6W5tym8jm0U9EfXbDk1tw==",
             "dev": true,
             "requires": {
-                "@jest/fake-timers": "^24.8.0",
-                "@jest/transform": "^24.8.0",
-                "@jest/types": "^24.8.0",
-                "jest-mock": "^24.8.0"
+                "@jest/fake-timers": "24.8.0",
+                "@jest/transform": "24.8.0",
+                "@jest/types": "24.8.0",
+                "jest-mock": "24.8.0"
             }
         },
         "@jest/fake-timers": {
@@ -728,9 +728,9 @@
             "integrity": "sha512-2M4d5MufVXwi6VzZhJ9f5S/wU4ud2ck0kxPof1Iz3zWx6Y+V2eJrES9jEktB6O3o/oEyk+il/uNu9PvASjWXQw==",
             "dev": true,
             "requires": {
-                "@jest/types": "^24.8.0",
-                "jest-message-util": "^24.8.0",
-                "jest-mock": "^24.8.0"
+                "@jest/types": "24.8.0",
+                "jest-message-util": "24.8.0",
+                "jest-mock": "24.8.0"
             }
         },
         "@jest/reporters": {
@@ -739,27 +739,27 @@
             "integrity": "sha512-eZ9TyUYpyIIXfYCrw0UHUWUvE35vx5I92HGMgS93Pv7du+GHIzl+/vh8Qj9MCWFK/4TqyttVBPakWMOfZRIfxw==",
             "dev": true,
             "requires": {
-                "@jest/environment": "^24.8.0",
-                "@jest/test-result": "^24.8.0",
-                "@jest/transform": "^24.8.0",
-                "@jest/types": "^24.8.0",
-                "chalk": "^2.0.1",
-                "exit": "^0.1.2",
-                "glob": "^7.1.2",
-                "istanbul-lib-coverage": "^2.0.2",
-                "istanbul-lib-instrument": "^3.0.1",
-                "istanbul-lib-report": "^2.0.4",
-                "istanbul-lib-source-maps": "^3.0.1",
-                "istanbul-reports": "^2.1.1",
-                "jest-haste-map": "^24.8.0",
-                "jest-resolve": "^24.8.0",
-                "jest-runtime": "^24.8.0",
-                "jest-util": "^24.8.0",
-                "jest-worker": "^24.6.0",
-                "node-notifier": "^5.2.1",
-                "slash": "^2.0.0",
-                "source-map": "^0.6.0",
-                "string-length": "^2.0.0"
+                "@jest/environment": "24.8.0",
+                "@jest/test-result": "24.8.0",
+                "@jest/transform": "24.8.0",
+                "@jest/types": "24.8.0",
+                "chalk": "2.4.2",
+                "exit": "0.1.2",
+                "glob": "7.1.3",
+                "istanbul-lib-coverage": "2.0.3",
+                "istanbul-lib-instrument": "3.1.0",
+                "istanbul-lib-report": "2.0.8",
+                "istanbul-lib-source-maps": "3.0.6",
+                "istanbul-reports": "2.2.4",
+                "jest-haste-map": "24.8.0",
+                "jest-resolve": "24.8.0",
+                "jest-runtime": "24.8.0",
+                "jest-util": "24.8.0",
+                "jest-worker": "24.6.0",
+                "node-notifier": "5.4.0",
+                "slash": "2.0.0",
+                "source-map": "0.6.1",
+                "string-length": "2.0.0"
             },
             "dependencies": {
                 "@jest/console": {
@@ -768,9 +768,9 @@
                     "integrity": "sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==",
                     "dev": true,
                     "requires": {
-                        "@jest/source-map": "^24.3.0",
-                        "chalk": "^2.0.1",
-                        "slash": "^2.0.0"
+                        "@jest/source-map": "24.3.0",
+                        "chalk": "2.4.2",
+                        "slash": "2.0.0"
                     }
                 },
                 "@jest/environment": {
@@ -779,10 +779,10 @@
                     "integrity": "sha512-vlGt2HLg7qM+vtBrSkjDxk9K0YtRBi7HfRFaDxoRtyi+DyVChzhF20duvpdAnKVBV6W5tym8jm0U9EfXbDk1tw==",
                     "dev": true,
                     "requires": {
-                        "@jest/fake-timers": "^24.8.0",
-                        "@jest/transform": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "jest-mock": "^24.8.0"
+                        "@jest/fake-timers": "24.8.0",
+                        "@jest/transform": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "jest-mock": "24.8.0"
                     }
                 },
                 "@jest/fake-timers": {
@@ -791,9 +791,9 @@
                     "integrity": "sha512-2M4d5MufVXwi6VzZhJ9f5S/wU4ud2ck0kxPof1Iz3zWx6Y+V2eJrES9jEktB6O3o/oEyk+il/uNu9PvASjWXQw==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "jest-message-util": "^24.8.0",
-                        "jest-mock": "^24.8.0"
+                        "@jest/types": "24.8.0",
+                        "jest-message-util": "24.8.0",
+                        "jest-mock": "24.8.0"
                     }
                 },
                 "@jest/test-result": {
@@ -802,9 +802,9 @@
                     "integrity": "sha512-+YdLlxwizlfqkFDh7Mc7ONPQAhA4YylU1s529vVM1rsf67vGZH/2GGm5uO8QzPeVyaVMobCQ7FTxl38QrKRlng==",
                     "dev": true,
                     "requires": {
-                        "@jest/console": "^24.7.1",
-                        "@jest/types": "^24.8.0",
-                        "@types/istanbul-lib-coverage": "^2.0.0"
+                        "@jest/console": "24.7.1",
+                        "@jest/types": "24.8.0",
+                        "@types/istanbul-lib-coverage": "2.0.1"
                     }
                 },
                 "@jest/transform": {
@@ -813,20 +813,20 @@
                     "integrity": "sha512-xBMfFUP7TortCs0O+Xtez2W7Zu1PLH9bvJgtraN1CDST6LBM/eTOZ9SfwS/lvV8yOfcDpFmwf9bq5cYbXvqsvA==",
                     "dev": true,
                     "requires": {
-                        "@babel/core": "^7.1.0",
-                        "@jest/types": "^24.8.0",
-                        "babel-plugin-istanbul": "^5.1.0",
-                        "chalk": "^2.0.1",
-                        "convert-source-map": "^1.4.0",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "graceful-fs": "^4.1.15",
-                        "jest-haste-map": "^24.8.0",
-                        "jest-regex-util": "^24.3.0",
-                        "jest-util": "^24.8.0",
-                        "micromatch": "^3.1.10",
-                        "realpath-native": "^1.1.0",
-                        "slash": "^2.0.0",
-                        "source-map": "^0.6.1",
+                        "@babel/core": "7.4.0",
+                        "@jest/types": "24.8.0",
+                        "babel-plugin-istanbul": "5.1.1",
+                        "chalk": "2.4.2",
+                        "convert-source-map": "1.6.0",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "graceful-fs": "4.1.15",
+                        "jest-haste-map": "24.8.0",
+                        "jest-regex-util": "24.3.0",
+                        "jest-util": "24.8.0",
+                        "micromatch": "3.1.10",
+                        "realpath-native": "1.1.0",
+                        "slash": "2.0.0",
+                        "source-map": "0.6.1",
                         "write-file-atomic": "2.4.1"
                     }
                 },
@@ -836,9 +836,9 @@
                     "integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^1.1.1",
-                        "@types/yargs": "^12.0.9"
+                        "@types/istanbul-lib-coverage": "2.0.1",
+                        "@types/istanbul-reports": "1.1.1",
+                        "@types/yargs": "12.0.10"
                     }
                 },
                 "@types/istanbul-lib-coverage": {
@@ -853,7 +853,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.2"
                     }
                 },
                 "chalk": {
@@ -862,9 +862,9 @@
                     "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.5.0"
                     }
                 },
                 "jest-haste-map": {
@@ -873,18 +873,18 @@
                     "integrity": "sha512-ZBPRGHdPt1rHajWelXdqygIDpJx8u3xOoLyUBWRW28r3tagrgoepPrzAozW7kW9HrQfhvmiv1tncsxqHJO1onQ==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "anymatch": "^2.0.0",
-                        "fb-watchman": "^2.0.0",
-                        "fsevents": "^1.2.7",
-                        "graceful-fs": "^4.1.15",
-                        "invariant": "^2.2.4",
-                        "jest-serializer": "^24.4.0",
-                        "jest-util": "^24.8.0",
-                        "jest-worker": "^24.6.0",
-                        "micromatch": "^3.1.10",
-                        "sane": "^4.0.3",
-                        "walker": "^1.0.7"
+                        "@jest/types": "24.8.0",
+                        "anymatch": "2.0.0",
+                        "fb-watchman": "2.0.0",
+                        "fsevents": "1.2.9",
+                        "graceful-fs": "4.1.15",
+                        "invariant": "2.2.4",
+                        "jest-serializer": "24.4.0",
+                        "jest-util": "24.8.0",
+                        "jest-worker": "24.6.0",
+                        "micromatch": "3.1.10",
+                        "sane": "4.1.0",
+                        "walker": "1.0.7"
                     }
                 },
                 "jest-message-util": {
@@ -893,14 +893,14 @@
                     "integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
                     "dev": true,
                     "requires": {
-                        "@babel/code-frame": "^7.0.0",
-                        "@jest/test-result": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "@types/stack-utils": "^1.0.1",
-                        "chalk": "^2.0.1",
-                        "micromatch": "^3.1.10",
-                        "slash": "^2.0.0",
-                        "stack-utils": "^1.0.1"
+                        "@babel/code-frame": "7.0.0",
+                        "@jest/test-result": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "@types/stack-utils": "1.0.1",
+                        "chalk": "2.4.2",
+                        "micromatch": "3.1.10",
+                        "slash": "2.0.0",
+                        "stack-utils": "1.0.2"
                     }
                 },
                 "jest-mock": {
@@ -909,7 +909,7 @@
                     "integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0"
+                        "@jest/types": "24.8.0"
                     }
                 },
                 "jest-resolve": {
@@ -918,11 +918,11 @@
                     "integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "browser-resolve": "^1.11.3",
-                        "chalk": "^2.0.1",
-                        "jest-pnp-resolver": "^1.2.1",
-                        "realpath-native": "^1.1.0"
+                        "@jest/types": "24.8.0",
+                        "browser-resolve": "1.11.3",
+                        "chalk": "2.4.2",
+                        "jest-pnp-resolver": "1.2.1",
+                        "realpath-native": "1.1.0"
                     }
                 },
                 "jest-util": {
@@ -931,18 +931,18 @@
                     "integrity": "sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==",
                     "dev": true,
                     "requires": {
-                        "@jest/console": "^24.7.1",
-                        "@jest/fake-timers": "^24.8.0",
-                        "@jest/source-map": "^24.3.0",
-                        "@jest/test-result": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "callsites": "^3.0.0",
-                        "chalk": "^2.0.1",
-                        "graceful-fs": "^4.1.15",
-                        "is-ci": "^2.0.0",
-                        "mkdirp": "^0.5.1",
-                        "slash": "^2.0.0",
-                        "source-map": "^0.6.0"
+                        "@jest/console": "24.7.1",
+                        "@jest/fake-timers": "24.8.0",
+                        "@jest/source-map": "24.3.0",
+                        "@jest/test-result": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "callsites": "3.0.0",
+                        "chalk": "2.4.2",
+                        "graceful-fs": "4.1.15",
+                        "is-ci": "2.0.0",
+                        "mkdirp": "0.5.1",
+                        "slash": "2.0.0",
+                        "source-map": "0.6.1"
                     }
                 },
                 "jest-worker": {
@@ -951,8 +951,8 @@
                     "integrity": "sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==",
                     "dev": true,
                     "requires": {
-                        "merge-stream": "^1.0.1",
-                        "supports-color": "^6.1.0"
+                        "merge-stream": "1.0.1",
+                        "supports-color": "6.1.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -961,7 +961,7 @@
                             "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
                             "dev": true,
                             "requires": {
-                                "has-flag": "^3.0.0"
+                                "has-flag": "3.0.0"
                             }
                         }
                     }
@@ -978,7 +978,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -989,9 +989,9 @@
             "integrity": "sha512-zALZt1t2ou8le/crCeeiRYzvdnTzaIlpOWaet45lNSqNJUnXbppUUFR4ZUAlzgDmKee4Q5P/tKXypI1RiHwgag==",
             "dev": true,
             "requires": {
-                "callsites": "^3.0.0",
-                "graceful-fs": "^4.1.15",
-                "source-map": "^0.6.0"
+                "callsites": "3.0.0",
+                "graceful-fs": "4.1.15",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "source-map": {
@@ -1008,9 +1008,9 @@
             "integrity": "sha512-+YdLlxwizlfqkFDh7Mc7ONPQAhA4YylU1s529vVM1rsf67vGZH/2GGm5uO8QzPeVyaVMobCQ7FTxl38QrKRlng==",
             "dev": true,
             "requires": {
-                "@jest/console": "^24.7.1",
-                "@jest/types": "^24.8.0",
-                "@types/istanbul-lib-coverage": "^2.0.0"
+                "@jest/console": "24.7.1",
+                "@jest/types": "24.8.0",
+                "@types/istanbul-lib-coverage": "2.0.1"
             },
             "dependencies": {
                 "@types/istanbul-lib-coverage": {
@@ -1027,10 +1027,10 @@
             "integrity": "sha512-OzL/2yHyPdCHXEzhoBuq37CE99nkme15eHkAzXRVqthreWZamEMA0WoetwstsQBCXABhczpK03JNbc4L01vvLg==",
             "dev": true,
             "requires": {
-                "@jest/test-result": "^24.8.0",
-                "jest-haste-map": "^24.8.0",
-                "jest-runner": "^24.8.0",
-                "jest-runtime": "^24.8.0"
+                "@jest/test-result": "24.8.0",
+                "jest-haste-map": "24.8.0",
+                "jest-runner": "24.8.0",
+                "jest-runtime": "24.8.0"
             },
             "dependencies": {
                 "@jest/console": {
@@ -1039,9 +1039,9 @@
                     "integrity": "sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==",
                     "dev": true,
                     "requires": {
-                        "@jest/source-map": "^24.3.0",
-                        "chalk": "^2.0.1",
-                        "slash": "^2.0.0"
+                        "@jest/source-map": "24.3.0",
+                        "chalk": "2.4.2",
+                        "slash": "2.0.0"
                     }
                 },
                 "@jest/fake-timers": {
@@ -1050,9 +1050,9 @@
                     "integrity": "sha512-2M4d5MufVXwi6VzZhJ9f5S/wU4ud2ck0kxPof1Iz3zWx6Y+V2eJrES9jEktB6O3o/oEyk+il/uNu9PvASjWXQw==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "jest-message-util": "^24.8.0",
-                        "jest-mock": "^24.8.0"
+                        "@jest/types": "24.8.0",
+                        "jest-message-util": "24.8.0",
+                        "jest-mock": "24.8.0"
                     }
                 },
                 "@jest/test-result": {
@@ -1061,9 +1061,9 @@
                     "integrity": "sha512-+YdLlxwizlfqkFDh7Mc7ONPQAhA4YylU1s529vVM1rsf67vGZH/2GGm5uO8QzPeVyaVMobCQ7FTxl38QrKRlng==",
                     "dev": true,
                     "requires": {
-                        "@jest/console": "^24.7.1",
-                        "@jest/types": "^24.8.0",
-                        "@types/istanbul-lib-coverage": "^2.0.0"
+                        "@jest/console": "24.7.1",
+                        "@jest/types": "24.8.0",
+                        "@types/istanbul-lib-coverage": "2.0.1"
                     }
                 },
                 "@jest/types": {
@@ -1072,9 +1072,9 @@
                     "integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^1.1.1",
-                        "@types/yargs": "^12.0.9"
+                        "@types/istanbul-lib-coverage": "2.0.1",
+                        "@types/istanbul-reports": "1.1.1",
+                        "@types/yargs": "12.0.10"
                     }
                 },
                 "@types/istanbul-lib-coverage": {
@@ -1089,7 +1089,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.2"
                     }
                 },
                 "chalk": {
@@ -1098,9 +1098,9 @@
                     "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.5.0"
                     }
                 },
                 "jest-haste-map": {
@@ -1109,18 +1109,18 @@
                     "integrity": "sha512-ZBPRGHdPt1rHajWelXdqygIDpJx8u3xOoLyUBWRW28r3tagrgoepPrzAozW7kW9HrQfhvmiv1tncsxqHJO1onQ==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "anymatch": "^2.0.0",
-                        "fb-watchman": "^2.0.0",
-                        "fsevents": "^1.2.7",
-                        "graceful-fs": "^4.1.15",
-                        "invariant": "^2.2.4",
-                        "jest-serializer": "^24.4.0",
-                        "jest-util": "^24.8.0",
-                        "jest-worker": "^24.6.0",
-                        "micromatch": "^3.1.10",
-                        "sane": "^4.0.3",
-                        "walker": "^1.0.7"
+                        "@jest/types": "24.8.0",
+                        "anymatch": "2.0.0",
+                        "fb-watchman": "2.0.0",
+                        "fsevents": "1.2.9",
+                        "graceful-fs": "4.1.15",
+                        "invariant": "2.2.4",
+                        "jest-serializer": "24.4.0",
+                        "jest-util": "24.8.0",
+                        "jest-worker": "24.6.0",
+                        "micromatch": "3.1.10",
+                        "sane": "4.1.0",
+                        "walker": "1.0.7"
                     }
                 },
                 "jest-message-util": {
@@ -1129,14 +1129,14 @@
                     "integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
                     "dev": true,
                     "requires": {
-                        "@babel/code-frame": "^7.0.0",
-                        "@jest/test-result": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "@types/stack-utils": "^1.0.1",
-                        "chalk": "^2.0.1",
-                        "micromatch": "^3.1.10",
-                        "slash": "^2.0.0",
-                        "stack-utils": "^1.0.1"
+                        "@babel/code-frame": "7.0.0",
+                        "@jest/test-result": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "@types/stack-utils": "1.0.1",
+                        "chalk": "2.4.2",
+                        "micromatch": "3.1.10",
+                        "slash": "2.0.0",
+                        "stack-utils": "1.0.2"
                     }
                 },
                 "jest-mock": {
@@ -1145,7 +1145,7 @@
                     "integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0"
+                        "@jest/types": "24.8.0"
                     }
                 },
                 "jest-util": {
@@ -1154,18 +1154,18 @@
                     "integrity": "sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==",
                     "dev": true,
                     "requires": {
-                        "@jest/console": "^24.7.1",
-                        "@jest/fake-timers": "^24.8.0",
-                        "@jest/source-map": "^24.3.0",
-                        "@jest/test-result": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "callsites": "^3.0.0",
-                        "chalk": "^2.0.1",
-                        "graceful-fs": "^4.1.15",
-                        "is-ci": "^2.0.0",
-                        "mkdirp": "^0.5.1",
-                        "slash": "^2.0.0",
-                        "source-map": "^0.6.0"
+                        "@jest/console": "24.7.1",
+                        "@jest/fake-timers": "24.8.0",
+                        "@jest/source-map": "24.3.0",
+                        "@jest/test-result": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "callsites": "3.0.0",
+                        "chalk": "2.4.2",
+                        "graceful-fs": "4.1.15",
+                        "is-ci": "2.0.0",
+                        "mkdirp": "0.5.1",
+                        "slash": "2.0.0",
+                        "source-map": "0.6.1"
                     }
                 },
                 "jest-worker": {
@@ -1174,8 +1174,8 @@
                     "integrity": "sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==",
                     "dev": true,
                     "requires": {
-                        "merge-stream": "^1.0.1",
-                        "supports-color": "^6.1.0"
+                        "merge-stream": "1.0.1",
+                        "supports-color": "6.1.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -1184,7 +1184,7 @@
                             "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
                             "dev": true,
                             "requires": {
-                                "has-flag": "^3.0.0"
+                                "has-flag": "3.0.0"
                             }
                         }
                     }
@@ -1201,7 +1201,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -1212,20 +1212,20 @@
             "integrity": "sha512-xBMfFUP7TortCs0O+Xtez2W7Zu1PLH9bvJgtraN1CDST6LBM/eTOZ9SfwS/lvV8yOfcDpFmwf9bq5cYbXvqsvA==",
             "dev": true,
             "requires": {
-                "@babel/core": "^7.1.0",
-                "@jest/types": "^24.8.0",
-                "babel-plugin-istanbul": "^5.1.0",
-                "chalk": "^2.0.1",
-                "convert-source-map": "^1.4.0",
-                "fast-json-stable-stringify": "^2.0.0",
-                "graceful-fs": "^4.1.15",
-                "jest-haste-map": "^24.8.0",
-                "jest-regex-util": "^24.3.0",
-                "jest-util": "^24.8.0",
-                "micromatch": "^3.1.10",
-                "realpath-native": "^1.1.0",
-                "slash": "^2.0.0",
-                "source-map": "^0.6.1",
+                "@babel/core": "7.4.0",
+                "@jest/types": "24.8.0",
+                "babel-plugin-istanbul": "5.1.1",
+                "chalk": "2.4.2",
+                "convert-source-map": "1.6.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "graceful-fs": "4.1.15",
+                "jest-haste-map": "24.8.0",
+                "jest-regex-util": "24.3.0",
+                "jest-util": "24.8.0",
+                "micromatch": "3.1.10",
+                "realpath-native": "1.1.0",
+                "slash": "2.0.0",
+                "source-map": "0.6.1",
                 "write-file-atomic": "2.4.1"
             },
             "dependencies": {
@@ -1243,9 +1243,9 @@
             "integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
             "dev": true,
             "requires": {
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^1.1.1",
-                "@types/yargs": "^12.0.9"
+                "@types/istanbul-lib-coverage": "2.0.1",
+                "@types/istanbul-reports": "1.1.1",
+                "@types/yargs": "12.0.10"
             },
             "dependencies": {
                 "@types/istanbul-lib-coverage": {
@@ -1262,11 +1262,11 @@
             "integrity": "sha512-+hjBtgcFPYyCTo0A15+nxrCVJL7aC6Acg87TXd5OW3QhHswdrOLoles+ldL2Uk8q++7yIfl4tURtztccdeeyOw==",
             "dev": true,
             "requires": {
-                "@babel/parser": "^7.1.0",
-                "@babel/types": "^7.0.0",
-                "@types/babel__generator": "*",
-                "@types/babel__template": "*",
-                "@types/babel__traverse": "*"
+                "@babel/parser": "7.3.2",
+                "@babel/types": "7.3.2",
+                "@types/babel__generator": "7.0.2",
+                "@types/babel__template": "7.0.2",
+                "@types/babel__traverse": "7.0.6"
             }
         },
         "@types/babel__generator": {
@@ -1275,7 +1275,7 @@
             "integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "7.3.2"
             }
         },
         "@types/babel__template": {
@@ -1284,8 +1284,8 @@
             "integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
             "dev": true,
             "requires": {
-                "@babel/parser": "^7.1.0",
-                "@babel/types": "^7.0.0"
+                "@babel/parser": "7.3.2",
+                "@babel/types": "7.3.2"
             }
         },
         "@types/babel__traverse": {
@@ -1294,7 +1294,7 @@
             "integrity": "sha512-XYVgHF2sQ0YblLRMLNPB3CkFMewzFmlDsH/TneZFHUXDlABQgh88uOxuez7ZcXxayLFrqLwtDH1t+FmlFwNZxw==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.3.0"
+                "@babel/types": "7.3.2"
             }
         },
         "@types/events": {
@@ -1309,9 +1309,9 @@
             "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
             "dev": true,
             "requires": {
-                "@types/events": "*",
-                "@types/minimatch": "*",
-                "@types/node": "*"
+                "@types/events": "3.0.0",
+                "@types/minimatch": "3.0.3",
+                "@types/node": "11.13.14"
             }
         },
         "@types/istanbul-lib-coverage": {
@@ -1326,7 +1326,7 @@
             "integrity": "sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==",
             "dev": true,
             "requires": {
-                "@types/istanbul-lib-coverage": "*"
+                "@types/istanbul-lib-coverage": "1.1.0"
             }
         },
         "@types/istanbul-reports": {
@@ -1335,8 +1335,8 @@
             "integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
             "dev": true,
             "requires": {
-                "@types/istanbul-lib-coverage": "*",
-                "@types/istanbul-lib-report": "*"
+                "@types/istanbul-lib-coverage": "1.1.0",
+                "@types/istanbul-lib-report": "1.1.1"
             }
         },
         "@types/jest": {
@@ -1345,7 +1345,7 @@
             "integrity": "sha512-MU1HIvWUme74stAoc3mgAi+aMlgKOudgEvQDIm1v4RkrDudBh1T+NFp5sftpBAdXdx1J0PbdpJ+M2EsSOi1djA==",
             "dev": true,
             "requires": {
-                "@types/jest-diff": "*"
+                "@types/jest-diff": "20.0.1"
             }
         },
         "@types/jest-diff": {
@@ -1372,7 +1372,7 @@
             "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
             "dev": true,
             "requires": {
-                "@types/node": "*"
+                "@types/node": "11.13.14"
             }
         },
         "@types/stack-utils": {
@@ -1405,8 +1405,8 @@
             "integrity": "sha512-BbzvZhVtZP+Bs1J1HcwrQe8ycfO0wStkSGxuul3He3GkHOIZ6eTqOkPuw9IP1X3+IkOo4wiJmwkobzXYz4wewQ==",
             "dev": true,
             "requires": {
-                "acorn": "^6.0.1",
-                "acorn-walk": "^6.0.1"
+                "acorn": "6.1.1",
+                "acorn-walk": "6.1.1"
             },
             "dependencies": {
                 "acorn": {
@@ -1429,10 +1429,10 @@
             "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
             "dev": true,
             "requires": {
-                "fast-deep-equal": "^2.0.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
+                "fast-deep-equal": "2.0.1",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.4.1",
+                "uri-js": "4.2.2"
             }
         },
         "ansi-escapes": {
@@ -1453,7 +1453,7 @@
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
             "dev": true,
             "requires": {
-                "color-convert": "^1.9.0"
+                "color-convert": "1.9.2"
             }
         },
         "anymatch": {
@@ -1462,8 +1462,8 @@
             "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
             "dev": true,
             "requires": {
-                "micromatch": "^3.1.4",
-                "normalize-path": "^2.1.1"
+                "micromatch": "3.1.10",
+                "normalize-path": "2.1.1"
             }
         },
         "argparse": {
@@ -1472,7 +1472,7 @@
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
             "requires": {
-                "sprintf-js": "~1.0.2"
+                "sprintf-js": "1.0.3"
             },
             "dependencies": {
                 "sprintf-js": {
@@ -1525,7 +1525,7 @@
             "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
             "dev": true,
             "requires": {
-                "safer-buffer": "~2.1.0"
+                "safer-buffer": "2.1.2"
             }
         },
         "assert-plus": {
@@ -1582,13 +1582,13 @@
             "integrity": "sha512-+5/kaZt4I9efoXzPlZASyK/lN9qdRKmmUav9smVc0ruPQD7IsfucQ87gpOE8mn2jbDuS6M/YOW6n3v9ZoIfgnw==",
             "dev": true,
             "requires": {
-                "@jest/transform": "^24.8.0",
-                "@jest/types": "^24.8.0",
-                "@types/babel__core": "^7.1.0",
-                "babel-plugin-istanbul": "^5.1.0",
-                "babel-preset-jest": "^24.6.0",
-                "chalk": "^2.4.2",
-                "slash": "^2.0.0"
+                "@jest/transform": "24.8.0",
+                "@jest/types": "24.8.0",
+                "@types/babel__core": "7.1.1",
+                "babel-plugin-istanbul": "5.1.1",
+                "babel-preset-jest": "24.6.0",
+                "chalk": "2.4.2",
+                "slash": "2.0.0"
             },
             "dependencies": {
                 "@jest/console": {
@@ -1597,9 +1597,9 @@
                     "integrity": "sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==",
                     "dev": true,
                     "requires": {
-                        "@jest/source-map": "^24.3.0",
-                        "chalk": "^2.0.1",
-                        "slash": "^2.0.0"
+                        "@jest/source-map": "24.3.0",
+                        "chalk": "2.4.2",
+                        "slash": "2.0.0"
                     }
                 },
                 "@jest/fake-timers": {
@@ -1608,9 +1608,9 @@
                     "integrity": "sha512-2M4d5MufVXwi6VzZhJ9f5S/wU4ud2ck0kxPof1Iz3zWx6Y+V2eJrES9jEktB6O3o/oEyk+il/uNu9PvASjWXQw==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "jest-message-util": "^24.8.0",
-                        "jest-mock": "^24.8.0"
+                        "@jest/types": "24.8.0",
+                        "jest-message-util": "24.8.0",
+                        "jest-mock": "24.8.0"
                     }
                 },
                 "@jest/test-result": {
@@ -1619,9 +1619,9 @@
                     "integrity": "sha512-+YdLlxwizlfqkFDh7Mc7ONPQAhA4YylU1s529vVM1rsf67vGZH/2GGm5uO8QzPeVyaVMobCQ7FTxl38QrKRlng==",
                     "dev": true,
                     "requires": {
-                        "@jest/console": "^24.7.1",
-                        "@jest/types": "^24.8.0",
-                        "@types/istanbul-lib-coverage": "^2.0.0"
+                        "@jest/console": "24.7.1",
+                        "@jest/types": "24.8.0",
+                        "@types/istanbul-lib-coverage": "2.0.1"
                     }
                 },
                 "@jest/transform": {
@@ -1630,20 +1630,20 @@
                     "integrity": "sha512-xBMfFUP7TortCs0O+Xtez2W7Zu1PLH9bvJgtraN1CDST6LBM/eTOZ9SfwS/lvV8yOfcDpFmwf9bq5cYbXvqsvA==",
                     "dev": true,
                     "requires": {
-                        "@babel/core": "^7.1.0",
-                        "@jest/types": "^24.8.0",
-                        "babel-plugin-istanbul": "^5.1.0",
-                        "chalk": "^2.0.1",
-                        "convert-source-map": "^1.4.0",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "graceful-fs": "^4.1.15",
-                        "jest-haste-map": "^24.8.0",
-                        "jest-regex-util": "^24.3.0",
-                        "jest-util": "^24.8.0",
-                        "micromatch": "^3.1.10",
-                        "realpath-native": "^1.1.0",
-                        "slash": "^2.0.0",
-                        "source-map": "^0.6.1",
+                        "@babel/core": "7.4.0",
+                        "@jest/types": "24.8.0",
+                        "babel-plugin-istanbul": "5.1.1",
+                        "chalk": "2.4.2",
+                        "convert-source-map": "1.6.0",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "graceful-fs": "4.1.15",
+                        "jest-haste-map": "24.8.0",
+                        "jest-regex-util": "24.3.0",
+                        "jest-util": "24.8.0",
+                        "micromatch": "3.1.10",
+                        "realpath-native": "1.1.0",
+                        "slash": "2.0.0",
+                        "source-map": "0.6.1",
                         "write-file-atomic": "2.4.1"
                     }
                 },
@@ -1653,9 +1653,9 @@
                     "integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^1.1.1",
-                        "@types/yargs": "^12.0.9"
+                        "@types/istanbul-lib-coverage": "2.0.1",
+                        "@types/istanbul-reports": "1.1.1",
+                        "@types/yargs": "12.0.10"
                     }
                 },
                 "@types/istanbul-lib-coverage": {
@@ -1670,7 +1670,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.2"
                     }
                 },
                 "chalk": {
@@ -1679,9 +1679,9 @@
                     "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.5.0"
                     }
                 },
                 "jest-haste-map": {
@@ -1690,18 +1690,18 @@
                     "integrity": "sha512-ZBPRGHdPt1rHajWelXdqygIDpJx8u3xOoLyUBWRW28r3tagrgoepPrzAozW7kW9HrQfhvmiv1tncsxqHJO1onQ==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "anymatch": "^2.0.0",
-                        "fb-watchman": "^2.0.0",
-                        "fsevents": "^1.2.7",
-                        "graceful-fs": "^4.1.15",
-                        "invariant": "^2.2.4",
-                        "jest-serializer": "^24.4.0",
-                        "jest-util": "^24.8.0",
-                        "jest-worker": "^24.6.0",
-                        "micromatch": "^3.1.10",
-                        "sane": "^4.0.3",
-                        "walker": "^1.0.7"
+                        "@jest/types": "24.8.0",
+                        "anymatch": "2.0.0",
+                        "fb-watchman": "2.0.0",
+                        "fsevents": "1.2.9",
+                        "graceful-fs": "4.1.15",
+                        "invariant": "2.2.4",
+                        "jest-serializer": "24.4.0",
+                        "jest-util": "24.8.0",
+                        "jest-worker": "24.6.0",
+                        "micromatch": "3.1.10",
+                        "sane": "4.1.0",
+                        "walker": "1.0.7"
                     }
                 },
                 "jest-message-util": {
@@ -1710,14 +1710,14 @@
                     "integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
                     "dev": true,
                     "requires": {
-                        "@babel/code-frame": "^7.0.0",
-                        "@jest/test-result": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "@types/stack-utils": "^1.0.1",
-                        "chalk": "^2.0.1",
-                        "micromatch": "^3.1.10",
-                        "slash": "^2.0.0",
-                        "stack-utils": "^1.0.1"
+                        "@babel/code-frame": "7.0.0",
+                        "@jest/test-result": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "@types/stack-utils": "1.0.1",
+                        "chalk": "2.4.2",
+                        "micromatch": "3.1.10",
+                        "slash": "2.0.0",
+                        "stack-utils": "1.0.2"
                     }
                 },
                 "jest-mock": {
@@ -1726,7 +1726,7 @@
                     "integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0"
+                        "@jest/types": "24.8.0"
                     }
                 },
                 "jest-util": {
@@ -1735,18 +1735,18 @@
                     "integrity": "sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==",
                     "dev": true,
                     "requires": {
-                        "@jest/console": "^24.7.1",
-                        "@jest/fake-timers": "^24.8.0",
-                        "@jest/source-map": "^24.3.0",
-                        "@jest/test-result": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "callsites": "^3.0.0",
-                        "chalk": "^2.0.1",
-                        "graceful-fs": "^4.1.15",
-                        "is-ci": "^2.0.0",
-                        "mkdirp": "^0.5.1",
-                        "slash": "^2.0.0",
-                        "source-map": "^0.6.0"
+                        "@jest/console": "24.7.1",
+                        "@jest/fake-timers": "24.8.0",
+                        "@jest/source-map": "24.3.0",
+                        "@jest/test-result": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "callsites": "3.0.0",
+                        "chalk": "2.4.2",
+                        "graceful-fs": "4.1.15",
+                        "is-ci": "2.0.0",
+                        "mkdirp": "0.5.1",
+                        "slash": "2.0.0",
+                        "source-map": "0.6.1"
                     }
                 },
                 "jest-worker": {
@@ -1755,8 +1755,8 @@
                     "integrity": "sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==",
                     "dev": true,
                     "requires": {
-                        "merge-stream": "^1.0.1",
-                        "supports-color": "^6.1.0"
+                        "merge-stream": "1.0.1",
+                        "supports-color": "6.1.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -1765,7 +1765,7 @@
                             "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
                             "dev": true,
                             "requires": {
-                                "has-flag": "^3.0.0"
+                                "has-flag": "3.0.0"
                             }
                         }
                     }
@@ -1782,7 +1782,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -1793,9 +1793,9 @@
             "integrity": "sha512-RNNVv2lsHAXJQsEJ5jonQwrJVWK8AcZpG1oxhnjCUaAjL7xahYLANhPUZbzEQHjKy1NMYUwn+0NPKQc8iSY4xQ==",
             "dev": true,
             "requires": {
-                "find-up": "^3.0.0",
-                "istanbul-lib-instrument": "^3.0.0",
-                "test-exclude": "^5.0.0"
+                "find-up": "3.0.0",
+                "istanbul-lib-instrument": "3.1.0",
+                "test-exclude": "5.1.0"
             }
         },
         "babel-plugin-jest-hoist": {
@@ -1804,7 +1804,7 @@
             "integrity": "sha512-3pKNH6hMt9SbOv0F3WVmy5CWQ4uogS3k0GY5XLyQHJ9EGpAT9XWkFd2ZiXXtkwFHdAHa5j7w7kfxSP5lAIwu7w==",
             "dev": true,
             "requires": {
-                "@types/babel__traverse": "^7.0.6"
+                "@types/babel__traverse": "7.0.6"
             }
         },
         "babel-preset-jest": {
@@ -1813,8 +1813,8 @@
             "integrity": "sha512-pdZqLEdmy1ZK5kyRUfvBb2IfTPb2BUvIJczlPspS8fWmBQslNNDBqVfh7BW5leOVJMDZKzjD8XEyABTk6gQ5yw==",
             "dev": true,
             "requires": {
-                "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-                "babel-plugin-jest-hoist": "^24.6.0"
+                "@babel/plugin-syntax-object-rest-spread": "7.2.0",
+                "babel-plugin-jest-hoist": "24.6.0"
             }
         },
         "balanced-match": {
@@ -1829,13 +1829,13 @@
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
             "dev": true,
             "requires": {
-                "cache-base": "^1.0.1",
-                "class-utils": "^0.3.5",
-                "component-emitter": "^1.2.1",
-                "define-property": "^1.0.0",
-                "isobject": "^3.0.1",
-                "mixin-deep": "^1.2.0",
-                "pascalcase": "^0.1.1"
+                "cache-base": "1.0.1",
+                "class-utils": "0.3.6",
+                "component-emitter": "1.2.1",
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "mixin-deep": "1.3.1",
+                "pascalcase": "0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -1844,7 +1844,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^1.0.0"
+                        "is-descriptor": "1.0.2"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -1853,7 +1853,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -1862,7 +1862,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -1871,9 +1871,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 }
             }
@@ -1884,7 +1884,7 @@
             "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
             "dev": true,
             "requires": {
-                "tweetnacl": "^0.14.3"
+                "tweetnacl": "0.14.5"
             }
         },
         "brace-expansion": {
@@ -1893,7 +1893,7 @@
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
             "requires": {
-                "balanced-match": "^1.0.0",
+                "balanced-match": "1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -1903,16 +1903,16 @@
             "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
             "dev": true,
             "requires": {
-                "arr-flatten": "^1.1.0",
-                "array-unique": "^0.3.2",
-                "extend-shallow": "^2.0.1",
-                "fill-range": "^4.0.0",
-                "isobject": "^3.0.1",
-                "repeat-element": "^1.1.2",
-                "snapdragon": "^0.8.1",
-                "snapdragon-node": "^2.0.1",
-                "split-string": "^3.0.2",
-                "to-regex": "^3.0.1"
+                "arr-flatten": "1.1.0",
+                "array-unique": "0.3.2",
+                "extend-shallow": "2.0.1",
+                "fill-range": "4.0.0",
+                "isobject": "3.0.1",
+                "repeat-element": "1.1.3",
+                "snapdragon": "0.8.2",
+                "snapdragon-node": "2.1.1",
+                "split-string": "3.1.0",
+                "to-regex": "3.0.2"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -1921,7 +1921,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -1955,7 +1955,7 @@
             "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
             "dev": true,
             "requires": {
-                "fast-json-stable-stringify": "2.x"
+                "fast-json-stable-stringify": "2.0.0"
             }
         },
         "bser": {
@@ -1964,7 +1964,7 @@
             "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
             "dev": true,
             "requires": {
-                "node-int64": "^0.4.0"
+                "node-int64": "0.4.0"
             }
         },
         "buffer-from": {
@@ -1985,15 +1985,15 @@
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
             "dev": true,
             "requires": {
-                "collection-visit": "^1.0.0",
-                "component-emitter": "^1.2.1",
-                "get-value": "^2.0.6",
-                "has-value": "^1.0.0",
-                "isobject": "^3.0.1",
-                "set-value": "^2.0.0",
-                "to-object-path": "^0.3.0",
-                "union-value": "^1.0.0",
-                "unset-value": "^1.0.0"
+                "collection-visit": "1.0.0",
+                "component-emitter": "1.2.1",
+                "get-value": "2.0.6",
+                "has-value": "1.0.0",
+                "isobject": "3.0.1",
+                "set-value": "2.0.0",
+                "to-object-path": "0.3.0",
+                "union-value": "1.0.0",
+                "unset-value": "1.0.0"
             }
         },
         "callsites": {
@@ -2014,7 +2014,7 @@
             "integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
             "dev": true,
             "requires": {
-                "rsvp": "^4.8.4"
+                "rsvp": "4.8.4"
             }
         },
         "caseless": {
@@ -2029,9 +2029,9 @@
             "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
             "dev": true,
             "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.5.0"
             }
         },
         "ci-info": {
@@ -2046,10 +2046,10 @@
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
             "dev": true,
             "requires": {
-                "arr-union": "^3.1.0",
-                "define-property": "^0.2.5",
-                "isobject": "^3.0.0",
-                "static-extend": "^0.1.1"
+                "arr-union": "3.1.0",
+                "define-property": "0.2.5",
+                "isobject": "3.0.1",
+                "static-extend": "0.1.2"
             },
             "dependencies": {
                 "define-property": {
@@ -2058,7 +2058,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 }
             }
@@ -2069,9 +2069,9 @@
             "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
             "dev": true,
             "requires": {
-                "string-width": "^2.1.1",
-                "strip-ansi": "^4.0.0",
-                "wrap-ansi": "^2.0.0"
+                "string-width": "2.1.1",
+                "strip-ansi": "4.0.0",
+                "wrap-ansi": "2.1.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -2086,7 +2086,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "3.0.0"
                     }
                 }
             }
@@ -2109,8 +2109,8 @@
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
             "dev": true,
             "requires": {
-                "map-visit": "^1.0.0",
-                "object-visit": "^1.0.0"
+                "map-visit": "1.0.0",
+                "object-visit": "1.0.1"
             }
         },
         "color-convert": {
@@ -2134,7 +2134,7 @@
             "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
             "dev": true,
             "requires": {
-                "delayed-stream": "~1.0.0"
+                "delayed-stream": "1.0.0"
             }
         },
         "commander": {
@@ -2161,7 +2161,7 @@
             "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
             "dev": true,
             "requires": {
-                "safe-buffer": "~5.1.1"
+                "safe-buffer": "5.1.1"
             }
         },
         "copy-descriptor": {
@@ -2182,11 +2182,11 @@
             "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
             "dev": true,
             "requires": {
-                "nice-try": "^1.0.4",
-                "path-key": "^2.0.1",
-                "semver": "^5.5.0",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
+                "nice-try": "1.0.5",
+                "path-key": "2.0.1",
+                "semver": "5.5.0",
+                "shebang-command": "1.2.0",
+                "which": "1.3.1"
             }
         },
         "cssom": {
@@ -2201,7 +2201,7 @@
             "integrity": "sha512-43wY3kl1CVQSvL7wUY1qXkxVGkStjpkDmVjiIKX8R97uhajy8Bybay78uOtqvh7Q5GK75dNPfW0geWjE6qQQow==",
             "dev": true,
             "requires": {
-                "cssom": "0.3.x"
+                "cssom": "0.3.6"
             }
         },
         "dashdash": {
@@ -2210,7 +2210,7 @@
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "dev": true,
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             }
         },
         "data-urls": {
@@ -2219,9 +2219,9 @@
             "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
             "dev": true,
             "requires": {
-                "abab": "^2.0.0",
-                "whatwg-mimetype": "^2.2.0",
-                "whatwg-url": "^7.0.0"
+                "abab": "2.0.0",
+                "whatwg-mimetype": "2.3.0",
+                "whatwg-url": "7.0.0"
             },
             "dependencies": {
                 "whatwg-url": {
@@ -2230,9 +2230,9 @@
                     "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
                     "dev": true,
                     "requires": {
-                        "lodash.sortby": "^4.7.0",
-                        "tr46": "^1.0.1",
-                        "webidl-conversions": "^4.0.2"
+                        "lodash.sortby": "4.7.0",
+                        "tr46": "1.0.1",
+                        "webidl-conversions": "4.0.2"
                     }
                 }
             }
@@ -2243,7 +2243,7 @@
             "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
             "dev": true,
             "requires": {
-                "ms": "^2.1.1"
+                "ms": "2.1.1"
             }
         },
         "decamelize": {
@@ -2270,7 +2270,7 @@
             "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
             "dev": true,
             "requires": {
-                "object-keys": "^1.0.12"
+                "object-keys": "1.1.0"
             }
         },
         "define-property": {
@@ -2279,8 +2279,8 @@
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
             "dev": true,
             "requires": {
-                "is-descriptor": "^1.0.2",
-                "isobject": "^3.0.1"
+                "is-descriptor": "1.0.2",
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "is-accessor-descriptor": {
@@ -2289,7 +2289,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -2298,7 +2298,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -2307,9 +2307,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 }
             }
@@ -2344,7 +2344,7 @@
             "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
             "dev": true,
             "requires": {
-                "webidl-conversions": "^4.0.2"
+                "webidl-conversions": "4.0.2"
             }
         },
         "ecc-jsbn": {
@@ -2353,8 +2353,8 @@
             "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
             "dev": true,
             "requires": {
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.1.0"
+                "jsbn": "0.1.1",
+                "safer-buffer": "2.1.2"
             }
         },
         "end-of-stream": {
@@ -2363,7 +2363,7 @@
             "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
             "dev": true,
             "requires": {
-                "once": "^1.4.0"
+                "once": "1.4.0"
             }
         },
         "error-ex": {
@@ -2372,7 +2372,7 @@
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
             "dev": true,
             "requires": {
-                "is-arrayish": "^0.2.1"
+                "is-arrayish": "0.2.1"
             }
         },
         "es-abstract": {
@@ -2381,12 +2381,12 @@
             "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
             "dev": true,
             "requires": {
-                "es-to-primitive": "^1.2.0",
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "is-callable": "^1.1.4",
-                "is-regex": "^1.0.4",
-                "object-keys": "^1.0.12"
+                "es-to-primitive": "1.2.0",
+                "function-bind": "1.1.1",
+                "has": "1.0.3",
+                "is-callable": "1.1.4",
+                "is-regex": "1.0.4",
+                "object-keys": "1.1.0"
             }
         },
         "es-to-primitive": {
@@ -2395,9 +2395,9 @@
             "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
             "dev": true,
             "requires": {
-                "is-callable": "^1.1.4",
-                "is-date-object": "^1.0.1",
-                "is-symbol": "^1.0.2"
+                "is-callable": "1.1.4",
+                "is-date-object": "1.0.1",
+                "is-symbol": "1.0.2"
             }
         },
         "escape-string-regexp": {
@@ -2412,11 +2412,11 @@
             "integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
             "dev": true,
             "requires": {
-                "esprima": "^3.1.3",
-                "estraverse": "^4.2.0",
-                "esutils": "^2.0.2",
-                "optionator": "^0.8.1",
-                "source-map": "~0.6.1"
+                "esprima": "3.1.3",
+                "estraverse": "4.2.0",
+                "esutils": "2.0.2",
+                "optionator": "0.8.2",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "esprima": {
@@ -2464,13 +2464,13 @@
             "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
             "dev": true,
             "requires": {
-                "cross-spawn": "^6.0.0",
-                "get-stream": "^4.0.0",
-                "is-stream": "^1.1.0",
-                "npm-run-path": "^2.0.0",
-                "p-finally": "^1.0.0",
-                "signal-exit": "^3.0.0",
-                "strip-eof": "^1.0.0"
+                "cross-spawn": "6.0.5",
+                "get-stream": "4.1.0",
+                "is-stream": "1.1.0",
+                "npm-run-path": "2.0.2",
+                "p-finally": "1.0.0",
+                "signal-exit": "3.0.2",
+                "strip-eof": "1.0.0"
             }
         },
         "exit": {
@@ -2485,13 +2485,13 @@
             "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
             "dev": true,
             "requires": {
-                "debug": "^2.3.3",
-                "define-property": "^0.2.5",
-                "extend-shallow": "^2.0.1",
-                "posix-character-classes": "^0.1.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "posix-character-classes": "0.1.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
             },
             "dependencies": {
                 "debug": {
@@ -2509,7 +2509,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 },
                 "extend-shallow": {
@@ -2518,7 +2518,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 },
                 "ms": {
@@ -2535,12 +2535,12 @@
             "integrity": "sha512-/zYvP8iMDrzaaxHVa724eJBCKqSHmO0FA7EDkBiRHxg6OipmMn1fN+C8T9L9K8yr7UONkOifu6+LLH+z76CnaA==",
             "dev": true,
             "requires": {
-                "@jest/types": "^24.8.0",
-                "ansi-styles": "^3.2.0",
-                "jest-get-type": "^24.8.0",
-                "jest-matcher-utils": "^24.8.0",
-                "jest-message-util": "^24.8.0",
-                "jest-regex-util": "^24.3.0"
+                "@jest/types": "24.8.0",
+                "ansi-styles": "3.2.1",
+                "jest-get-type": "24.8.0",
+                "jest-matcher-utils": "24.8.0",
+                "jest-message-util": "24.8.0",
+                "jest-regex-util": "24.3.0"
             }
         },
         "extend": {
@@ -2555,8 +2555,8 @@
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
             "dev": true,
             "requires": {
-                "assign-symbols": "^1.0.0",
-                "is-extendable": "^1.0.1"
+                "assign-symbols": "1.0.0",
+                "is-extendable": "1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -2565,7 +2565,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "^2.0.4"
+                        "is-plain-object": "2.0.4"
                     }
                 }
             }
@@ -2576,14 +2576,14 @@
             "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
             "dev": true,
             "requires": {
-                "array-unique": "^0.3.2",
-                "define-property": "^1.0.0",
-                "expand-brackets": "^2.1.4",
-                "extend-shallow": "^2.0.1",
-                "fragment-cache": "^0.2.1",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "array-unique": "0.3.2",
+                "define-property": "1.0.0",
+                "expand-brackets": "2.1.4",
+                "extend-shallow": "2.0.1",
+                "fragment-cache": "0.2.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
             },
             "dependencies": {
                 "define-property": {
@@ -2592,7 +2592,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^1.0.0"
+                        "is-descriptor": "1.0.2"
                     }
                 },
                 "extend-shallow": {
@@ -2601,7 +2601,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -2610,7 +2610,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -2619,7 +2619,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -2628,9 +2628,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 }
             }
@@ -2665,7 +2665,7 @@
             "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
             "dev": true,
             "requires": {
-                "bser": "^2.0.0"
+                "bser": "2.0.0"
             }
         },
         "fengari": {
@@ -2674,9 +2674,9 @@
             "integrity": "sha512-6ujqUuiIYmcgkGz8MGAdERU57EIluGGPSUgGPTsco657EHa+srq0S3/YUl/r9kx1+D+d4rGfYObd+m8K22gB1g==",
             "dev": true,
             "requires": {
-                "readline-sync": "^1.4.9",
-                "sprintf-js": "^1.1.1",
-                "tmp": "^0.0.33"
+                "readline-sync": "1.4.9",
+                "sprintf-js": "1.1.2",
+                "tmp": "0.0.33"
             }
         },
         "fill-range": {
@@ -2685,10 +2685,10 @@
             "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
             "dev": true,
             "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-number": "^3.0.0",
-                "repeat-string": "^1.6.1",
-                "to-regex-range": "^2.1.0"
+                "extend-shallow": "2.0.1",
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1",
+                "to-regex-range": "2.1.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -2697,7 +2697,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -2708,7 +2708,7 @@
             "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
             "dev": true,
             "requires": {
-                "locate-path": "^3.0.0"
+                "locate-path": "3.0.0"
             }
         },
         "for-in": {
@@ -2729,9 +2729,9 @@
             "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
             "dev": true,
             "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.6",
-                "mime-types": "^2.1.12"
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.7",
+                "mime-types": "2.1.24"
             }
         },
         "fragment-cache": {
@@ -2740,7 +2740,7 @@
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
             "dev": true,
             "requires": {
-                "map-cache": "^0.2.2"
+                "map-cache": "0.2.2"
             }
         },
         "fs.realpath": {
@@ -2756,8 +2756,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "nan": "^2.12.1",
-                "node-pre-gyp": "^0.12.0"
+                "nan": "2.13.2",
+                "node-pre-gyp": "0.12.0"
             },
             "dependencies": {
                 "abbrev": {
@@ -2783,8 +2783,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "delegates": "^1.0.0",
-                        "readable-stream": "^2.0.6"
+                        "delegates": "1.0.0",
+                        "readable-stream": "2.3.6"
                     }
                 },
                 "balanced-match": {
@@ -2797,7 +2797,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "balanced-match": "^1.0.0",
+                        "balanced-match": "1.0.0",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -2834,7 +2834,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.1"
                     }
                 },
                 "deep-extend": {
@@ -2861,7 +2861,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "^2.2.1"
+                        "minipass": "2.3.5"
                     }
                 },
                 "fs.realpath": {
@@ -2876,14 +2876,14 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "aproba": "^1.0.3",
-                        "console-control-strings": "^1.0.0",
-                        "has-unicode": "^2.0.0",
-                        "object-assign": "^4.1.0",
-                        "signal-exit": "^3.0.0",
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1",
-                        "wide-align": "^1.1.0"
+                        "aproba": "1.2.0",
+                        "console-control-strings": "1.1.0",
+                        "has-unicode": "2.0.1",
+                        "object-assign": "4.1.1",
+                        "signal-exit": "3.0.2",
+                        "string-width": "1.0.2",
+                        "strip-ansi": "3.0.1",
+                        "wide-align": "1.1.3"
                     }
                 },
                 "glob": {
@@ -2892,12 +2892,12 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "has-unicode": {
@@ -2912,7 +2912,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safer-buffer": ">= 2.1.2 < 3"
+                        "safer-buffer": "2.1.2"
                     }
                 },
                 "ignore-walk": {
@@ -2921,7 +2921,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minimatch": "^3.0.4"
+                        "minimatch": "3.0.4"
                     }
                 },
                 "inflight": {
@@ -2930,8 +2930,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "once": "^1.3.0",
-                        "wrappy": "1"
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
                     }
                 },
                 "inherits": {
@@ -2950,7 +2950,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "^1.0.0"
+                        "number-is-nan": "1.0.1"
                     }
                 },
                 "isarray": {
@@ -2964,7 +2964,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "^1.1.7"
+                        "brace-expansion": "1.1.11"
                     }
                 },
                 "minimist": {
@@ -2977,8 +2977,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "^5.1.2",
-                        "yallist": "^3.0.0"
+                        "safe-buffer": "5.1.2",
+                        "yallist": "3.0.3"
                     }
                 },
                 "minizlib": {
@@ -2987,7 +2987,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "^2.2.1"
+                        "minipass": "2.3.5"
                     }
                 },
                 "mkdirp": {
@@ -3010,9 +3010,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "debug": "^4.1.0",
-                        "iconv-lite": "^0.4.4",
-                        "sax": "^1.2.4"
+                        "debug": "4.1.1",
+                        "iconv-lite": "0.4.24",
+                        "sax": "1.2.4"
                     }
                 },
                 "node-pre-gyp": {
@@ -3021,16 +3021,16 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "detect-libc": "^1.0.2",
-                        "mkdirp": "^0.5.1",
-                        "needle": "^2.2.1",
-                        "nopt": "^4.0.1",
-                        "npm-packlist": "^1.1.6",
-                        "npmlog": "^4.0.2",
-                        "rc": "^1.2.7",
-                        "rimraf": "^2.6.1",
-                        "semver": "^5.3.0",
-                        "tar": "^4"
+                        "detect-libc": "1.0.3",
+                        "mkdirp": "0.5.1",
+                        "needle": "2.3.0",
+                        "nopt": "4.0.1",
+                        "npm-packlist": "1.4.1",
+                        "npmlog": "4.1.2",
+                        "rc": "1.2.8",
+                        "rimraf": "2.6.3",
+                        "semver": "5.7.0",
+                        "tar": "4.4.8"
                     }
                 },
                 "nopt": {
@@ -3039,8 +3039,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "abbrev": "1",
-                        "osenv": "^0.1.4"
+                        "abbrev": "1.1.1",
+                        "osenv": "0.1.5"
                     }
                 },
                 "npm-bundled": {
@@ -3055,8 +3055,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "ignore-walk": "^3.0.1",
-                        "npm-bundled": "^1.0.1"
+                        "ignore-walk": "3.0.1",
+                        "npm-bundled": "1.0.6"
                     }
                 },
                 "npmlog": {
@@ -3065,10 +3065,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "are-we-there-yet": "~1.1.2",
-                        "console-control-strings": "~1.1.0",
-                        "gauge": "~2.7.3",
-                        "set-blocking": "~2.0.0"
+                        "are-we-there-yet": "1.1.5",
+                        "console-control-strings": "1.1.0",
+                        "gauge": "2.7.4",
+                        "set-blocking": "2.0.0"
                     }
                 },
                 "number-is-nan": {
@@ -3087,7 +3087,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "wrappy": "1"
+                        "wrappy": "1.0.2"
                     }
                 },
                 "os-homedir": {
@@ -3108,8 +3108,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "os-homedir": "^1.0.0",
-                        "os-tmpdir": "^1.0.0"
+                        "os-homedir": "1.0.2",
+                        "os-tmpdir": "1.0.2"
                     }
                 },
                 "path-is-absolute": {
@@ -3130,10 +3130,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "deep-extend": "^0.6.0",
-                        "ini": "~1.3.0",
-                        "minimist": "^1.2.0",
-                        "strip-json-comments": "~2.0.1"
+                        "deep-extend": "0.6.0",
+                        "ini": "1.3.5",
+                        "minimist": "1.2.0",
+                        "strip-json-comments": "2.0.1"
                     },
                     "dependencies": {
                         "minimist": {
@@ -3150,13 +3150,13 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "2.0.0",
+                        "safe-buffer": "5.1.2",
+                        "string_decoder": "1.1.1",
+                        "util-deprecate": "1.0.2"
                     }
                 },
                 "rimraf": {
@@ -3165,7 +3165,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "glob": "^7.1.3"
+                        "glob": "7.1.3"
                     }
                 },
                 "safe-buffer": {
@@ -3208,9 +3208,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
                     }
                 },
                 "string_decoder": {
@@ -3219,7 +3219,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safe-buffer": "~5.1.0"
+                        "safe-buffer": "5.1.2"
                     }
                 },
                 "strip-ansi": {
@@ -3227,7 +3227,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^2.0.0"
+                        "ansi-regex": "2.1.1"
                     }
                 },
                 "strip-json-comments": {
@@ -3242,13 +3242,13 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "chownr": "^1.1.1",
-                        "fs-minipass": "^1.2.5",
-                        "minipass": "^2.3.4",
-                        "minizlib": "^1.1.1",
-                        "mkdirp": "^0.5.0",
-                        "safe-buffer": "^5.1.2",
-                        "yallist": "^3.0.2"
+                        "chownr": "1.1.1",
+                        "fs-minipass": "1.2.5",
+                        "minipass": "2.3.5",
+                        "minizlib": "1.2.1",
+                        "mkdirp": "0.5.1",
+                        "safe-buffer": "5.1.2",
+                        "yallist": "3.0.3"
                     }
                 },
                 "util-deprecate": {
@@ -3263,7 +3263,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "string-width": "^1.0.2 || 2"
+                        "string-width": "1.0.2"
                     }
                 },
                 "wrappy": {
@@ -3296,7 +3296,7 @@
             "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
             "dev": true,
             "requires": {
-                "pump": "^3.0.0"
+                "pump": "3.0.0"
             }
         },
         "get-value": {
@@ -3311,7 +3311,7 @@
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "dev": true,
             "requires": {
-                "assert-plus": "^1.0.0"
+                "assert-plus": "1.0.0"
             }
         },
         "glob": {
@@ -3320,12 +3320,12 @@
             "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
             "dev": true,
             "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
             }
         },
         "globals": {
@@ -3352,10 +3352,10 @@
             "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
             "dev": true,
             "requires": {
-                "neo-async": "^2.6.0",
-                "optimist": "^0.6.1",
-                "source-map": "^0.6.1",
-                "uglify-js": "^3.1.4"
+                "neo-async": "2.6.0",
+                "optimist": "0.6.1",
+                "source-map": "0.6.1",
+                "uglify-js": "3.5.10"
             },
             "dependencies": {
                 "source-map": {
@@ -3378,8 +3378,8 @@
             "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
             "dev": true,
             "requires": {
-                "ajv": "^6.5.5",
-                "har-schema": "^2.0.0"
+                "ajv": "6.10.0",
+                "har-schema": "2.0.0"
             }
         },
         "has": {
@@ -3388,7 +3388,7 @@
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
             "dev": true,
             "requires": {
-                "function-bind": "^1.1.1"
+                "function-bind": "1.1.1"
             }
         },
         "has-flag": {
@@ -3409,9 +3409,9 @@
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
             "dev": true,
             "requires": {
-                "get-value": "^2.0.6",
-                "has-values": "^1.0.0",
-                "isobject": "^3.0.0"
+                "get-value": "2.0.6",
+                "has-values": "1.0.0",
+                "isobject": "3.0.1"
             }
         },
         "has-values": {
@@ -3420,8 +3420,8 @@
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
             "dev": true,
             "requires": {
-                "is-number": "^3.0.0",
-                "kind-of": "^4.0.0"
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -3430,7 +3430,7 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -3447,7 +3447,7 @@
             "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
             "dev": true,
             "requires": {
-                "whatwg-encoding": "^1.0.1"
+                "whatwg-encoding": "1.0.5"
             }
         },
         "http-signature": {
@@ -3456,9 +3456,9 @@
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "dev": true,
             "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.16.1"
             }
         },
         "iconv-lite": {
@@ -3467,7 +3467,7 @@
             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
             "dev": true,
             "requires": {
-                "safer-buffer": ">= 2.1.2 < 3"
+                "safer-buffer": "2.1.2"
             }
         },
         "import-local": {
@@ -3476,8 +3476,8 @@
             "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
             "dev": true,
             "requires": {
-                "pkg-dir": "^3.0.0",
-                "resolve-cwd": "^2.0.0"
+                "pkg-dir": "3.0.0",
+                "resolve-cwd": "2.0.0"
             }
         },
         "imurmurhash": {
@@ -3492,8 +3492,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
             }
         },
         "inherits": {
@@ -3508,7 +3508,7 @@
             "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
             "dev": true,
             "requires": {
-                "loose-envify": "^1.0.0"
+                "loose-envify": "1.4.0"
             }
         },
         "invert-kv": {
@@ -3523,7 +3523,7 @@
             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
             "dev": true,
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -3532,7 +3532,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -3561,7 +3561,7 @@
             "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
             "dev": true,
             "requires": {
-                "ci-info": "^2.0.0"
+                "ci-info": "2.0.0"
             }
         },
         "is-data-descriptor": {
@@ -3570,7 +3570,7 @@
             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
             "dev": true,
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -3579,7 +3579,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -3596,9 +3596,9 @@
             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
             "dev": true,
             "requires": {
-                "is-accessor-descriptor": "^0.1.6",
-                "is-data-descriptor": "^0.1.4",
-                "kind-of": "^5.0.0"
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -3633,7 +3633,7 @@
             "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
             "dev": true,
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -3642,7 +3642,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -3653,7 +3653,7 @@
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
             "requires": {
-                "isobject": "^3.0.1"
+                "isobject": "3.0.1"
             }
         },
         "is-regex": {
@@ -3662,7 +3662,7 @@
             "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
             "dev": true,
             "requires": {
-                "has": "^1.0.1"
+                "has": "1.0.3"
             }
         },
         "is-stream": {
@@ -3677,7 +3677,7 @@
             "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
             "dev": true,
             "requires": {
-                "has-symbols": "^1.0.0"
+                "has-symbols": "1.0.0"
             }
         },
         "is-typedarray": {
@@ -3734,13 +3734,13 @@
             "integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
             "dev": true,
             "requires": {
-                "@babel/generator": "^7.0.0",
-                "@babel/parser": "^7.0.0",
-                "@babel/template": "^7.0.0",
-                "@babel/traverse": "^7.0.0",
-                "@babel/types": "^7.0.0",
-                "istanbul-lib-coverage": "^2.0.3",
-                "semver": "^5.5.0"
+                "@babel/generator": "7.3.2",
+                "@babel/parser": "7.3.2",
+                "@babel/template": "7.2.2",
+                "@babel/traverse": "7.2.3",
+                "@babel/types": "7.3.2",
+                "istanbul-lib-coverage": "2.0.3",
+                "semver": "5.5.0"
             }
         },
         "istanbul-lib-report": {
@@ -3749,9 +3749,9 @@
             "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
             "dev": true,
             "requires": {
-                "istanbul-lib-coverage": "^2.0.5",
-                "make-dir": "^2.1.0",
-                "supports-color": "^6.1.0"
+                "istanbul-lib-coverage": "2.0.5",
+                "make-dir": "2.1.0",
+                "supports-color": "6.1.0"
             },
             "dependencies": {
                 "istanbul-lib-coverage": {
@@ -3766,7 +3766,7 @@
                     "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -3777,11 +3777,11 @@
             "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
             "dev": true,
             "requires": {
-                "debug": "^4.1.1",
-                "istanbul-lib-coverage": "^2.0.5",
-                "make-dir": "^2.1.0",
-                "rimraf": "^2.6.3",
-                "source-map": "^0.6.1"
+                "debug": "4.1.1",
+                "istanbul-lib-coverage": "2.0.5",
+                "make-dir": "2.1.0",
+                "rimraf": "2.6.3",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "istanbul-lib-coverage": {
@@ -3804,7 +3804,7 @@
             "integrity": "sha512-QCHGyZEK0bfi9GR215QSm+NJwFKEShbtc7tfbUdLAEzn3kKhLDDZqvljn8rPZM9v8CEOhzL1nlYoO4r1ryl67w==",
             "dev": true,
             "requires": {
-                "handlebars": "^4.1.2"
+                "handlebars": "4.1.2"
             }
         },
         "jest": {
@@ -3813,8 +3813,8 @@
             "integrity": "sha512-o0HM90RKFRNWmAWvlyV8i5jGZ97pFwkeVoGvPW1EtLTgJc2+jcuqcbbqcSZLE/3f2S5pt0y2ZBETuhpWNl1Reg==",
             "dev": true,
             "requires": {
-                "import-local": "^2.0.0",
-                "jest-cli": "^24.8.0"
+                "import-local": "2.0.0",
+                "jest-cli": "24.8.0"
             },
             "dependencies": {
                 "@jest/console": {
@@ -3823,9 +3823,9 @@
                     "integrity": "sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==",
                     "dev": true,
                     "requires": {
-                        "@jest/source-map": "^24.3.0",
-                        "chalk": "^2.0.1",
-                        "slash": "^2.0.0"
+                        "@jest/source-map": "24.3.0",
+                        "chalk": "2.4.2",
+                        "slash": "2.0.0"
                     }
                 },
                 "@jest/fake-timers": {
@@ -3834,9 +3834,9 @@
                     "integrity": "sha512-2M4d5MufVXwi6VzZhJ9f5S/wU4ud2ck0kxPof1Iz3zWx6Y+V2eJrES9jEktB6O3o/oEyk+il/uNu9PvASjWXQw==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "jest-message-util": "^24.8.0",
-                        "jest-mock": "^24.8.0"
+                        "@jest/types": "24.8.0",
+                        "jest-message-util": "24.8.0",
+                        "jest-mock": "24.8.0"
                     }
                 },
                 "@jest/test-result": {
@@ -3845,9 +3845,9 @@
                     "integrity": "sha512-+YdLlxwizlfqkFDh7Mc7ONPQAhA4YylU1s529vVM1rsf67vGZH/2GGm5uO8QzPeVyaVMobCQ7FTxl38QrKRlng==",
                     "dev": true,
                     "requires": {
-                        "@jest/console": "^24.7.1",
-                        "@jest/types": "^24.8.0",
-                        "@types/istanbul-lib-coverage": "^2.0.0"
+                        "@jest/console": "24.7.1",
+                        "@jest/types": "24.8.0",
+                        "@types/istanbul-lib-coverage": "2.0.1"
                     }
                 },
                 "@jest/types": {
@@ -3856,9 +3856,9 @@
                     "integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^1.1.1",
-                        "@types/yargs": "^12.0.9"
+                        "@types/istanbul-lib-coverage": "2.0.1",
+                        "@types/istanbul-reports": "1.1.1",
+                        "@types/yargs": "12.0.10"
                     }
                 },
                 "@types/istanbul-lib-coverage": {
@@ -3873,7 +3873,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.2"
                     }
                 },
                 "chalk": {
@@ -3882,9 +3882,9 @@
                     "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.5.0"
                     }
                 },
                 "jest-cli": {
@@ -3893,19 +3893,19 @@
                     "integrity": "sha512-+p6J00jSMPQ116ZLlHJJvdf8wbjNbZdeSX9ptfHX06/MSNaXmKihQzx5vQcw0q2G6JsdVkUIdWbOWtSnaYs3yA==",
                     "dev": true,
                     "requires": {
-                        "@jest/core": "^24.8.0",
-                        "@jest/test-result": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "chalk": "^2.0.1",
-                        "exit": "^0.1.2",
-                        "import-local": "^2.0.0",
-                        "is-ci": "^2.0.0",
-                        "jest-config": "^24.8.0",
-                        "jest-util": "^24.8.0",
-                        "jest-validate": "^24.8.0",
-                        "prompts": "^2.0.1",
-                        "realpath-native": "^1.1.0",
-                        "yargs": "^12.0.2"
+                        "@jest/core": "24.8.0",
+                        "@jest/test-result": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "chalk": "2.4.2",
+                        "exit": "0.1.2",
+                        "import-local": "2.0.0",
+                        "is-ci": "2.0.0",
+                        "jest-config": "24.8.0",
+                        "jest-util": "24.8.0",
+                        "jest-validate": "24.8.0",
+                        "prompts": "2.0.4",
+                        "realpath-native": "1.1.0",
+                        "yargs": "12.0.5"
                     }
                 },
                 "jest-message-util": {
@@ -3914,14 +3914,14 @@
                     "integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
                     "dev": true,
                     "requires": {
-                        "@babel/code-frame": "^7.0.0",
-                        "@jest/test-result": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "@types/stack-utils": "^1.0.1",
-                        "chalk": "^2.0.1",
-                        "micromatch": "^3.1.10",
-                        "slash": "^2.0.0",
-                        "stack-utils": "^1.0.1"
+                        "@babel/code-frame": "7.0.0",
+                        "@jest/test-result": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "@types/stack-utils": "1.0.1",
+                        "chalk": "2.4.2",
+                        "micromatch": "3.1.10",
+                        "slash": "2.0.0",
+                        "stack-utils": "1.0.2"
                     }
                 },
                 "jest-mock": {
@@ -3930,7 +3930,7 @@
                     "integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0"
+                        "@jest/types": "24.8.0"
                     }
                 },
                 "jest-util": {
@@ -3939,18 +3939,18 @@
                     "integrity": "sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==",
                     "dev": true,
                     "requires": {
-                        "@jest/console": "^24.7.1",
-                        "@jest/fake-timers": "^24.8.0",
-                        "@jest/source-map": "^24.3.0",
-                        "@jest/test-result": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "callsites": "^3.0.0",
-                        "chalk": "^2.0.1",
-                        "graceful-fs": "^4.1.15",
-                        "is-ci": "^2.0.0",
-                        "mkdirp": "^0.5.1",
-                        "slash": "^2.0.0",
-                        "source-map": "^0.6.0"
+                        "@jest/console": "24.7.1",
+                        "@jest/fake-timers": "24.8.0",
+                        "@jest/source-map": "24.3.0",
+                        "@jest/test-result": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "callsites": "3.0.0",
+                        "chalk": "2.4.2",
+                        "graceful-fs": "4.1.15",
+                        "is-ci": "2.0.0",
+                        "mkdirp": "0.5.1",
+                        "slash": "2.0.0",
+                        "source-map": "0.6.1"
                     }
                 },
                 "source-map": {
@@ -3965,7 +3965,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -3976,9 +3976,9 @@
             "integrity": "sha512-qgANC1Yrivsq+UrLXsvJefBKVoCsKB0Hv+mBb6NMjjZ90wwxCDmU3hsCXBya30cH+LnPYjwgcU65i6yJ5Nfuug==",
             "dev": true,
             "requires": {
-                "@jest/types": "^24.8.0",
-                "execa": "^1.0.0",
-                "throat": "^4.0.0"
+                "@jest/types": "24.8.0",
+                "execa": "1.0.0",
+                "throat": "4.1.0"
             },
             "dependencies": {
                 "@jest/types": {
@@ -3987,9 +3987,9 @@
                     "integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^1.1.1",
-                        "@types/yargs": "^12.0.9"
+                        "@types/istanbul-lib-coverage": "2.0.1",
+                        "@types/istanbul-reports": "1.1.1",
+                        "@types/yargs": "12.0.10"
                     }
                 },
                 "@types/istanbul-lib-coverage": {
@@ -4006,22 +4006,22 @@
             "integrity": "sha512-2QASG3QuDdk0SMP2O73D8u3/lc/A/E2G7q23v5WhbUR+hCGzWZXwRMKif18f11dSLfL1wcrMbwE4IorvV0DRVw==",
             "dev": true,
             "requires": {
-                "@babel/traverse": "^7.1.0",
-                "@jest/environment": "^24.8.0",
-                "@jest/test-result": "^24.8.0",
-                "@jest/types": "^24.8.0",
-                "chalk": "^2.0.1",
-                "co": "^4.6.0",
-                "expect": "^24.8.0",
-                "is-generator-fn": "^2.0.0",
-                "jest-each": "^24.8.0",
-                "jest-matcher-utils": "^24.8.0",
-                "jest-message-util": "^24.8.0",
-                "jest-snapshot": "^24.8.0",
-                "jest-util": "^24.8.0",
-                "pretty-format": "^24.8.0",
-                "stack-utils": "^1.0.1",
-                "throat": "^4.0.0"
+                "@babel/traverse": "7.2.3",
+                "@jest/environment": "24.8.0",
+                "@jest/test-result": "24.8.0",
+                "@jest/types": "24.8.0",
+                "chalk": "2.4.2",
+                "co": "4.6.0",
+                "expect": "24.8.0",
+                "is-generator-fn": "2.0.0",
+                "jest-each": "24.8.0",
+                "jest-matcher-utils": "24.8.0",
+                "jest-message-util": "24.8.0",
+                "jest-snapshot": "24.8.0",
+                "jest-util": "24.8.0",
+                "pretty-format": "24.8.0",
+                "stack-utils": "1.0.2",
+                "throat": "4.1.0"
             }
         },
         "jest-config": {
@@ -4030,23 +4030,23 @@
             "integrity": "sha512-Czl3Nn2uEzVGsOeaewGWoDPD8GStxCpAe0zOYs2x2l0fZAgPbCr3uwUkgNKV3LwE13VXythM946cd5rdGkkBZw==",
             "dev": true,
             "requires": {
-                "@babel/core": "^7.1.0",
-                "@jest/test-sequencer": "^24.8.0",
-                "@jest/types": "^24.8.0",
-                "babel-jest": "^24.8.0",
-                "chalk": "^2.0.1",
-                "glob": "^7.1.1",
-                "jest-environment-jsdom": "^24.8.0",
-                "jest-environment-node": "^24.8.0",
-                "jest-get-type": "^24.8.0",
-                "jest-jasmine2": "^24.8.0",
-                "jest-regex-util": "^24.3.0",
-                "jest-resolve": "^24.8.0",
-                "jest-util": "^24.8.0",
-                "jest-validate": "^24.8.0",
-                "micromatch": "^3.1.10",
-                "pretty-format": "^24.8.0",
-                "realpath-native": "^1.1.0"
+                "@babel/core": "7.4.0",
+                "@jest/test-sequencer": "24.8.0",
+                "@jest/types": "24.8.0",
+                "babel-jest": "24.8.0",
+                "chalk": "2.4.2",
+                "glob": "7.1.3",
+                "jest-environment-jsdom": "24.8.0",
+                "jest-environment-node": "24.8.0",
+                "jest-get-type": "24.8.0",
+                "jest-jasmine2": "24.8.0",
+                "jest-regex-util": "24.3.0",
+                "jest-resolve": "24.8.0",
+                "jest-util": "24.8.0",
+                "jest-validate": "24.8.0",
+                "micromatch": "3.1.10",
+                "pretty-format": "24.8.0",
+                "realpath-native": "1.1.0"
             },
             "dependencies": {
                 "@jest/console": {
@@ -4055,9 +4055,9 @@
                     "integrity": "sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==",
                     "dev": true,
                     "requires": {
-                        "@jest/source-map": "^24.3.0",
-                        "chalk": "^2.0.1",
-                        "slash": "^2.0.0"
+                        "@jest/source-map": "24.3.0",
+                        "chalk": "2.4.2",
+                        "slash": "2.0.0"
                     }
                 },
                 "@jest/fake-timers": {
@@ -4066,9 +4066,9 @@
                     "integrity": "sha512-2M4d5MufVXwi6VzZhJ9f5S/wU4ud2ck0kxPof1Iz3zWx6Y+V2eJrES9jEktB6O3o/oEyk+il/uNu9PvASjWXQw==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "jest-message-util": "^24.8.0",
-                        "jest-mock": "^24.8.0"
+                        "@jest/types": "24.8.0",
+                        "jest-message-util": "24.8.0",
+                        "jest-mock": "24.8.0"
                     }
                 },
                 "@jest/test-result": {
@@ -4077,9 +4077,9 @@
                     "integrity": "sha512-+YdLlxwizlfqkFDh7Mc7ONPQAhA4YylU1s529vVM1rsf67vGZH/2GGm5uO8QzPeVyaVMobCQ7FTxl38QrKRlng==",
                     "dev": true,
                     "requires": {
-                        "@jest/console": "^24.7.1",
-                        "@jest/types": "^24.8.0",
-                        "@types/istanbul-lib-coverage": "^2.0.0"
+                        "@jest/console": "24.7.1",
+                        "@jest/types": "24.8.0",
+                        "@types/istanbul-lib-coverage": "2.0.1"
                     }
                 },
                 "@jest/types": {
@@ -4088,9 +4088,9 @@
                     "integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^1.1.1",
-                        "@types/yargs": "^12.0.9"
+                        "@types/istanbul-lib-coverage": "2.0.1",
+                        "@types/istanbul-reports": "1.1.1",
+                        "@types/yargs": "12.0.10"
                     }
                 },
                 "@types/istanbul-lib-coverage": {
@@ -4111,7 +4111,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.2"
                     }
                 },
                 "chalk": {
@@ -4120,9 +4120,9 @@
                     "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.5.0"
                     }
                 },
                 "jest-get-type": {
@@ -4137,14 +4137,14 @@
                     "integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
                     "dev": true,
                     "requires": {
-                        "@babel/code-frame": "^7.0.0",
-                        "@jest/test-result": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "@types/stack-utils": "^1.0.1",
-                        "chalk": "^2.0.1",
-                        "micromatch": "^3.1.10",
-                        "slash": "^2.0.0",
-                        "stack-utils": "^1.0.1"
+                        "@babel/code-frame": "7.0.0",
+                        "@jest/test-result": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "@types/stack-utils": "1.0.1",
+                        "chalk": "2.4.2",
+                        "micromatch": "3.1.10",
+                        "slash": "2.0.0",
+                        "stack-utils": "1.0.2"
                     }
                 },
                 "jest-mock": {
@@ -4153,7 +4153,7 @@
                     "integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0"
+                        "@jest/types": "24.8.0"
                     }
                 },
                 "jest-resolve": {
@@ -4162,11 +4162,11 @@
                     "integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "browser-resolve": "^1.11.3",
-                        "chalk": "^2.0.1",
-                        "jest-pnp-resolver": "^1.2.1",
-                        "realpath-native": "^1.1.0"
+                        "@jest/types": "24.8.0",
+                        "browser-resolve": "1.11.3",
+                        "chalk": "2.4.2",
+                        "jest-pnp-resolver": "1.2.1",
+                        "realpath-native": "1.1.0"
                     }
                 },
                 "jest-util": {
@@ -4175,18 +4175,18 @@
                     "integrity": "sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==",
                     "dev": true,
                     "requires": {
-                        "@jest/console": "^24.7.1",
-                        "@jest/fake-timers": "^24.8.0",
-                        "@jest/source-map": "^24.3.0",
-                        "@jest/test-result": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "callsites": "^3.0.0",
-                        "chalk": "^2.0.1",
-                        "graceful-fs": "^4.1.15",
-                        "is-ci": "^2.0.0",
-                        "mkdirp": "^0.5.1",
-                        "slash": "^2.0.0",
-                        "source-map": "^0.6.0"
+                        "@jest/console": "24.7.1",
+                        "@jest/fake-timers": "24.8.0",
+                        "@jest/source-map": "24.3.0",
+                        "@jest/test-result": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "callsites": "3.0.0",
+                        "chalk": "2.4.2",
+                        "graceful-fs": "4.1.15",
+                        "is-ci": "2.0.0",
+                        "mkdirp": "0.5.1",
+                        "slash": "2.0.0",
+                        "source-map": "0.6.1"
                     }
                 },
                 "pretty-format": {
@@ -4195,10 +4195,10 @@
                     "integrity": "sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "ansi-regex": "^4.0.0",
-                        "ansi-styles": "^3.2.0",
-                        "react-is": "^16.8.4"
+                        "@jest/types": "24.8.0",
+                        "ansi-regex": "4.1.0",
+                        "ansi-styles": "3.2.1",
+                        "react-is": "16.8.4"
                     }
                 },
                 "source-map": {
@@ -4213,7 +4213,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -4224,10 +4224,10 @@
             "integrity": "sha512-wxetCEl49zUpJ/bvUmIFjd/o52J+yWcoc5ZyPq4/W1LUKGEhRYDIbP1KcF6t+PvqNrGAFk4/JhtxDq/Nnzs66g==",
             "dev": true,
             "requires": {
-                "chalk": "^2.0.1",
-                "diff-sequences": "^24.3.0",
-                "jest-get-type": "^24.8.0",
-                "pretty-format": "^24.8.0"
+                "chalk": "2.4.2",
+                "diff-sequences": "24.3.0",
+                "jest-get-type": "24.8.0",
+                "pretty-format": "24.8.0"
             }
         },
         "jest-docblock": {
@@ -4236,7 +4236,7 @@
             "integrity": "sha512-nlANmF9Yq1dufhFlKG9rasfQlrY7wINJbo3q01tu56Jv5eBU5jirylhF2O5ZBnLxzOVBGRDz/9NAwNyBtG4Nyg==",
             "dev": true,
             "requires": {
-                "detect-newline": "^2.1.0"
+                "detect-newline": "2.1.0"
             }
         },
         "jest-each": {
@@ -4245,11 +4245,11 @@
             "integrity": "sha512-NrwK9gaL5+XgrgoCsd9svsoWdVkK4gnvyhcpzd6m487tXHqIdYeykgq3MKI1u4I+5Zf0tofr70at9dWJDeb+BA==",
             "dev": true,
             "requires": {
-                "@jest/types": "^24.8.0",
-                "chalk": "^2.0.1",
-                "jest-get-type": "^24.8.0",
-                "jest-util": "^24.8.0",
-                "pretty-format": "^24.8.0"
+                "@jest/types": "24.8.0",
+                "chalk": "2.4.2",
+                "jest-get-type": "24.8.0",
+                "jest-util": "24.8.0",
+                "pretty-format": "24.8.0"
             }
         },
         "jest-environment-jsdom": {
@@ -4258,12 +4258,12 @@
             "integrity": "sha512-qbvgLmR7PpwjoFjM/sbuqHJt/NCkviuq9vus9NBn/76hhSidO+Z6Bn9tU8friecegbJL8gzZQEMZBQlFWDCwAQ==",
             "dev": true,
             "requires": {
-                "@jest/environment": "^24.8.0",
-                "@jest/fake-timers": "^24.8.0",
-                "@jest/types": "^24.8.0",
-                "jest-mock": "^24.8.0",
-                "jest-util": "^24.8.0",
-                "jsdom": "^11.5.1"
+                "@jest/environment": "24.8.0",
+                "@jest/fake-timers": "24.8.0",
+                "@jest/types": "24.8.0",
+                "jest-mock": "24.8.0",
+                "jest-util": "24.8.0",
+                "jsdom": "11.12.0"
             },
             "dependencies": {
                 "@jest/console": {
@@ -4272,9 +4272,9 @@
                     "integrity": "sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==",
                     "dev": true,
                     "requires": {
-                        "@jest/source-map": "^24.3.0",
-                        "chalk": "^2.0.1",
-                        "slash": "^2.0.0"
+                        "@jest/source-map": "24.3.0",
+                        "chalk": "2.4.2",
+                        "slash": "2.0.0"
                     }
                 },
                 "@jest/environment": {
@@ -4283,10 +4283,10 @@
                     "integrity": "sha512-vlGt2HLg7qM+vtBrSkjDxk9K0YtRBi7HfRFaDxoRtyi+DyVChzhF20duvpdAnKVBV6W5tym8jm0U9EfXbDk1tw==",
                     "dev": true,
                     "requires": {
-                        "@jest/fake-timers": "^24.8.0",
-                        "@jest/transform": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "jest-mock": "^24.8.0"
+                        "@jest/fake-timers": "24.8.0",
+                        "@jest/transform": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "jest-mock": "24.8.0"
                     }
                 },
                 "@jest/fake-timers": {
@@ -4295,9 +4295,9 @@
                     "integrity": "sha512-2M4d5MufVXwi6VzZhJ9f5S/wU4ud2ck0kxPof1Iz3zWx6Y+V2eJrES9jEktB6O3o/oEyk+il/uNu9PvASjWXQw==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "jest-message-util": "^24.8.0",
-                        "jest-mock": "^24.8.0"
+                        "@jest/types": "24.8.0",
+                        "jest-message-util": "24.8.0",
+                        "jest-mock": "24.8.0"
                     }
                 },
                 "@jest/test-result": {
@@ -4306,9 +4306,9 @@
                     "integrity": "sha512-+YdLlxwizlfqkFDh7Mc7ONPQAhA4YylU1s529vVM1rsf67vGZH/2GGm5uO8QzPeVyaVMobCQ7FTxl38QrKRlng==",
                     "dev": true,
                     "requires": {
-                        "@jest/console": "^24.7.1",
-                        "@jest/types": "^24.8.0",
-                        "@types/istanbul-lib-coverage": "^2.0.0"
+                        "@jest/console": "24.7.1",
+                        "@jest/types": "24.8.0",
+                        "@types/istanbul-lib-coverage": "2.0.1"
                     }
                 },
                 "@jest/transform": {
@@ -4317,20 +4317,20 @@
                     "integrity": "sha512-xBMfFUP7TortCs0O+Xtez2W7Zu1PLH9bvJgtraN1CDST6LBM/eTOZ9SfwS/lvV8yOfcDpFmwf9bq5cYbXvqsvA==",
                     "dev": true,
                     "requires": {
-                        "@babel/core": "^7.1.0",
-                        "@jest/types": "^24.8.0",
-                        "babel-plugin-istanbul": "^5.1.0",
-                        "chalk": "^2.0.1",
-                        "convert-source-map": "^1.4.0",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "graceful-fs": "^4.1.15",
-                        "jest-haste-map": "^24.8.0",
-                        "jest-regex-util": "^24.3.0",
-                        "jest-util": "^24.8.0",
-                        "micromatch": "^3.1.10",
-                        "realpath-native": "^1.1.0",
-                        "slash": "^2.0.0",
-                        "source-map": "^0.6.1",
+                        "@babel/core": "7.4.0",
+                        "@jest/types": "24.8.0",
+                        "babel-plugin-istanbul": "5.1.1",
+                        "chalk": "2.4.2",
+                        "convert-source-map": "1.6.0",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "graceful-fs": "4.1.15",
+                        "jest-haste-map": "24.8.0",
+                        "jest-regex-util": "24.3.0",
+                        "jest-util": "24.8.0",
+                        "micromatch": "3.1.10",
+                        "realpath-native": "1.1.0",
+                        "slash": "2.0.0",
+                        "source-map": "0.6.1",
                         "write-file-atomic": "2.4.1"
                     }
                 },
@@ -4340,9 +4340,9 @@
                     "integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^1.1.1",
-                        "@types/yargs": "^12.0.9"
+                        "@types/istanbul-lib-coverage": "2.0.1",
+                        "@types/istanbul-reports": "1.1.1",
+                        "@types/yargs": "12.0.10"
                     }
                 },
                 "@types/istanbul-lib-coverage": {
@@ -4357,7 +4357,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.2"
                     }
                 },
                 "chalk": {
@@ -4366,9 +4366,9 @@
                     "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.5.0"
                     }
                 },
                 "jest-haste-map": {
@@ -4377,18 +4377,18 @@
                     "integrity": "sha512-ZBPRGHdPt1rHajWelXdqygIDpJx8u3xOoLyUBWRW28r3tagrgoepPrzAozW7kW9HrQfhvmiv1tncsxqHJO1onQ==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "anymatch": "^2.0.0",
-                        "fb-watchman": "^2.0.0",
-                        "fsevents": "^1.2.7",
-                        "graceful-fs": "^4.1.15",
-                        "invariant": "^2.2.4",
-                        "jest-serializer": "^24.4.0",
-                        "jest-util": "^24.8.0",
-                        "jest-worker": "^24.6.0",
-                        "micromatch": "^3.1.10",
-                        "sane": "^4.0.3",
-                        "walker": "^1.0.7"
+                        "@jest/types": "24.8.0",
+                        "anymatch": "2.0.0",
+                        "fb-watchman": "2.0.0",
+                        "fsevents": "1.2.9",
+                        "graceful-fs": "4.1.15",
+                        "invariant": "2.2.4",
+                        "jest-serializer": "24.4.0",
+                        "jest-util": "24.8.0",
+                        "jest-worker": "24.6.0",
+                        "micromatch": "3.1.10",
+                        "sane": "4.1.0",
+                        "walker": "1.0.7"
                     }
                 },
                 "jest-message-util": {
@@ -4397,14 +4397,14 @@
                     "integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
                     "dev": true,
                     "requires": {
-                        "@babel/code-frame": "^7.0.0",
-                        "@jest/test-result": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "@types/stack-utils": "^1.0.1",
-                        "chalk": "^2.0.1",
-                        "micromatch": "^3.1.10",
-                        "slash": "^2.0.0",
-                        "stack-utils": "^1.0.1"
+                        "@babel/code-frame": "7.0.0",
+                        "@jest/test-result": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "@types/stack-utils": "1.0.1",
+                        "chalk": "2.4.2",
+                        "micromatch": "3.1.10",
+                        "slash": "2.0.0",
+                        "stack-utils": "1.0.2"
                     }
                 },
                 "jest-mock": {
@@ -4413,7 +4413,7 @@
                     "integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0"
+                        "@jest/types": "24.8.0"
                     }
                 },
                 "jest-util": {
@@ -4422,18 +4422,18 @@
                     "integrity": "sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==",
                     "dev": true,
                     "requires": {
-                        "@jest/console": "^24.7.1",
-                        "@jest/fake-timers": "^24.8.0",
-                        "@jest/source-map": "^24.3.0",
-                        "@jest/test-result": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "callsites": "^3.0.0",
-                        "chalk": "^2.0.1",
-                        "graceful-fs": "^4.1.15",
-                        "is-ci": "^2.0.0",
-                        "mkdirp": "^0.5.1",
-                        "slash": "^2.0.0",
-                        "source-map": "^0.6.0"
+                        "@jest/console": "24.7.1",
+                        "@jest/fake-timers": "24.8.0",
+                        "@jest/source-map": "24.3.0",
+                        "@jest/test-result": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "callsites": "3.0.0",
+                        "chalk": "2.4.2",
+                        "graceful-fs": "4.1.15",
+                        "is-ci": "2.0.0",
+                        "mkdirp": "0.5.1",
+                        "slash": "2.0.0",
+                        "source-map": "0.6.1"
                     }
                 },
                 "jest-worker": {
@@ -4442,8 +4442,8 @@
                     "integrity": "sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==",
                     "dev": true,
                     "requires": {
-                        "merge-stream": "^1.0.1",
-                        "supports-color": "^6.1.0"
+                        "merge-stream": "1.0.1",
+                        "supports-color": "6.1.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -4452,7 +4452,7 @@
                             "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
                             "dev": true,
                             "requires": {
-                                "has-flag": "^3.0.0"
+                                "has-flag": "3.0.0"
                             }
                         }
                     }
@@ -4469,7 +4469,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -4480,11 +4480,11 @@
             "integrity": "sha512-vIGUEScd1cdDgR6sqn2M08sJTRLQp6Dk/eIkCeO4PFHxZMOgy+uYLPMC4ix3PEfM5Au/x3uQ/5Tl0DpXXZsJ/Q==",
             "dev": true,
             "requires": {
-                "@jest/environment": "^24.8.0",
-                "@jest/fake-timers": "^24.8.0",
-                "@jest/types": "^24.8.0",
-                "jest-mock": "^24.8.0",
-                "jest-util": "^24.8.0"
+                "@jest/environment": "24.8.0",
+                "@jest/fake-timers": "24.8.0",
+                "@jest/types": "24.8.0",
+                "jest-mock": "24.8.0",
+                "jest-util": "24.8.0"
             },
             "dependencies": {
                 "@jest/console": {
@@ -4493,9 +4493,9 @@
                     "integrity": "sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==",
                     "dev": true,
                     "requires": {
-                        "@jest/source-map": "^24.3.0",
-                        "chalk": "^2.0.1",
-                        "slash": "^2.0.0"
+                        "@jest/source-map": "24.3.0",
+                        "chalk": "2.4.2",
+                        "slash": "2.0.0"
                     }
                 },
                 "@jest/environment": {
@@ -4504,10 +4504,10 @@
                     "integrity": "sha512-vlGt2HLg7qM+vtBrSkjDxk9K0YtRBi7HfRFaDxoRtyi+DyVChzhF20duvpdAnKVBV6W5tym8jm0U9EfXbDk1tw==",
                     "dev": true,
                     "requires": {
-                        "@jest/fake-timers": "^24.8.0",
-                        "@jest/transform": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "jest-mock": "^24.8.0"
+                        "@jest/fake-timers": "24.8.0",
+                        "@jest/transform": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "jest-mock": "24.8.0"
                     }
                 },
                 "@jest/fake-timers": {
@@ -4516,9 +4516,9 @@
                     "integrity": "sha512-2M4d5MufVXwi6VzZhJ9f5S/wU4ud2ck0kxPof1Iz3zWx6Y+V2eJrES9jEktB6O3o/oEyk+il/uNu9PvASjWXQw==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "jest-message-util": "^24.8.0",
-                        "jest-mock": "^24.8.0"
+                        "@jest/types": "24.8.0",
+                        "jest-message-util": "24.8.0",
+                        "jest-mock": "24.8.0"
                     }
                 },
                 "@jest/test-result": {
@@ -4527,9 +4527,9 @@
                     "integrity": "sha512-+YdLlxwizlfqkFDh7Mc7ONPQAhA4YylU1s529vVM1rsf67vGZH/2GGm5uO8QzPeVyaVMobCQ7FTxl38QrKRlng==",
                     "dev": true,
                     "requires": {
-                        "@jest/console": "^24.7.1",
-                        "@jest/types": "^24.8.0",
-                        "@types/istanbul-lib-coverage": "^2.0.0"
+                        "@jest/console": "24.7.1",
+                        "@jest/types": "24.8.0",
+                        "@types/istanbul-lib-coverage": "2.0.1"
                     }
                 },
                 "@jest/transform": {
@@ -4538,20 +4538,20 @@
                     "integrity": "sha512-xBMfFUP7TortCs0O+Xtez2W7Zu1PLH9bvJgtraN1CDST6LBM/eTOZ9SfwS/lvV8yOfcDpFmwf9bq5cYbXvqsvA==",
                     "dev": true,
                     "requires": {
-                        "@babel/core": "^7.1.0",
-                        "@jest/types": "^24.8.0",
-                        "babel-plugin-istanbul": "^5.1.0",
-                        "chalk": "^2.0.1",
-                        "convert-source-map": "^1.4.0",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "graceful-fs": "^4.1.15",
-                        "jest-haste-map": "^24.8.0",
-                        "jest-regex-util": "^24.3.0",
-                        "jest-util": "^24.8.0",
-                        "micromatch": "^3.1.10",
-                        "realpath-native": "^1.1.0",
-                        "slash": "^2.0.0",
-                        "source-map": "^0.6.1",
+                        "@babel/core": "7.4.0",
+                        "@jest/types": "24.8.0",
+                        "babel-plugin-istanbul": "5.1.1",
+                        "chalk": "2.4.2",
+                        "convert-source-map": "1.6.0",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "graceful-fs": "4.1.15",
+                        "jest-haste-map": "24.8.0",
+                        "jest-regex-util": "24.3.0",
+                        "jest-util": "24.8.0",
+                        "micromatch": "3.1.10",
+                        "realpath-native": "1.1.0",
+                        "slash": "2.0.0",
+                        "source-map": "0.6.1",
                         "write-file-atomic": "2.4.1"
                     }
                 },
@@ -4561,9 +4561,9 @@
                     "integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^1.1.1",
-                        "@types/yargs": "^12.0.9"
+                        "@types/istanbul-lib-coverage": "2.0.1",
+                        "@types/istanbul-reports": "1.1.1",
+                        "@types/yargs": "12.0.10"
                     }
                 },
                 "@types/istanbul-lib-coverage": {
@@ -4578,7 +4578,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.2"
                     }
                 },
                 "chalk": {
@@ -4587,9 +4587,9 @@
                     "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.5.0"
                     }
                 },
                 "jest-haste-map": {
@@ -4598,18 +4598,18 @@
                     "integrity": "sha512-ZBPRGHdPt1rHajWelXdqygIDpJx8u3xOoLyUBWRW28r3tagrgoepPrzAozW7kW9HrQfhvmiv1tncsxqHJO1onQ==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "anymatch": "^2.0.0",
-                        "fb-watchman": "^2.0.0",
-                        "fsevents": "^1.2.7",
-                        "graceful-fs": "^4.1.15",
-                        "invariant": "^2.2.4",
-                        "jest-serializer": "^24.4.0",
-                        "jest-util": "^24.8.0",
-                        "jest-worker": "^24.6.0",
-                        "micromatch": "^3.1.10",
-                        "sane": "^4.0.3",
-                        "walker": "^1.0.7"
+                        "@jest/types": "24.8.0",
+                        "anymatch": "2.0.0",
+                        "fb-watchman": "2.0.0",
+                        "fsevents": "1.2.9",
+                        "graceful-fs": "4.1.15",
+                        "invariant": "2.2.4",
+                        "jest-serializer": "24.4.0",
+                        "jest-util": "24.8.0",
+                        "jest-worker": "24.6.0",
+                        "micromatch": "3.1.10",
+                        "sane": "4.1.0",
+                        "walker": "1.0.7"
                     }
                 },
                 "jest-message-util": {
@@ -4618,14 +4618,14 @@
                     "integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
                     "dev": true,
                     "requires": {
-                        "@babel/code-frame": "^7.0.0",
-                        "@jest/test-result": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "@types/stack-utils": "^1.0.1",
-                        "chalk": "^2.0.1",
-                        "micromatch": "^3.1.10",
-                        "slash": "^2.0.0",
-                        "stack-utils": "^1.0.1"
+                        "@babel/code-frame": "7.0.0",
+                        "@jest/test-result": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "@types/stack-utils": "1.0.1",
+                        "chalk": "2.4.2",
+                        "micromatch": "3.1.10",
+                        "slash": "2.0.0",
+                        "stack-utils": "1.0.2"
                     }
                 },
                 "jest-mock": {
@@ -4634,7 +4634,7 @@
                     "integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0"
+                        "@jest/types": "24.8.0"
                     }
                 },
                 "jest-util": {
@@ -4643,18 +4643,18 @@
                     "integrity": "sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==",
                     "dev": true,
                     "requires": {
-                        "@jest/console": "^24.7.1",
-                        "@jest/fake-timers": "^24.8.0",
-                        "@jest/source-map": "^24.3.0",
-                        "@jest/test-result": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "callsites": "^3.0.0",
-                        "chalk": "^2.0.1",
-                        "graceful-fs": "^4.1.15",
-                        "is-ci": "^2.0.0",
-                        "mkdirp": "^0.5.1",
-                        "slash": "^2.0.0",
-                        "source-map": "^0.6.0"
+                        "@jest/console": "24.7.1",
+                        "@jest/fake-timers": "24.8.0",
+                        "@jest/source-map": "24.3.0",
+                        "@jest/test-result": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "callsites": "3.0.0",
+                        "chalk": "2.4.2",
+                        "graceful-fs": "4.1.15",
+                        "is-ci": "2.0.0",
+                        "mkdirp": "0.5.1",
+                        "slash": "2.0.0",
+                        "source-map": "0.6.1"
                     }
                 },
                 "jest-worker": {
@@ -4663,8 +4663,8 @@
                     "integrity": "sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==",
                     "dev": true,
                     "requires": {
-                        "merge-stream": "^1.0.1",
-                        "supports-color": "^6.1.0"
+                        "merge-stream": "1.0.1",
+                        "supports-color": "6.1.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -4673,7 +4673,7 @@
                             "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
                             "dev": true,
                             "requires": {
-                                "has-flag": "^3.0.0"
+                                "has-flag": "3.0.0"
                             }
                         }
                     }
@@ -4690,7 +4690,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -4707,18 +4707,18 @@
             "integrity": "sha512-ZBPRGHdPt1rHajWelXdqygIDpJx8u3xOoLyUBWRW28r3tagrgoepPrzAozW7kW9HrQfhvmiv1tncsxqHJO1onQ==",
             "dev": true,
             "requires": {
-                "@jest/types": "^24.8.0",
-                "anymatch": "^2.0.0",
-                "fb-watchman": "^2.0.0",
-                "fsevents": "^1.2.7",
-                "graceful-fs": "^4.1.15",
-                "invariant": "^2.2.4",
-                "jest-serializer": "^24.4.0",
-                "jest-util": "^24.8.0",
-                "jest-worker": "^24.6.0",
-                "micromatch": "^3.1.10",
-                "sane": "^4.0.3",
-                "walker": "^1.0.7"
+                "@jest/types": "24.8.0",
+                "anymatch": "2.0.0",
+                "fb-watchman": "2.0.0",
+                "fsevents": "1.2.9",
+                "graceful-fs": "4.1.15",
+                "invariant": "2.2.4",
+                "jest-serializer": "24.4.0",
+                "jest-util": "24.8.0",
+                "jest-worker": "24.6.0",
+                "micromatch": "3.1.10",
+                "sane": "4.1.0",
+                "walker": "1.0.7"
             }
         },
         "jest-jasmine2": {
@@ -4727,22 +4727,22 @@
             "integrity": "sha512-cEky88npEE5LKd5jPpTdDCLvKkdyklnaRycBXL6GNmpxe41F0WN44+i7lpQKa/hcbXaQ+rc9RMaM4dsebrYong==",
             "dev": true,
             "requires": {
-                "@babel/traverse": "^7.1.0",
-                "@jest/environment": "^24.8.0",
-                "@jest/test-result": "^24.8.0",
-                "@jest/types": "^24.8.0",
-                "chalk": "^2.0.1",
-                "co": "^4.6.0",
-                "expect": "^24.8.0",
-                "is-generator-fn": "^2.0.0",
-                "jest-each": "^24.8.0",
-                "jest-matcher-utils": "^24.8.0",
-                "jest-message-util": "^24.8.0",
-                "jest-runtime": "^24.8.0",
-                "jest-snapshot": "^24.8.0",
-                "jest-util": "^24.8.0",
-                "pretty-format": "^24.8.0",
-                "throat": "^4.0.0"
+                "@babel/traverse": "7.2.3",
+                "@jest/environment": "24.8.0",
+                "@jest/test-result": "24.8.0",
+                "@jest/types": "24.8.0",
+                "chalk": "2.4.2",
+                "co": "4.6.0",
+                "expect": "24.8.0",
+                "is-generator-fn": "2.0.0",
+                "jest-each": "24.8.0",
+                "jest-matcher-utils": "24.8.0",
+                "jest-message-util": "24.8.0",
+                "jest-runtime": "24.8.0",
+                "jest-snapshot": "24.8.0",
+                "jest-util": "24.8.0",
+                "pretty-format": "24.8.0",
+                "throat": "4.1.0"
             },
             "dependencies": {
                 "@jest/console": {
@@ -4751,9 +4751,9 @@
                     "integrity": "sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==",
                     "dev": true,
                     "requires": {
-                        "@jest/source-map": "^24.3.0",
-                        "chalk": "^2.0.1",
-                        "slash": "^2.0.0"
+                        "@jest/source-map": "24.3.0",
+                        "chalk": "2.4.2",
+                        "slash": "2.0.0"
                     }
                 },
                 "@jest/environment": {
@@ -4762,10 +4762,10 @@
                     "integrity": "sha512-vlGt2HLg7qM+vtBrSkjDxk9K0YtRBi7HfRFaDxoRtyi+DyVChzhF20duvpdAnKVBV6W5tym8jm0U9EfXbDk1tw==",
                     "dev": true,
                     "requires": {
-                        "@jest/fake-timers": "^24.8.0",
-                        "@jest/transform": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "jest-mock": "^24.8.0"
+                        "@jest/fake-timers": "24.8.0",
+                        "@jest/transform": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "jest-mock": "24.8.0"
                     }
                 },
                 "@jest/fake-timers": {
@@ -4774,9 +4774,9 @@
                     "integrity": "sha512-2M4d5MufVXwi6VzZhJ9f5S/wU4ud2ck0kxPof1Iz3zWx6Y+V2eJrES9jEktB6O3o/oEyk+il/uNu9PvASjWXQw==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "jest-message-util": "^24.8.0",
-                        "jest-mock": "^24.8.0"
+                        "@jest/types": "24.8.0",
+                        "jest-message-util": "24.8.0",
+                        "jest-mock": "24.8.0"
                     }
                 },
                 "@jest/test-result": {
@@ -4785,9 +4785,9 @@
                     "integrity": "sha512-+YdLlxwizlfqkFDh7Mc7ONPQAhA4YylU1s529vVM1rsf67vGZH/2GGm5uO8QzPeVyaVMobCQ7FTxl38QrKRlng==",
                     "dev": true,
                     "requires": {
-                        "@jest/console": "^24.7.1",
-                        "@jest/types": "^24.8.0",
-                        "@types/istanbul-lib-coverage": "^2.0.0"
+                        "@jest/console": "24.7.1",
+                        "@jest/types": "24.8.0",
+                        "@types/istanbul-lib-coverage": "2.0.1"
                     }
                 },
                 "@jest/transform": {
@@ -4796,20 +4796,20 @@
                     "integrity": "sha512-xBMfFUP7TortCs0O+Xtez2W7Zu1PLH9bvJgtraN1CDST6LBM/eTOZ9SfwS/lvV8yOfcDpFmwf9bq5cYbXvqsvA==",
                     "dev": true,
                     "requires": {
-                        "@babel/core": "^7.1.0",
-                        "@jest/types": "^24.8.0",
-                        "babel-plugin-istanbul": "^5.1.0",
-                        "chalk": "^2.0.1",
-                        "convert-source-map": "^1.4.0",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "graceful-fs": "^4.1.15",
-                        "jest-haste-map": "^24.8.0",
-                        "jest-regex-util": "^24.3.0",
-                        "jest-util": "^24.8.0",
-                        "micromatch": "^3.1.10",
-                        "realpath-native": "^1.1.0",
-                        "slash": "^2.0.0",
-                        "source-map": "^0.6.1",
+                        "@babel/core": "7.4.0",
+                        "@jest/types": "24.8.0",
+                        "babel-plugin-istanbul": "5.1.1",
+                        "chalk": "2.4.2",
+                        "convert-source-map": "1.6.0",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "graceful-fs": "4.1.15",
+                        "jest-haste-map": "24.8.0",
+                        "jest-regex-util": "24.3.0",
+                        "jest-util": "24.8.0",
+                        "micromatch": "3.1.10",
+                        "realpath-native": "1.1.0",
+                        "slash": "2.0.0",
+                        "source-map": "0.6.1",
                         "write-file-atomic": "2.4.1"
                     }
                 },
@@ -4819,9 +4819,9 @@
                     "integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^1.1.1",
-                        "@types/yargs": "^12.0.9"
+                        "@types/istanbul-lib-coverage": "2.0.1",
+                        "@types/istanbul-reports": "1.1.1",
+                        "@types/yargs": "12.0.10"
                     }
                 },
                 "@types/istanbul-lib-coverage": {
@@ -4842,7 +4842,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.2"
                     }
                 },
                 "chalk": {
@@ -4851,9 +4851,9 @@
                     "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.5.0"
                     }
                 },
                 "expect": {
@@ -4862,12 +4862,12 @@
                     "integrity": "sha512-/zYvP8iMDrzaaxHVa724eJBCKqSHmO0FA7EDkBiRHxg6OipmMn1fN+C8T9L9K8yr7UONkOifu6+LLH+z76CnaA==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "ansi-styles": "^3.2.0",
-                        "jest-get-type": "^24.8.0",
-                        "jest-matcher-utils": "^24.8.0",
-                        "jest-message-util": "^24.8.0",
-                        "jest-regex-util": "^24.3.0"
+                        "@jest/types": "24.8.0",
+                        "ansi-styles": "3.2.1",
+                        "jest-get-type": "24.8.0",
+                        "jest-matcher-utils": "24.8.0",
+                        "jest-message-util": "24.8.0",
+                        "jest-regex-util": "24.3.0"
                     }
                 },
                 "jest-diff": {
@@ -4876,10 +4876,10 @@
                     "integrity": "sha512-wxetCEl49zUpJ/bvUmIFjd/o52J+yWcoc5ZyPq4/W1LUKGEhRYDIbP1KcF6t+PvqNrGAFk4/JhtxDq/Nnzs66g==",
                     "dev": true,
                     "requires": {
-                        "chalk": "^2.0.1",
-                        "diff-sequences": "^24.3.0",
-                        "jest-get-type": "^24.8.0",
-                        "pretty-format": "^24.8.0"
+                        "chalk": "2.4.2",
+                        "diff-sequences": "24.3.0",
+                        "jest-get-type": "24.8.0",
+                        "pretty-format": "24.8.0"
                     }
                 },
                 "jest-each": {
@@ -4888,11 +4888,11 @@
                     "integrity": "sha512-NrwK9gaL5+XgrgoCsd9svsoWdVkK4gnvyhcpzd6m487tXHqIdYeykgq3MKI1u4I+5Zf0tofr70at9dWJDeb+BA==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "chalk": "^2.0.1",
-                        "jest-get-type": "^24.8.0",
-                        "jest-util": "^24.8.0",
-                        "pretty-format": "^24.8.0"
+                        "@jest/types": "24.8.0",
+                        "chalk": "2.4.2",
+                        "jest-get-type": "24.8.0",
+                        "jest-util": "24.8.0",
+                        "pretty-format": "24.8.0"
                     }
                 },
                 "jest-get-type": {
@@ -4907,18 +4907,18 @@
                     "integrity": "sha512-ZBPRGHdPt1rHajWelXdqygIDpJx8u3xOoLyUBWRW28r3tagrgoepPrzAozW7kW9HrQfhvmiv1tncsxqHJO1onQ==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "anymatch": "^2.0.0",
-                        "fb-watchman": "^2.0.0",
-                        "fsevents": "^1.2.7",
-                        "graceful-fs": "^4.1.15",
-                        "invariant": "^2.2.4",
-                        "jest-serializer": "^24.4.0",
-                        "jest-util": "^24.8.0",
-                        "jest-worker": "^24.6.0",
-                        "micromatch": "^3.1.10",
-                        "sane": "^4.0.3",
-                        "walker": "^1.0.7"
+                        "@jest/types": "24.8.0",
+                        "anymatch": "2.0.0",
+                        "fb-watchman": "2.0.0",
+                        "fsevents": "1.2.9",
+                        "graceful-fs": "4.1.15",
+                        "invariant": "2.2.4",
+                        "jest-serializer": "24.4.0",
+                        "jest-util": "24.8.0",
+                        "jest-worker": "24.6.0",
+                        "micromatch": "3.1.10",
+                        "sane": "4.1.0",
+                        "walker": "1.0.7"
                     }
                 },
                 "jest-matcher-utils": {
@@ -4927,10 +4927,10 @@
                     "integrity": "sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==",
                     "dev": true,
                     "requires": {
-                        "chalk": "^2.0.1",
-                        "jest-diff": "^24.8.0",
-                        "jest-get-type": "^24.8.0",
-                        "pretty-format": "^24.8.0"
+                        "chalk": "2.4.2",
+                        "jest-diff": "24.8.0",
+                        "jest-get-type": "24.8.0",
+                        "pretty-format": "24.8.0"
                     }
                 },
                 "jest-message-util": {
@@ -4939,14 +4939,14 @@
                     "integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
                     "dev": true,
                     "requires": {
-                        "@babel/code-frame": "^7.0.0",
-                        "@jest/test-result": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "@types/stack-utils": "^1.0.1",
-                        "chalk": "^2.0.1",
-                        "micromatch": "^3.1.10",
-                        "slash": "^2.0.0",
-                        "stack-utils": "^1.0.1"
+                        "@babel/code-frame": "7.0.0",
+                        "@jest/test-result": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "@types/stack-utils": "1.0.1",
+                        "chalk": "2.4.2",
+                        "micromatch": "3.1.10",
+                        "slash": "2.0.0",
+                        "stack-utils": "1.0.2"
                     }
                 },
                 "jest-mock": {
@@ -4955,7 +4955,7 @@
                     "integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0"
+                        "@jest/types": "24.8.0"
                     }
                 },
                 "jest-resolve": {
@@ -4964,11 +4964,11 @@
                     "integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "browser-resolve": "^1.11.3",
-                        "chalk": "^2.0.1",
-                        "jest-pnp-resolver": "^1.2.1",
-                        "realpath-native": "^1.1.0"
+                        "@jest/types": "24.8.0",
+                        "browser-resolve": "1.11.3",
+                        "chalk": "2.4.2",
+                        "jest-pnp-resolver": "1.2.1",
+                        "realpath-native": "1.1.0"
                     }
                 },
                 "jest-snapshot": {
@@ -4977,18 +4977,18 @@
                     "integrity": "sha512-5ehtWoc8oU9/cAPe6fez6QofVJLBKyqkY2+TlKTOf0VllBB/mqUNdARdcjlZrs9F1Cv+/HKoCS/BknT0+tmfPg==",
                     "dev": true,
                     "requires": {
-                        "@babel/types": "^7.0.0",
-                        "@jest/types": "^24.8.0",
-                        "chalk": "^2.0.1",
-                        "expect": "^24.8.0",
-                        "jest-diff": "^24.8.0",
-                        "jest-matcher-utils": "^24.8.0",
-                        "jest-message-util": "^24.8.0",
-                        "jest-resolve": "^24.8.0",
-                        "mkdirp": "^0.5.1",
-                        "natural-compare": "^1.4.0",
-                        "pretty-format": "^24.8.0",
-                        "semver": "^5.5.0"
+                        "@babel/types": "7.3.2",
+                        "@jest/types": "24.8.0",
+                        "chalk": "2.4.2",
+                        "expect": "24.8.0",
+                        "jest-diff": "24.8.0",
+                        "jest-matcher-utils": "24.8.0",
+                        "jest-message-util": "24.8.0",
+                        "jest-resolve": "24.8.0",
+                        "mkdirp": "0.5.1",
+                        "natural-compare": "1.4.0",
+                        "pretty-format": "24.8.0",
+                        "semver": "5.5.0"
                     }
                 },
                 "jest-util": {
@@ -4997,18 +4997,18 @@
                     "integrity": "sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==",
                     "dev": true,
                     "requires": {
-                        "@jest/console": "^24.7.1",
-                        "@jest/fake-timers": "^24.8.0",
-                        "@jest/source-map": "^24.3.0",
-                        "@jest/test-result": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "callsites": "^3.0.0",
-                        "chalk": "^2.0.1",
-                        "graceful-fs": "^4.1.15",
-                        "is-ci": "^2.0.0",
-                        "mkdirp": "^0.5.1",
-                        "slash": "^2.0.0",
-                        "source-map": "^0.6.0"
+                        "@jest/console": "24.7.1",
+                        "@jest/fake-timers": "24.8.0",
+                        "@jest/source-map": "24.3.0",
+                        "@jest/test-result": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "callsites": "3.0.0",
+                        "chalk": "2.4.2",
+                        "graceful-fs": "4.1.15",
+                        "is-ci": "2.0.0",
+                        "mkdirp": "0.5.1",
+                        "slash": "2.0.0",
+                        "source-map": "0.6.1"
                     }
                 },
                 "jest-worker": {
@@ -5017,8 +5017,8 @@
                     "integrity": "sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==",
                     "dev": true,
                     "requires": {
-                        "merge-stream": "^1.0.1",
-                        "supports-color": "^6.1.0"
+                        "merge-stream": "1.0.1",
+                        "supports-color": "6.1.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -5027,7 +5027,7 @@
                             "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
                             "dev": true,
                             "requires": {
-                                "has-flag": "^3.0.0"
+                                "has-flag": "3.0.0"
                             }
                         }
                     }
@@ -5038,10 +5038,10 @@
                     "integrity": "sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "ansi-regex": "^4.0.0",
-                        "ansi-styles": "^3.2.0",
-                        "react-is": "^16.8.4"
+                        "@jest/types": "24.8.0",
+                        "ansi-regex": "4.1.0",
+                        "ansi-styles": "3.2.1",
+                        "react-is": "16.8.4"
                     }
                 },
                 "source-map": {
@@ -5056,7 +5056,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -5067,7 +5067,7 @@
             "integrity": "sha512-cG0yRSK8A831LN8lIHxI3AblB40uhv0z+SsQdW3GoMMVcK+sJwrIIyax5tu3eHHNJ8Fu6IMDpnLda2jhn2pD/g==",
             "dev": true,
             "requires": {
-                "pretty-format": "^24.8.0"
+                "pretty-format": "24.8.0"
             },
             "dependencies": {
                 "@jest/types": {
@@ -5076,9 +5076,9 @@
                     "integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^1.1.1",
-                        "@types/yargs": "^12.0.9"
+                        "@types/istanbul-lib-coverage": "2.0.1",
+                        "@types/istanbul-reports": "1.1.1",
+                        "@types/yargs": "12.0.10"
                     }
                 },
                 "@types/istanbul-lib-coverage": {
@@ -5099,7 +5099,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.2"
                     }
                 },
                 "pretty-format": {
@@ -5108,10 +5108,10 @@
                     "integrity": "sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "ansi-regex": "^4.0.0",
-                        "ansi-styles": "^3.2.0",
-                        "react-is": "^16.8.4"
+                        "@jest/types": "24.8.0",
+                        "ansi-regex": "4.1.0",
+                        "ansi-styles": "3.2.1",
+                        "react-is": "16.8.4"
                     }
                 }
             }
@@ -5122,10 +5122,10 @@
             "integrity": "sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==",
             "dev": true,
             "requires": {
-                "chalk": "^2.0.1",
-                "jest-diff": "^24.8.0",
-                "jest-get-type": "^24.8.0",
-                "pretty-format": "^24.8.0"
+                "chalk": "2.4.2",
+                "jest-diff": "24.8.0",
+                "jest-get-type": "24.8.0",
+                "pretty-format": "24.8.0"
             }
         },
         "jest-message-util": {
@@ -5134,14 +5134,14 @@
             "integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "@jest/test-result": "^24.8.0",
-                "@jest/types": "^24.8.0",
-                "@types/stack-utils": "^1.0.1",
-                "chalk": "^2.0.1",
-                "micromatch": "^3.1.10",
-                "slash": "^2.0.0",
-                "stack-utils": "^1.0.1"
+                "@babel/code-frame": "7.0.0",
+                "@jest/test-result": "24.8.0",
+                "@jest/types": "24.8.0",
+                "@types/stack-utils": "1.0.1",
+                "chalk": "2.4.2",
+                "micromatch": "3.1.10",
+                "slash": "2.0.0",
+                "stack-utils": "1.0.2"
             }
         },
         "jest-mock": {
@@ -5150,7 +5150,7 @@
             "integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
             "dev": true,
             "requires": {
-                "@jest/types": "^24.8.0"
+                "@jest/types": "24.8.0"
             }
         },
         "jest-pnp-resolver": {
@@ -5171,11 +5171,11 @@
             "integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
             "dev": true,
             "requires": {
-                "@jest/types": "^24.8.0",
-                "browser-resolve": "^1.11.3",
-                "chalk": "^2.0.1",
-                "jest-pnp-resolver": "^1.2.1",
-                "realpath-native": "^1.1.0"
+                "@jest/types": "24.8.0",
+                "browser-resolve": "1.11.3",
+                "chalk": "2.4.2",
+                "jest-pnp-resolver": "1.2.1",
+                "realpath-native": "1.1.0"
             }
         },
         "jest-resolve-dependencies": {
@@ -5184,9 +5184,9 @@
             "integrity": "sha512-hyK1qfIf/krV+fSNyhyJeq3elVMhK9Eijlwy+j5jqmZ9QsxwKBiP6qukQxaHtK8k6zql/KYWwCTQ+fDGTIJauw==",
             "dev": true,
             "requires": {
-                "@jest/types": "^24.8.0",
-                "jest-regex-util": "^24.3.0",
-                "jest-snapshot": "^24.8.0"
+                "@jest/types": "24.8.0",
+                "jest-regex-util": "24.3.0",
+                "jest-snapshot": "24.8.0"
             },
             "dependencies": {
                 "@jest/console": {
@@ -5195,9 +5195,9 @@
                     "integrity": "sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==",
                     "dev": true,
                     "requires": {
-                        "@jest/source-map": "^24.3.0",
-                        "chalk": "^2.0.1",
-                        "slash": "^2.0.0"
+                        "@jest/source-map": "24.3.0",
+                        "chalk": "2.4.2",
+                        "slash": "2.0.0"
                     }
                 },
                 "@jest/test-result": {
@@ -5206,9 +5206,9 @@
                     "integrity": "sha512-+YdLlxwizlfqkFDh7Mc7ONPQAhA4YylU1s529vVM1rsf67vGZH/2GGm5uO8QzPeVyaVMobCQ7FTxl38QrKRlng==",
                     "dev": true,
                     "requires": {
-                        "@jest/console": "^24.7.1",
-                        "@jest/types": "^24.8.0",
-                        "@types/istanbul-lib-coverage": "^2.0.0"
+                        "@jest/console": "24.7.1",
+                        "@jest/types": "24.8.0",
+                        "@types/istanbul-lib-coverage": "2.0.1"
                     }
                 },
                 "@jest/types": {
@@ -5217,9 +5217,9 @@
                     "integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^1.1.1",
-                        "@types/yargs": "^12.0.9"
+                        "@types/istanbul-lib-coverage": "2.0.1",
+                        "@types/istanbul-reports": "1.1.1",
+                        "@types/yargs": "12.0.10"
                     }
                 },
                 "@types/istanbul-lib-coverage": {
@@ -5240,7 +5240,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.2"
                     }
                 },
                 "chalk": {
@@ -5249,9 +5249,9 @@
                     "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.5.0"
                     }
                 },
                 "expect": {
@@ -5260,12 +5260,12 @@
                     "integrity": "sha512-/zYvP8iMDrzaaxHVa724eJBCKqSHmO0FA7EDkBiRHxg6OipmMn1fN+C8T9L9K8yr7UONkOifu6+LLH+z76CnaA==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "ansi-styles": "^3.2.0",
-                        "jest-get-type": "^24.8.0",
-                        "jest-matcher-utils": "^24.8.0",
-                        "jest-message-util": "^24.8.0",
-                        "jest-regex-util": "^24.3.0"
+                        "@jest/types": "24.8.0",
+                        "ansi-styles": "3.2.1",
+                        "jest-get-type": "24.8.0",
+                        "jest-matcher-utils": "24.8.0",
+                        "jest-message-util": "24.8.0",
+                        "jest-regex-util": "24.3.0"
                     }
                 },
                 "jest-diff": {
@@ -5274,10 +5274,10 @@
                     "integrity": "sha512-wxetCEl49zUpJ/bvUmIFjd/o52J+yWcoc5ZyPq4/W1LUKGEhRYDIbP1KcF6t+PvqNrGAFk4/JhtxDq/Nnzs66g==",
                     "dev": true,
                     "requires": {
-                        "chalk": "^2.0.1",
-                        "diff-sequences": "^24.3.0",
-                        "jest-get-type": "^24.8.0",
-                        "pretty-format": "^24.8.0"
+                        "chalk": "2.4.2",
+                        "diff-sequences": "24.3.0",
+                        "jest-get-type": "24.8.0",
+                        "pretty-format": "24.8.0"
                     }
                 },
                 "jest-get-type": {
@@ -5292,10 +5292,10 @@
                     "integrity": "sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==",
                     "dev": true,
                     "requires": {
-                        "chalk": "^2.0.1",
-                        "jest-diff": "^24.8.0",
-                        "jest-get-type": "^24.8.0",
-                        "pretty-format": "^24.8.0"
+                        "chalk": "2.4.2",
+                        "jest-diff": "24.8.0",
+                        "jest-get-type": "24.8.0",
+                        "pretty-format": "24.8.0"
                     }
                 },
                 "jest-message-util": {
@@ -5304,14 +5304,14 @@
                     "integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
                     "dev": true,
                     "requires": {
-                        "@babel/code-frame": "^7.0.0",
-                        "@jest/test-result": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "@types/stack-utils": "^1.0.1",
-                        "chalk": "^2.0.1",
-                        "micromatch": "^3.1.10",
-                        "slash": "^2.0.0",
-                        "stack-utils": "^1.0.1"
+                        "@babel/code-frame": "7.0.0",
+                        "@jest/test-result": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "@types/stack-utils": "1.0.1",
+                        "chalk": "2.4.2",
+                        "micromatch": "3.1.10",
+                        "slash": "2.0.0",
+                        "stack-utils": "1.0.2"
                     }
                 },
                 "jest-resolve": {
@@ -5320,11 +5320,11 @@
                     "integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "browser-resolve": "^1.11.3",
-                        "chalk": "^2.0.1",
-                        "jest-pnp-resolver": "^1.2.1",
-                        "realpath-native": "^1.1.0"
+                        "@jest/types": "24.8.0",
+                        "browser-resolve": "1.11.3",
+                        "chalk": "2.4.2",
+                        "jest-pnp-resolver": "1.2.1",
+                        "realpath-native": "1.1.0"
                     }
                 },
                 "jest-snapshot": {
@@ -5333,18 +5333,18 @@
                     "integrity": "sha512-5ehtWoc8oU9/cAPe6fez6QofVJLBKyqkY2+TlKTOf0VllBB/mqUNdARdcjlZrs9F1Cv+/HKoCS/BknT0+tmfPg==",
                     "dev": true,
                     "requires": {
-                        "@babel/types": "^7.0.0",
-                        "@jest/types": "^24.8.0",
-                        "chalk": "^2.0.1",
-                        "expect": "^24.8.0",
-                        "jest-diff": "^24.8.0",
-                        "jest-matcher-utils": "^24.8.0",
-                        "jest-message-util": "^24.8.0",
-                        "jest-resolve": "^24.8.0",
-                        "mkdirp": "^0.5.1",
-                        "natural-compare": "^1.4.0",
-                        "pretty-format": "^24.8.0",
-                        "semver": "^5.5.0"
+                        "@babel/types": "7.3.2",
+                        "@jest/types": "24.8.0",
+                        "chalk": "2.4.2",
+                        "expect": "24.8.0",
+                        "jest-diff": "24.8.0",
+                        "jest-matcher-utils": "24.8.0",
+                        "jest-message-util": "24.8.0",
+                        "jest-resolve": "24.8.0",
+                        "mkdirp": "0.5.1",
+                        "natural-compare": "1.4.0",
+                        "pretty-format": "24.8.0",
+                        "semver": "5.5.0"
                     }
                 },
                 "pretty-format": {
@@ -5353,10 +5353,10 @@
                     "integrity": "sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "ansi-regex": "^4.0.0",
-                        "ansi-styles": "^3.2.0",
-                        "react-is": "^16.8.4"
+                        "@jest/types": "24.8.0",
+                        "ansi-regex": "4.1.0",
+                        "ansi-styles": "3.2.1",
+                        "react-is": "16.8.4"
                     }
                 },
                 "supports-color": {
@@ -5365,7 +5365,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -5376,25 +5376,25 @@
             "integrity": "sha512-utFqC5BaA3JmznbissSs95X1ZF+d+4WuOWwpM9+Ak356YtMhHE/GXUondZdcyAAOTBEsRGAgH/0TwLzfI9h7ow==",
             "dev": true,
             "requires": {
-                "@jest/console": "^24.7.1",
-                "@jest/environment": "^24.8.0",
-                "@jest/test-result": "^24.8.0",
-                "@jest/types": "^24.8.0",
-                "chalk": "^2.4.2",
-                "exit": "^0.1.2",
-                "graceful-fs": "^4.1.15",
-                "jest-config": "^24.8.0",
-                "jest-docblock": "^24.3.0",
-                "jest-haste-map": "^24.8.0",
-                "jest-jasmine2": "^24.8.0",
-                "jest-leak-detector": "^24.8.0",
-                "jest-message-util": "^24.8.0",
-                "jest-resolve": "^24.8.0",
-                "jest-runtime": "^24.8.0",
-                "jest-util": "^24.8.0",
-                "jest-worker": "^24.6.0",
-                "source-map-support": "^0.5.6",
-                "throat": "^4.0.0"
+                "@jest/console": "24.7.1",
+                "@jest/environment": "24.8.0",
+                "@jest/test-result": "24.8.0",
+                "@jest/types": "24.8.0",
+                "chalk": "2.4.2",
+                "exit": "0.1.2",
+                "graceful-fs": "4.1.15",
+                "jest-config": "24.8.0",
+                "jest-docblock": "24.3.0",
+                "jest-haste-map": "24.8.0",
+                "jest-jasmine2": "24.8.0",
+                "jest-leak-detector": "24.8.0",
+                "jest-message-util": "24.8.0",
+                "jest-resolve": "24.8.0",
+                "jest-runtime": "24.8.0",
+                "jest-util": "24.8.0",
+                "jest-worker": "24.6.0",
+                "source-map-support": "0.5.6",
+                "throat": "4.1.0"
             },
             "dependencies": {
                 "@jest/console": {
@@ -5403,9 +5403,9 @@
                     "integrity": "sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==",
                     "dev": true,
                     "requires": {
-                        "@jest/source-map": "^24.3.0",
-                        "chalk": "^2.0.1",
-                        "slash": "^2.0.0"
+                        "@jest/source-map": "24.3.0",
+                        "chalk": "2.4.2",
+                        "slash": "2.0.0"
                     }
                 },
                 "@jest/environment": {
@@ -5414,10 +5414,10 @@
                     "integrity": "sha512-vlGt2HLg7qM+vtBrSkjDxk9K0YtRBi7HfRFaDxoRtyi+DyVChzhF20duvpdAnKVBV6W5tym8jm0U9EfXbDk1tw==",
                     "dev": true,
                     "requires": {
-                        "@jest/fake-timers": "^24.8.0",
-                        "@jest/transform": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "jest-mock": "^24.8.0"
+                        "@jest/fake-timers": "24.8.0",
+                        "@jest/transform": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "jest-mock": "24.8.0"
                     }
                 },
                 "@jest/fake-timers": {
@@ -5426,9 +5426,9 @@
                     "integrity": "sha512-2M4d5MufVXwi6VzZhJ9f5S/wU4ud2ck0kxPof1Iz3zWx6Y+V2eJrES9jEktB6O3o/oEyk+il/uNu9PvASjWXQw==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "jest-message-util": "^24.8.0",
-                        "jest-mock": "^24.8.0"
+                        "@jest/types": "24.8.0",
+                        "jest-message-util": "24.8.0",
+                        "jest-mock": "24.8.0"
                     }
                 },
                 "@jest/test-result": {
@@ -5437,9 +5437,9 @@
                     "integrity": "sha512-+YdLlxwizlfqkFDh7Mc7ONPQAhA4YylU1s529vVM1rsf67vGZH/2GGm5uO8QzPeVyaVMobCQ7FTxl38QrKRlng==",
                     "dev": true,
                     "requires": {
-                        "@jest/console": "^24.7.1",
-                        "@jest/types": "^24.8.0",
-                        "@types/istanbul-lib-coverage": "^2.0.0"
+                        "@jest/console": "24.7.1",
+                        "@jest/types": "24.8.0",
+                        "@types/istanbul-lib-coverage": "2.0.1"
                     }
                 },
                 "@jest/transform": {
@@ -5448,20 +5448,20 @@
                     "integrity": "sha512-xBMfFUP7TortCs0O+Xtez2W7Zu1PLH9bvJgtraN1CDST6LBM/eTOZ9SfwS/lvV8yOfcDpFmwf9bq5cYbXvqsvA==",
                     "dev": true,
                     "requires": {
-                        "@babel/core": "^7.1.0",
-                        "@jest/types": "^24.8.0",
-                        "babel-plugin-istanbul": "^5.1.0",
-                        "chalk": "^2.0.1",
-                        "convert-source-map": "^1.4.0",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "graceful-fs": "^4.1.15",
-                        "jest-haste-map": "^24.8.0",
-                        "jest-regex-util": "^24.3.0",
-                        "jest-util": "^24.8.0",
-                        "micromatch": "^3.1.10",
-                        "realpath-native": "^1.1.0",
-                        "slash": "^2.0.0",
-                        "source-map": "^0.6.1",
+                        "@babel/core": "7.4.0",
+                        "@jest/types": "24.8.0",
+                        "babel-plugin-istanbul": "5.1.1",
+                        "chalk": "2.4.2",
+                        "convert-source-map": "1.6.0",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "graceful-fs": "4.1.15",
+                        "jest-haste-map": "24.8.0",
+                        "jest-regex-util": "24.3.0",
+                        "jest-util": "24.8.0",
+                        "micromatch": "3.1.10",
+                        "realpath-native": "1.1.0",
+                        "slash": "2.0.0",
+                        "source-map": "0.6.1",
                         "write-file-atomic": "2.4.1"
                     }
                 },
@@ -5471,9 +5471,9 @@
                     "integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^1.1.1",
-                        "@types/yargs": "^12.0.9"
+                        "@types/istanbul-lib-coverage": "2.0.1",
+                        "@types/istanbul-reports": "1.1.1",
+                        "@types/yargs": "12.0.10"
                     }
                 },
                 "@types/istanbul-lib-coverage": {
@@ -5488,7 +5488,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.2"
                     }
                 },
                 "chalk": {
@@ -5497,9 +5497,9 @@
                     "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.5.0"
                     }
                 },
                 "jest-haste-map": {
@@ -5508,18 +5508,18 @@
                     "integrity": "sha512-ZBPRGHdPt1rHajWelXdqygIDpJx8u3xOoLyUBWRW28r3tagrgoepPrzAozW7kW9HrQfhvmiv1tncsxqHJO1onQ==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "anymatch": "^2.0.0",
-                        "fb-watchman": "^2.0.0",
-                        "fsevents": "^1.2.7",
-                        "graceful-fs": "^4.1.15",
-                        "invariant": "^2.2.4",
-                        "jest-serializer": "^24.4.0",
-                        "jest-util": "^24.8.0",
-                        "jest-worker": "^24.6.0",
-                        "micromatch": "^3.1.10",
-                        "sane": "^4.0.3",
-                        "walker": "^1.0.7"
+                        "@jest/types": "24.8.0",
+                        "anymatch": "2.0.0",
+                        "fb-watchman": "2.0.0",
+                        "fsevents": "1.2.9",
+                        "graceful-fs": "4.1.15",
+                        "invariant": "2.2.4",
+                        "jest-serializer": "24.4.0",
+                        "jest-util": "24.8.0",
+                        "jest-worker": "24.6.0",
+                        "micromatch": "3.1.10",
+                        "sane": "4.1.0",
+                        "walker": "1.0.7"
                     }
                 },
                 "jest-message-util": {
@@ -5528,14 +5528,14 @@
                     "integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
                     "dev": true,
                     "requires": {
-                        "@babel/code-frame": "^7.0.0",
-                        "@jest/test-result": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "@types/stack-utils": "^1.0.1",
-                        "chalk": "^2.0.1",
-                        "micromatch": "^3.1.10",
-                        "slash": "^2.0.0",
-                        "stack-utils": "^1.0.1"
+                        "@babel/code-frame": "7.0.0",
+                        "@jest/test-result": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "@types/stack-utils": "1.0.1",
+                        "chalk": "2.4.2",
+                        "micromatch": "3.1.10",
+                        "slash": "2.0.0",
+                        "stack-utils": "1.0.2"
                     }
                 },
                 "jest-mock": {
@@ -5544,7 +5544,7 @@
                     "integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0"
+                        "@jest/types": "24.8.0"
                     }
                 },
                 "jest-resolve": {
@@ -5553,11 +5553,11 @@
                     "integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "browser-resolve": "^1.11.3",
-                        "chalk": "^2.0.1",
-                        "jest-pnp-resolver": "^1.2.1",
-                        "realpath-native": "^1.1.0"
+                        "@jest/types": "24.8.0",
+                        "browser-resolve": "1.11.3",
+                        "chalk": "2.4.2",
+                        "jest-pnp-resolver": "1.2.1",
+                        "realpath-native": "1.1.0"
                     }
                 },
                 "jest-util": {
@@ -5566,18 +5566,18 @@
                     "integrity": "sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==",
                     "dev": true,
                     "requires": {
-                        "@jest/console": "^24.7.1",
-                        "@jest/fake-timers": "^24.8.0",
-                        "@jest/source-map": "^24.3.0",
-                        "@jest/test-result": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "callsites": "^3.0.0",
-                        "chalk": "^2.0.1",
-                        "graceful-fs": "^4.1.15",
-                        "is-ci": "^2.0.0",
-                        "mkdirp": "^0.5.1",
-                        "slash": "^2.0.0",
-                        "source-map": "^0.6.0"
+                        "@jest/console": "24.7.1",
+                        "@jest/fake-timers": "24.8.0",
+                        "@jest/source-map": "24.3.0",
+                        "@jest/test-result": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "callsites": "3.0.0",
+                        "chalk": "2.4.2",
+                        "graceful-fs": "4.1.15",
+                        "is-ci": "2.0.0",
+                        "mkdirp": "0.5.1",
+                        "slash": "2.0.0",
+                        "source-map": "0.6.1"
                     }
                 },
                 "jest-worker": {
@@ -5586,8 +5586,8 @@
                     "integrity": "sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==",
                     "dev": true,
                     "requires": {
-                        "merge-stream": "^1.0.1",
-                        "supports-color": "^6.1.0"
+                        "merge-stream": "1.0.1",
+                        "supports-color": "6.1.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -5596,7 +5596,7 @@
                             "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
                             "dev": true,
                             "requires": {
-                                "has-flag": "^3.0.0"
+                                "has-flag": "3.0.0"
                             }
                         }
                     }
@@ -5613,7 +5613,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -5624,29 +5624,29 @@
             "integrity": "sha512-Mq0aIXhvO/3bX44ccT+czU1/57IgOMyy80oM0XR/nyD5zgBcesF84BPabZi39pJVA6UXw+fY2Q1N+4BiVUBWOA==",
             "dev": true,
             "requires": {
-                "@jest/console": "^24.7.1",
-                "@jest/environment": "^24.8.0",
-                "@jest/source-map": "^24.3.0",
-                "@jest/transform": "^24.8.0",
-                "@jest/types": "^24.8.0",
-                "@types/yargs": "^12.0.2",
-                "chalk": "^2.0.1",
-                "exit": "^0.1.2",
-                "glob": "^7.1.3",
-                "graceful-fs": "^4.1.15",
-                "jest-config": "^24.8.0",
-                "jest-haste-map": "^24.8.0",
-                "jest-message-util": "^24.8.0",
-                "jest-mock": "^24.8.0",
-                "jest-regex-util": "^24.3.0",
-                "jest-resolve": "^24.8.0",
-                "jest-snapshot": "^24.8.0",
-                "jest-util": "^24.8.0",
-                "jest-validate": "^24.8.0",
-                "realpath-native": "^1.1.0",
-                "slash": "^2.0.0",
-                "strip-bom": "^3.0.0",
-                "yargs": "^12.0.2"
+                "@jest/console": "24.7.1",
+                "@jest/environment": "24.8.0",
+                "@jest/source-map": "24.3.0",
+                "@jest/transform": "24.8.0",
+                "@jest/types": "24.8.0",
+                "@types/yargs": "12.0.10",
+                "chalk": "2.4.2",
+                "exit": "0.1.2",
+                "glob": "7.1.3",
+                "graceful-fs": "4.1.15",
+                "jest-config": "24.8.0",
+                "jest-haste-map": "24.8.0",
+                "jest-message-util": "24.8.0",
+                "jest-mock": "24.8.0",
+                "jest-regex-util": "24.3.0",
+                "jest-resolve": "24.8.0",
+                "jest-snapshot": "24.8.0",
+                "jest-util": "24.8.0",
+                "jest-validate": "24.8.0",
+                "realpath-native": "1.1.0",
+                "slash": "2.0.0",
+                "strip-bom": "3.0.0",
+                "yargs": "12.0.5"
             },
             "dependencies": {
                 "@jest/console": {
@@ -5655,9 +5655,9 @@
                     "integrity": "sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==",
                     "dev": true,
                     "requires": {
-                        "@jest/source-map": "^24.3.0",
-                        "chalk": "^2.0.1",
-                        "slash": "^2.0.0"
+                        "@jest/source-map": "24.3.0",
+                        "chalk": "2.4.2",
+                        "slash": "2.0.0"
                     }
                 },
                 "@jest/environment": {
@@ -5666,10 +5666,10 @@
                     "integrity": "sha512-vlGt2HLg7qM+vtBrSkjDxk9K0YtRBi7HfRFaDxoRtyi+DyVChzhF20duvpdAnKVBV6W5tym8jm0U9EfXbDk1tw==",
                     "dev": true,
                     "requires": {
-                        "@jest/fake-timers": "^24.8.0",
-                        "@jest/transform": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "jest-mock": "^24.8.0"
+                        "@jest/fake-timers": "24.8.0",
+                        "@jest/transform": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "jest-mock": "24.8.0"
                     }
                 },
                 "@jest/fake-timers": {
@@ -5678,9 +5678,9 @@
                     "integrity": "sha512-2M4d5MufVXwi6VzZhJ9f5S/wU4ud2ck0kxPof1Iz3zWx6Y+V2eJrES9jEktB6O3o/oEyk+il/uNu9PvASjWXQw==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "jest-message-util": "^24.8.0",
-                        "jest-mock": "^24.8.0"
+                        "@jest/types": "24.8.0",
+                        "jest-message-util": "24.8.0",
+                        "jest-mock": "24.8.0"
                     }
                 },
                 "@jest/test-result": {
@@ -5689,9 +5689,9 @@
                     "integrity": "sha512-+YdLlxwizlfqkFDh7Mc7ONPQAhA4YylU1s529vVM1rsf67vGZH/2GGm5uO8QzPeVyaVMobCQ7FTxl38QrKRlng==",
                     "dev": true,
                     "requires": {
-                        "@jest/console": "^24.7.1",
-                        "@jest/types": "^24.8.0",
-                        "@types/istanbul-lib-coverage": "^2.0.0"
+                        "@jest/console": "24.7.1",
+                        "@jest/types": "24.8.0",
+                        "@types/istanbul-lib-coverage": "2.0.1"
                     }
                 },
                 "@jest/transform": {
@@ -5700,20 +5700,20 @@
                     "integrity": "sha512-xBMfFUP7TortCs0O+Xtez2W7Zu1PLH9bvJgtraN1CDST6LBM/eTOZ9SfwS/lvV8yOfcDpFmwf9bq5cYbXvqsvA==",
                     "dev": true,
                     "requires": {
-                        "@babel/core": "^7.1.0",
-                        "@jest/types": "^24.8.0",
-                        "babel-plugin-istanbul": "^5.1.0",
-                        "chalk": "^2.0.1",
-                        "convert-source-map": "^1.4.0",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "graceful-fs": "^4.1.15",
-                        "jest-haste-map": "^24.8.0",
-                        "jest-regex-util": "^24.3.0",
-                        "jest-util": "^24.8.0",
-                        "micromatch": "^3.1.10",
-                        "realpath-native": "^1.1.0",
-                        "slash": "^2.0.0",
-                        "source-map": "^0.6.1",
+                        "@babel/core": "7.4.0",
+                        "@jest/types": "24.8.0",
+                        "babel-plugin-istanbul": "5.1.1",
+                        "chalk": "2.4.2",
+                        "convert-source-map": "1.6.0",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "graceful-fs": "4.1.15",
+                        "jest-haste-map": "24.8.0",
+                        "jest-regex-util": "24.3.0",
+                        "jest-util": "24.8.0",
+                        "micromatch": "3.1.10",
+                        "realpath-native": "1.1.0",
+                        "slash": "2.0.0",
+                        "source-map": "0.6.1",
                         "write-file-atomic": "2.4.1"
                     }
                 },
@@ -5723,9 +5723,9 @@
                     "integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^1.1.1",
-                        "@types/yargs": "^12.0.9"
+                        "@types/istanbul-lib-coverage": "2.0.1",
+                        "@types/istanbul-reports": "1.1.1",
+                        "@types/yargs": "12.0.10"
                     }
                 },
                 "@types/istanbul-lib-coverage": {
@@ -5746,7 +5746,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.2"
                     }
                 },
                 "chalk": {
@@ -5755,9 +5755,9 @@
                     "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.5.0"
                     }
                 },
                 "expect": {
@@ -5766,12 +5766,12 @@
                     "integrity": "sha512-/zYvP8iMDrzaaxHVa724eJBCKqSHmO0FA7EDkBiRHxg6OipmMn1fN+C8T9L9K8yr7UONkOifu6+LLH+z76CnaA==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "ansi-styles": "^3.2.0",
-                        "jest-get-type": "^24.8.0",
-                        "jest-matcher-utils": "^24.8.0",
-                        "jest-message-util": "^24.8.0",
-                        "jest-regex-util": "^24.3.0"
+                        "@jest/types": "24.8.0",
+                        "ansi-styles": "3.2.1",
+                        "jest-get-type": "24.8.0",
+                        "jest-matcher-utils": "24.8.0",
+                        "jest-message-util": "24.8.0",
+                        "jest-regex-util": "24.3.0"
                     }
                 },
                 "glob": {
@@ -5780,12 +5780,12 @@
                     "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 },
                 "jest-diff": {
@@ -5794,10 +5794,10 @@
                     "integrity": "sha512-wxetCEl49zUpJ/bvUmIFjd/o52J+yWcoc5ZyPq4/W1LUKGEhRYDIbP1KcF6t+PvqNrGAFk4/JhtxDq/Nnzs66g==",
                     "dev": true,
                     "requires": {
-                        "chalk": "^2.0.1",
-                        "diff-sequences": "^24.3.0",
-                        "jest-get-type": "^24.8.0",
-                        "pretty-format": "^24.8.0"
+                        "chalk": "2.4.2",
+                        "diff-sequences": "24.3.0",
+                        "jest-get-type": "24.8.0",
+                        "pretty-format": "24.8.0"
                     }
                 },
                 "jest-get-type": {
@@ -5812,18 +5812,18 @@
                     "integrity": "sha512-ZBPRGHdPt1rHajWelXdqygIDpJx8u3xOoLyUBWRW28r3tagrgoepPrzAozW7kW9HrQfhvmiv1tncsxqHJO1onQ==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "anymatch": "^2.0.0",
-                        "fb-watchman": "^2.0.0",
-                        "fsevents": "^1.2.7",
-                        "graceful-fs": "^4.1.15",
-                        "invariant": "^2.2.4",
-                        "jest-serializer": "^24.4.0",
-                        "jest-util": "^24.8.0",
-                        "jest-worker": "^24.6.0",
-                        "micromatch": "^3.1.10",
-                        "sane": "^4.0.3",
-                        "walker": "^1.0.7"
+                        "@jest/types": "24.8.0",
+                        "anymatch": "2.0.0",
+                        "fb-watchman": "2.0.0",
+                        "fsevents": "1.2.9",
+                        "graceful-fs": "4.1.15",
+                        "invariant": "2.2.4",
+                        "jest-serializer": "24.4.0",
+                        "jest-util": "24.8.0",
+                        "jest-worker": "24.6.0",
+                        "micromatch": "3.1.10",
+                        "sane": "4.1.0",
+                        "walker": "1.0.7"
                     }
                 },
                 "jest-matcher-utils": {
@@ -5832,10 +5832,10 @@
                     "integrity": "sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==",
                     "dev": true,
                     "requires": {
-                        "chalk": "^2.0.1",
-                        "jest-diff": "^24.8.0",
-                        "jest-get-type": "^24.8.0",
-                        "pretty-format": "^24.8.0"
+                        "chalk": "2.4.2",
+                        "jest-diff": "24.8.0",
+                        "jest-get-type": "24.8.0",
+                        "pretty-format": "24.8.0"
                     }
                 },
                 "jest-message-util": {
@@ -5844,14 +5844,14 @@
                     "integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
                     "dev": true,
                     "requires": {
-                        "@babel/code-frame": "^7.0.0",
-                        "@jest/test-result": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "@types/stack-utils": "^1.0.1",
-                        "chalk": "^2.0.1",
-                        "micromatch": "^3.1.10",
-                        "slash": "^2.0.0",
-                        "stack-utils": "^1.0.1"
+                        "@babel/code-frame": "7.0.0",
+                        "@jest/test-result": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "@types/stack-utils": "1.0.1",
+                        "chalk": "2.4.2",
+                        "micromatch": "3.1.10",
+                        "slash": "2.0.0",
+                        "stack-utils": "1.0.2"
                     }
                 },
                 "jest-mock": {
@@ -5860,7 +5860,7 @@
                     "integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0"
+                        "@jest/types": "24.8.0"
                     }
                 },
                 "jest-resolve": {
@@ -5869,11 +5869,11 @@
                     "integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "browser-resolve": "^1.11.3",
-                        "chalk": "^2.0.1",
-                        "jest-pnp-resolver": "^1.2.1",
-                        "realpath-native": "^1.1.0"
+                        "@jest/types": "24.8.0",
+                        "browser-resolve": "1.11.3",
+                        "chalk": "2.4.2",
+                        "jest-pnp-resolver": "1.2.1",
+                        "realpath-native": "1.1.0"
                     }
                 },
                 "jest-snapshot": {
@@ -5882,18 +5882,18 @@
                     "integrity": "sha512-5ehtWoc8oU9/cAPe6fez6QofVJLBKyqkY2+TlKTOf0VllBB/mqUNdARdcjlZrs9F1Cv+/HKoCS/BknT0+tmfPg==",
                     "dev": true,
                     "requires": {
-                        "@babel/types": "^7.0.0",
-                        "@jest/types": "^24.8.0",
-                        "chalk": "^2.0.1",
-                        "expect": "^24.8.0",
-                        "jest-diff": "^24.8.0",
-                        "jest-matcher-utils": "^24.8.0",
-                        "jest-message-util": "^24.8.0",
-                        "jest-resolve": "^24.8.0",
-                        "mkdirp": "^0.5.1",
-                        "natural-compare": "^1.4.0",
-                        "pretty-format": "^24.8.0",
-                        "semver": "^5.5.0"
+                        "@babel/types": "7.3.2",
+                        "@jest/types": "24.8.0",
+                        "chalk": "2.4.2",
+                        "expect": "24.8.0",
+                        "jest-diff": "24.8.0",
+                        "jest-matcher-utils": "24.8.0",
+                        "jest-message-util": "24.8.0",
+                        "jest-resolve": "24.8.0",
+                        "mkdirp": "0.5.1",
+                        "natural-compare": "1.4.0",
+                        "pretty-format": "24.8.0",
+                        "semver": "5.5.0"
                     }
                 },
                 "jest-util": {
@@ -5902,18 +5902,18 @@
                     "integrity": "sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==",
                     "dev": true,
                     "requires": {
-                        "@jest/console": "^24.7.1",
-                        "@jest/fake-timers": "^24.8.0",
-                        "@jest/source-map": "^24.3.0",
-                        "@jest/test-result": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "callsites": "^3.0.0",
-                        "chalk": "^2.0.1",
-                        "graceful-fs": "^4.1.15",
-                        "is-ci": "^2.0.0",
-                        "mkdirp": "^0.5.1",
-                        "slash": "^2.0.0",
-                        "source-map": "^0.6.0"
+                        "@jest/console": "24.7.1",
+                        "@jest/fake-timers": "24.8.0",
+                        "@jest/source-map": "24.3.0",
+                        "@jest/test-result": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "callsites": "3.0.0",
+                        "chalk": "2.4.2",
+                        "graceful-fs": "4.1.15",
+                        "is-ci": "2.0.0",
+                        "mkdirp": "0.5.1",
+                        "slash": "2.0.0",
+                        "source-map": "0.6.1"
                     }
                 },
                 "jest-worker": {
@@ -5922,8 +5922,8 @@
                     "integrity": "sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==",
                     "dev": true,
                     "requires": {
-                        "merge-stream": "^1.0.1",
-                        "supports-color": "^6.1.0"
+                        "merge-stream": "1.0.1",
+                        "supports-color": "6.1.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -5932,7 +5932,7 @@
                             "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
                             "dev": true,
                             "requires": {
-                                "has-flag": "^3.0.0"
+                                "has-flag": "3.0.0"
                             }
                         }
                     }
@@ -5943,10 +5943,10 @@
                     "integrity": "sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "ansi-regex": "^4.0.0",
-                        "ansi-styles": "^3.2.0",
-                        "react-is": "^16.8.4"
+                        "@jest/types": "24.8.0",
+                        "ansi-regex": "4.1.0",
+                        "ansi-styles": "3.2.1",
+                        "react-is": "16.8.4"
                     }
                 },
                 "source-map": {
@@ -5961,7 +5961,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -5978,18 +5978,18 @@
             "integrity": "sha512-5ehtWoc8oU9/cAPe6fez6QofVJLBKyqkY2+TlKTOf0VllBB/mqUNdARdcjlZrs9F1Cv+/HKoCS/BknT0+tmfPg==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0",
-                "@jest/types": "^24.8.0",
-                "chalk": "^2.0.1",
-                "expect": "^24.8.0",
-                "jest-diff": "^24.8.0",
-                "jest-matcher-utils": "^24.8.0",
-                "jest-message-util": "^24.8.0",
-                "jest-resolve": "^24.8.0",
-                "mkdirp": "^0.5.1",
-                "natural-compare": "^1.4.0",
-                "pretty-format": "^24.8.0",
-                "semver": "^5.5.0"
+                "@babel/types": "7.3.2",
+                "@jest/types": "24.8.0",
+                "chalk": "2.4.2",
+                "expect": "24.8.0",
+                "jest-diff": "24.8.0",
+                "jest-matcher-utils": "24.8.0",
+                "jest-message-util": "24.8.0",
+                "jest-resolve": "24.8.0",
+                "mkdirp": "0.5.1",
+                "natural-compare": "1.4.0",
+                "pretty-format": "24.8.0",
+                "semver": "5.5.0"
             }
         },
         "jest-util": {
@@ -5998,18 +5998,18 @@
             "integrity": "sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==",
             "dev": true,
             "requires": {
-                "@jest/console": "^24.7.1",
-                "@jest/fake-timers": "^24.8.0",
-                "@jest/source-map": "^24.3.0",
-                "@jest/test-result": "^24.8.0",
-                "@jest/types": "^24.8.0",
-                "callsites": "^3.0.0",
-                "chalk": "^2.0.1",
-                "graceful-fs": "^4.1.15",
-                "is-ci": "^2.0.0",
-                "mkdirp": "^0.5.1",
-                "slash": "^2.0.0",
-                "source-map": "^0.6.0"
+                "@jest/console": "24.7.1",
+                "@jest/fake-timers": "24.8.0",
+                "@jest/source-map": "24.3.0",
+                "@jest/test-result": "24.8.0",
+                "@jest/types": "24.8.0",
+                "callsites": "3.0.0",
+                "chalk": "2.4.2",
+                "graceful-fs": "4.1.15",
+                "is-ci": "2.0.0",
+                "mkdirp": "0.5.1",
+                "slash": "2.0.0",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "source-map": {
@@ -6026,12 +6026,12 @@
             "integrity": "sha512-+/N7VOEMW1Vzsrk3UWBDYTExTPwf68tavEPKDnJzrC6UlHtUDU/fuEdXqFoHzv9XnQ+zW6X3qMZhJ3YexfeLDA==",
             "dev": true,
             "requires": {
-                "@jest/types": "^24.8.0",
-                "camelcase": "^5.0.0",
-                "chalk": "^2.0.1",
-                "jest-get-type": "^24.8.0",
-                "leven": "^2.1.0",
-                "pretty-format": "^24.8.0"
+                "@jest/types": "24.8.0",
+                "camelcase": "5.3.1",
+                "chalk": "2.4.2",
+                "jest-get-type": "24.8.0",
+                "leven": "2.1.0",
+                "pretty-format": "24.8.0"
             },
             "dependencies": {
                 "@jest/types": {
@@ -6040,9 +6040,9 @@
                     "integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^1.1.1",
-                        "@types/yargs": "^12.0.9"
+                        "@types/istanbul-lib-coverage": "2.0.1",
+                        "@types/istanbul-reports": "1.1.1",
+                        "@types/yargs": "12.0.10"
                     }
                 },
                 "@types/istanbul-lib-coverage": {
@@ -6063,7 +6063,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.2"
                     }
                 },
                 "chalk": {
@@ -6072,9 +6072,9 @@
                     "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.5.0"
                     }
                 },
                 "jest-get-type": {
@@ -6089,10 +6089,10 @@
                     "integrity": "sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "ansi-regex": "^4.0.0",
-                        "ansi-styles": "^3.2.0",
-                        "react-is": "^16.8.4"
+                        "@jest/types": "24.8.0",
+                        "ansi-regex": "4.1.0",
+                        "ansi-styles": "3.2.1",
+                        "react-is": "16.8.4"
                     }
                 },
                 "supports-color": {
@@ -6101,7 +6101,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -6112,13 +6112,13 @@
             "integrity": "sha512-SBjwHt5NedQoVu54M5GEx7cl7IGEFFznvd/HNT8ier7cCAx/Qgu9ZMlaTQkvK22G1YOpcWBLQPFSImmxdn3DAw==",
             "dev": true,
             "requires": {
-                "@jest/test-result": "^24.8.0",
-                "@jest/types": "^24.8.0",
-                "@types/yargs": "^12.0.9",
-                "ansi-escapes": "^3.0.0",
-                "chalk": "^2.0.1",
-                "jest-util": "^24.8.0",
-                "string-length": "^2.0.0"
+                "@jest/test-result": "24.8.0",
+                "@jest/types": "24.8.0",
+                "@types/yargs": "12.0.10",
+                "ansi-escapes": "3.2.0",
+                "chalk": "2.4.2",
+                "jest-util": "24.8.0",
+                "string-length": "2.0.0"
             },
             "dependencies": {
                 "@jest/console": {
@@ -6127,9 +6127,9 @@
                     "integrity": "sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==",
                     "dev": true,
                     "requires": {
-                        "@jest/source-map": "^24.3.0",
-                        "chalk": "^2.0.1",
-                        "slash": "^2.0.0"
+                        "@jest/source-map": "24.3.0",
+                        "chalk": "2.4.2",
+                        "slash": "2.0.0"
                     }
                 },
                 "@jest/fake-timers": {
@@ -6138,9 +6138,9 @@
                     "integrity": "sha512-2M4d5MufVXwi6VzZhJ9f5S/wU4ud2ck0kxPof1Iz3zWx6Y+V2eJrES9jEktB6O3o/oEyk+il/uNu9PvASjWXQw==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0",
-                        "jest-message-util": "^24.8.0",
-                        "jest-mock": "^24.8.0"
+                        "@jest/types": "24.8.0",
+                        "jest-message-util": "24.8.0",
+                        "jest-mock": "24.8.0"
                     }
                 },
                 "@jest/test-result": {
@@ -6149,9 +6149,9 @@
                     "integrity": "sha512-+YdLlxwizlfqkFDh7Mc7ONPQAhA4YylU1s529vVM1rsf67vGZH/2GGm5uO8QzPeVyaVMobCQ7FTxl38QrKRlng==",
                     "dev": true,
                     "requires": {
-                        "@jest/console": "^24.7.1",
-                        "@jest/types": "^24.8.0",
-                        "@types/istanbul-lib-coverage": "^2.0.0"
+                        "@jest/console": "24.7.1",
+                        "@jest/types": "24.8.0",
+                        "@types/istanbul-lib-coverage": "2.0.1"
                     }
                 },
                 "@jest/types": {
@@ -6160,9 +6160,9 @@
                     "integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
                     "dev": true,
                     "requires": {
-                        "@types/istanbul-lib-coverage": "^2.0.0",
-                        "@types/istanbul-reports": "^1.1.1",
-                        "@types/yargs": "^12.0.9"
+                        "@types/istanbul-lib-coverage": "2.0.1",
+                        "@types/istanbul-reports": "1.1.1",
+                        "@types/yargs": "12.0.10"
                     }
                 },
                 "@types/istanbul-lib-coverage": {
@@ -6177,7 +6177,7 @@
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "^1.9.0"
+                        "color-convert": "1.9.2"
                     }
                 },
                 "chalk": {
@@ -6186,9 +6186,9 @@
                     "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "3.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "supports-color": "5.5.0"
                     }
                 },
                 "jest-message-util": {
@@ -6197,14 +6197,14 @@
                     "integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
                     "dev": true,
                     "requires": {
-                        "@babel/code-frame": "^7.0.0",
-                        "@jest/test-result": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "@types/stack-utils": "^1.0.1",
-                        "chalk": "^2.0.1",
-                        "micromatch": "^3.1.10",
-                        "slash": "^2.0.0",
-                        "stack-utils": "^1.0.1"
+                        "@babel/code-frame": "7.0.0",
+                        "@jest/test-result": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "@types/stack-utils": "1.0.1",
+                        "chalk": "2.4.2",
+                        "micromatch": "3.1.10",
+                        "slash": "2.0.0",
+                        "stack-utils": "1.0.2"
                     }
                 },
                 "jest-mock": {
@@ -6213,7 +6213,7 @@
                     "integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
                     "dev": true,
                     "requires": {
-                        "@jest/types": "^24.8.0"
+                        "@jest/types": "24.8.0"
                     }
                 },
                 "jest-util": {
@@ -6222,18 +6222,18 @@
                     "integrity": "sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==",
                     "dev": true,
                     "requires": {
-                        "@jest/console": "^24.7.1",
-                        "@jest/fake-timers": "^24.8.0",
-                        "@jest/source-map": "^24.3.0",
-                        "@jest/test-result": "^24.8.0",
-                        "@jest/types": "^24.8.0",
-                        "callsites": "^3.0.0",
-                        "chalk": "^2.0.1",
-                        "graceful-fs": "^4.1.15",
-                        "is-ci": "^2.0.0",
-                        "mkdirp": "^0.5.1",
-                        "slash": "^2.0.0",
-                        "source-map": "^0.6.0"
+                        "@jest/console": "24.7.1",
+                        "@jest/fake-timers": "24.8.0",
+                        "@jest/source-map": "24.3.0",
+                        "@jest/test-result": "24.8.0",
+                        "@jest/types": "24.8.0",
+                        "callsites": "3.0.0",
+                        "chalk": "2.4.2",
+                        "graceful-fs": "4.1.15",
+                        "is-ci": "2.0.0",
+                        "mkdirp": "0.5.1",
+                        "slash": "2.0.0",
+                        "source-map": "0.6.1"
                     }
                 },
                 "source-map": {
@@ -6248,7 +6248,7 @@
                     "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -6259,8 +6259,8 @@
             "integrity": "sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==",
             "dev": true,
             "requires": {
-                "merge-stream": "^1.0.1",
-                "supports-color": "^6.1.0"
+                "merge-stream": "1.0.1",
+                "supports-color": "6.1.0"
             },
             "dependencies": {
                 "supports-color": {
@@ -6269,7 +6269,7 @@
                     "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "^3.0.0"
+                        "has-flag": "3.0.0"
                     }
                 }
             }
@@ -6286,8 +6286,8 @@
             "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
             "dev": true,
             "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
+                "argparse": "1.0.10",
+                "esprima": "4.0.1"
             }
         },
         "jsbn": {
@@ -6302,32 +6302,32 @@
             "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
             "dev": true,
             "requires": {
-                "abab": "^2.0.0",
-                "acorn": "^5.5.3",
-                "acorn-globals": "^4.1.0",
-                "array-equal": "^1.0.0",
-                "cssom": ">= 0.3.2 < 0.4.0",
-                "cssstyle": "^1.0.0",
-                "data-urls": "^1.0.0",
-                "domexception": "^1.0.1",
-                "escodegen": "^1.9.1",
-                "html-encoding-sniffer": "^1.0.2",
-                "left-pad": "^1.3.0",
-                "nwsapi": "^2.0.7",
+                "abab": "2.0.0",
+                "acorn": "5.7.3",
+                "acorn-globals": "4.3.2",
+                "array-equal": "1.0.0",
+                "cssom": "0.3.6",
+                "cssstyle": "1.2.2",
+                "data-urls": "1.1.0",
+                "domexception": "1.0.1",
+                "escodegen": "1.11.1",
+                "html-encoding-sniffer": "1.0.2",
+                "left-pad": "1.3.0",
+                "nwsapi": "2.1.4",
                 "parse5": "4.0.0",
-                "pn": "^1.1.0",
-                "request": "^2.87.0",
-                "request-promise-native": "^1.0.5",
-                "sax": "^1.2.4",
-                "symbol-tree": "^3.2.2",
-                "tough-cookie": "^2.3.4",
-                "w3c-hr-time": "^1.0.1",
-                "webidl-conversions": "^4.0.2",
-                "whatwg-encoding": "^1.0.3",
-                "whatwg-mimetype": "^2.1.0",
-                "whatwg-url": "^6.4.1",
-                "ws": "^5.2.0",
-                "xml-name-validator": "^3.0.0"
+                "pn": "1.1.0",
+                "request": "2.88.0",
+                "request-promise-native": "1.0.7",
+                "sax": "1.2.4",
+                "symbol-tree": "3.2.2",
+                "tough-cookie": "2.5.0",
+                "w3c-hr-time": "1.0.1",
+                "webidl-conversions": "4.0.2",
+                "whatwg-encoding": "1.0.5",
+                "whatwg-mimetype": "2.3.0",
+                "whatwg-url": "6.5.0",
+                "ws": "5.2.2",
+                "xml-name-validator": "3.0.0"
             }
         },
         "jsesc": {
@@ -6366,7 +6366,7 @@
             "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
             "dev": true,
             "requires": {
-                "minimist": "^1.2.0"
+                "minimist": "1.2.0"
             }
         },
         "jsprim": {
@@ -6399,7 +6399,7 @@
             "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
             "dev": true,
             "requires": {
-                "invert-kv": "^2.0.0"
+                "invert-kv": "2.0.0"
             }
         },
         "left-pad": {
@@ -6420,8 +6420,8 @@
             "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
             "dev": true,
             "requires": {
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2"
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2"
             }
         },
         "load-json-file": {
@@ -6430,10 +6430,10 @@
             "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "parse-json": "^4.0.0",
-                "pify": "^3.0.0",
-                "strip-bom": "^3.0.0"
+                "graceful-fs": "4.1.15",
+                "parse-json": "4.0.0",
+                "pify": "3.0.0",
+                "strip-bom": "3.0.0"
             }
         },
         "locate-path": {
@@ -6442,8 +6442,8 @@
             "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
             "dev": true,
             "requires": {
-                "p-locate": "^3.0.0",
-                "path-exists": "^3.0.0"
+                "p-locate": "3.0.0",
+                "path-exists": "3.0.0"
             }
         },
         "lodash": {
@@ -6464,7 +6464,7 @@
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
             "dev": true,
             "requires": {
-                "js-tokens": "^3.0.0 || ^4.0.0"
+                "js-tokens": "3.0.2"
             }
         },
         "make-dir": {
@@ -6473,8 +6473,8 @@
             "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
             "dev": true,
             "requires": {
-                "pify": "^4.0.1",
-                "semver": "^5.6.0"
+                "pify": "4.0.1",
+                "semver": "5.7.0"
             },
             "dependencies": {
                 "pify": {
@@ -6503,7 +6503,7 @@
             "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
             "dev": true,
             "requires": {
-                "tmpl": "1.0.x"
+                "tmpl": "1.0.4"
             }
         },
         "map-age-cleaner": {
@@ -6512,7 +6512,7 @@
             "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
             "dev": true,
             "requires": {
-                "p-defer": "^1.0.0"
+                "p-defer": "1.0.0"
             }
         },
         "map-cache": {
@@ -6527,7 +6527,7 @@
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
             "dev": true,
             "requires": {
-                "object-visit": "^1.0.0"
+                "object-visit": "1.0.1"
             }
         },
         "mem": {
@@ -6536,9 +6536,9 @@
             "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
             "dev": true,
             "requires": {
-                "map-age-cleaner": "^0.1.1",
-                "mimic-fn": "^2.0.0",
-                "p-is-promise": "^2.0.0"
+                "map-age-cleaner": "0.1.3",
+                "mimic-fn": "2.1.0",
+                "p-is-promise": "2.1.0"
             }
         },
         "merge-stream": {
@@ -6547,7 +6547,7 @@
             "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
             "dev": true,
             "requires": {
-                "readable-stream": "^2.0.1"
+                "readable-stream": "2.3.6"
             }
         },
         "micromatch": {
@@ -6556,19 +6556,19 @@
             "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
             "dev": true,
             "requires": {
-                "arr-diff": "^4.0.0",
-                "array-unique": "^0.3.2",
-                "braces": "^2.3.1",
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "extglob": "^2.0.4",
-                "fragment-cache": "^0.2.1",
-                "kind-of": "^6.0.2",
-                "nanomatch": "^1.2.9",
-                "object.pick": "^1.3.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.2"
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "braces": "2.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "extglob": "2.0.4",
+                "fragment-cache": "0.2.1",
+                "kind-of": "6.0.2",
+                "nanomatch": "1.2.13",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
             }
         },
         "mime-db": {
@@ -6598,7 +6598,7 @@
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
             "requires": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "1.1.11"
             }
         },
         "minimist": {
@@ -6613,8 +6613,8 @@
             "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
             "dev": true,
             "requires": {
-                "for-in": "^1.0.2",
-                "is-extendable": "^1.0.1"
+                "for-in": "1.0.2",
+                "is-extendable": "1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -6623,7 +6623,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "^2.0.4"
+                        "is-plain-object": "2.0.4"
                     }
                 }
             }
@@ -6664,17 +6664,17 @@
             "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
             "dev": true,
             "requires": {
-                "arr-diff": "^4.0.0",
-                "array-unique": "^0.3.2",
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "fragment-cache": "^0.2.1",
-                "is-windows": "^1.0.2",
-                "kind-of": "^6.0.2",
-                "object.pick": "^1.3.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "fragment-cache": "0.2.1",
+                "is-windows": "1.0.2",
+                "kind-of": "6.0.2",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
             }
         },
         "natural-compare": {
@@ -6713,11 +6713,11 @@
             "integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
             "dev": true,
             "requires": {
-                "growly": "^1.3.0",
-                "is-wsl": "^1.1.0",
-                "semver": "^5.5.0",
-                "shellwords": "^0.1.1",
-                "which": "^1.3.0"
+                "growly": "1.3.0",
+                "is-wsl": "1.1.0",
+                "semver": "5.5.0",
+                "shellwords": "0.1.1",
+                "which": "1.3.1"
             }
         },
         "normalize-package-data": {
@@ -6726,10 +6726,10 @@
             "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
             "dev": true,
             "requires": {
-                "hosted-git-info": "^2.1.4",
-                "resolve": "^1.10.0",
-                "semver": "2 || 3 || 4 || 5",
-                "validate-npm-package-license": "^3.0.1"
+                "hosted-git-info": "2.7.1",
+                "resolve": "1.10.0",
+                "semver": "5.5.0",
+                "validate-npm-package-license": "3.0.4"
             },
             "dependencies": {
                 "path-parse": {
@@ -6744,7 +6744,7 @@
                     "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
                     "dev": true,
                     "requires": {
-                        "path-parse": "^1.0.6"
+                        "path-parse": "1.0.6"
                     }
                 }
             }
@@ -6755,7 +6755,7 @@
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
-                "remove-trailing-separator": "^1.0.1"
+                "remove-trailing-separator": "1.1.0"
             }
         },
         "npm-run-path": {
@@ -6764,7 +6764,7 @@
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
             "dev": true,
             "requires": {
-                "path-key": "^2.0.0"
+                "path-key": "2.0.1"
             }
         },
         "number-is-nan": {
@@ -6791,9 +6791,9 @@
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
             "dev": true,
             "requires": {
-                "copy-descriptor": "^0.1.0",
-                "define-property": "^0.2.5",
-                "kind-of": "^3.0.3"
+                "copy-descriptor": "0.1.1",
+                "define-property": "0.2.5",
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "define-property": {
@@ -6802,7 +6802,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 },
                 "kind-of": {
@@ -6811,7 +6811,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -6828,7 +6828,7 @@
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
             "dev": true,
             "requires": {
-                "isobject": "^3.0.0"
+                "isobject": "3.0.1"
             }
         },
         "object.getownpropertydescriptors": {
@@ -6837,8 +6837,8 @@
             "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.2",
-                "es-abstract": "^1.5.1"
+                "define-properties": "1.1.3",
+                "es-abstract": "1.13.0"
             }
         },
         "object.pick": {
@@ -6847,7 +6847,7 @@
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "dev": true,
             "requires": {
-                "isobject": "^3.0.1"
+                "isobject": "3.0.1"
             }
         },
         "once": {
@@ -6856,7 +6856,7 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1"
+                "wrappy": "1.0.2"
             }
         },
         "optimist": {
@@ -6865,8 +6865,8 @@
             "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
             "dev": true,
             "requires": {
-                "minimist": "~0.0.1",
-                "wordwrap": "~0.0.2"
+                "minimist": "0.0.10",
+                "wordwrap": "0.0.3"
             },
             "dependencies": {
                 "minimist": {
@@ -6883,12 +6883,12 @@
             "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
             "dev": true,
             "requires": {
-                "deep-is": "~0.1.3",
-                "fast-levenshtein": "~2.0.4",
-                "levn": "~0.3.0",
-                "prelude-ls": "~1.1.2",
-                "type-check": "~0.3.2",
-                "wordwrap": "~1.0.0"
+                "deep-is": "0.1.3",
+                "fast-levenshtein": "2.0.6",
+                "levn": "0.3.0",
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2",
+                "wordwrap": "1.0.0"
             },
             "dependencies": {
                 "wordwrap": {
@@ -6905,9 +6905,9 @@
             "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
             "dev": true,
             "requires": {
-                "execa": "^1.0.0",
-                "lcid": "^2.0.0",
-                "mem": "^4.0.0"
+                "execa": "1.0.0",
+                "lcid": "2.0.0",
+                "mem": "4.3.0"
             }
         },
         "os-tmpdir": {
@@ -6928,7 +6928,7 @@
             "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
             "dev": true,
             "requires": {
-                "p-reduce": "^1.0.0"
+                "p-reduce": "1.0.0"
             }
         },
         "p-finally": {
@@ -6949,7 +6949,7 @@
             "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
             "dev": true,
             "requires": {
-                "p-try": "^2.0.0"
+                "p-try": "2.1.0"
             }
         },
         "p-locate": {
@@ -6958,7 +6958,7 @@
             "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
             "dev": true,
             "requires": {
-                "p-limit": "^2.0.0"
+                "p-limit": "2.2.0"
             }
         },
         "p-reduce": {
@@ -6979,8 +6979,8 @@
             "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
             "dev": true,
             "requires": {
-                "error-ex": "^1.3.1",
-                "json-parse-better-errors": "^1.0.1"
+                "error-ex": "1.3.2",
+                "json-parse-better-errors": "1.0.2"
             }
         },
         "parse5": {
@@ -7024,7 +7024,7 @@
             "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
             "dev": true,
             "requires": {
-                "pify": "^3.0.0"
+                "pify": "3.0.0"
             }
         },
         "performance-now": {
@@ -7045,7 +7045,7 @@
             "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
             "dev": true,
             "requires": {
-                "node-modules-regexp": "^1.0.0"
+                "node-modules-regexp": "1.0.0"
             }
         },
         "pkg-dir": {
@@ -7054,7 +7054,7 @@
             "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
             "dev": true,
             "requires": {
-                "find-up": "^3.0.0"
+                "find-up": "3.0.0"
             }
         },
         "pn": {
@@ -7087,10 +7087,10 @@
             "integrity": "sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==",
             "dev": true,
             "requires": {
-                "@jest/types": "^24.8.0",
-                "ansi-regex": "^4.0.0",
-                "ansi-styles": "^3.2.0",
-                "react-is": "^16.8.4"
+                "@jest/types": "24.8.0",
+                "ansi-regex": "4.1.0",
+                "ansi-styles": "3.2.1",
+                "react-is": "16.8.4"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -7113,8 +7113,8 @@
             "integrity": "sha512-HTzM3UWp/99A0gk51gAegwo1QRYA7xjcZufMNe33rCclFszUYAuHe1fIN/3ZmiHeGPkUsNaRyQm1hHOfM0PKxA==",
             "dev": true,
             "requires": {
-                "kleur": "^3.0.2",
-                "sisteransi": "^1.0.0"
+                "kleur": "3.0.3",
+                "sisteransi": "1.0.0"
             }
         },
         "psl": {
@@ -7129,8 +7129,8 @@
             "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
             "dev": true,
             "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
             }
         },
         "punycode": {
@@ -7157,9 +7157,9 @@
             "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
             "dev": true,
             "requires": {
-                "load-json-file": "^4.0.0",
-                "normalize-package-data": "^2.3.2",
-                "path-type": "^3.0.0"
+                "load-json-file": "4.0.0",
+                "normalize-package-data": "2.5.0",
+                "path-type": "3.0.0"
             }
         },
         "read-pkg-up": {
@@ -7168,8 +7168,8 @@
             "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
             "dev": true,
             "requires": {
-                "find-up": "^3.0.0",
-                "read-pkg": "^3.0.0"
+                "find-up": "3.0.0",
+                "read-pkg": "3.0.0"
             }
         },
         "readable-stream": {
@@ -7178,13 +7178,13 @@
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "dev": true,
             "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.0",
+                "safe-buffer": "5.1.1",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
             }
         },
         "readline-sync": {
@@ -7199,7 +7199,7 @@
             "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
             "dev": true,
             "requires": {
-                "util.promisify": "^1.0.0"
+                "util.promisify": "1.0.0"
             }
         },
         "regex-not": {
@@ -7208,8 +7208,8 @@
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
             "dev": true,
             "requires": {
-                "extend-shallow": "^3.0.2",
-                "safe-regex": "^1.1.0"
+                "extend-shallow": "3.0.2",
+                "safe-regex": "1.1.0"
             }
         },
         "remove-trailing-separator": {
@@ -7236,26 +7236,26 @@
             "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
             "dev": true,
             "requires": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.8.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.6",
-                "extend": "~3.0.2",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "har-validator": "~5.1.0",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.19",
-                "oauth-sign": "~0.9.0",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.2",
-                "safe-buffer": "^5.1.2",
-                "tough-cookie": "~2.4.3",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.3.2"
+                "aws-sign2": "0.7.0",
+                "aws4": "1.8.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.7",
+                "extend": "3.0.2",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.3",
+                "har-validator": "5.1.3",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.24",
+                "oauth-sign": "0.9.0",
+                "performance-now": "2.1.0",
+                "qs": "6.5.2",
+                "safe-buffer": "5.1.2",
+                "tough-cookie": "2.4.3",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.3.2"
             },
             "dependencies": {
                 "punycode": {
@@ -7276,8 +7276,8 @@
                     "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
                     "dev": true,
                     "requires": {
-                        "psl": "^1.1.24",
-                        "punycode": "^1.4.1"
+                        "psl": "1.1.31",
+                        "punycode": "1.4.1"
                     }
                 }
             }
@@ -7288,7 +7288,7 @@
             "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
             "dev": true,
             "requires": {
-                "lodash": "^4.17.11"
+                "lodash": "4.17.11"
             }
         },
         "request-promise-native": {
@@ -7298,8 +7298,8 @@
             "dev": true,
             "requires": {
                 "request-promise-core": "1.1.2",
-                "stealthy-require": "^1.1.1",
-                "tough-cookie": "^2.3.3"
+                "stealthy-require": "1.1.1",
+                "tough-cookie": "2.5.0"
             }
         },
         "require-directory": {
@@ -7319,7 +7319,7 @@
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
             "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
             "requires": {
-                "path-parse": "^1.0.6"
+                "path-parse": "1.0.6"
             }
         },
         "resolve-cwd": {
@@ -7328,7 +7328,7 @@
             "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
             "dev": true,
             "requires": {
-                "resolve-from": "^3.0.0"
+                "resolve-from": "3.0.0"
             }
         },
         "resolve-from": {
@@ -7355,7 +7355,7 @@
             "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
             "dev": true,
             "requires": {
-                "glob": "^7.1.3"
+                "glob": "7.1.3"
             },
             "dependencies": {
                 "glob": {
@@ -7364,12 +7364,12 @@
                     "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
+                        "fs.realpath": "1.0.0",
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
                     }
                 }
             }
@@ -7392,7 +7392,7 @@
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
-                "ret": "~0.1.10"
+                "ret": "0.1.15"
             }
         },
         "safer-buffer": {
@@ -7407,15 +7407,15 @@
             "integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
             "dev": true,
             "requires": {
-                "@cnakazawa/watch": "^1.0.3",
-                "anymatch": "^2.0.0",
-                "capture-exit": "^2.0.0",
-                "exec-sh": "^0.3.2",
-                "execa": "^1.0.0",
-                "fb-watchman": "^2.0.0",
-                "micromatch": "^3.1.4",
-                "minimist": "^1.1.1",
-                "walker": "~1.0.5"
+                "@cnakazawa/watch": "1.0.3",
+                "anymatch": "2.0.0",
+                "capture-exit": "2.0.0",
+                "exec-sh": "0.3.2",
+                "execa": "1.0.0",
+                "fb-watchman": "2.0.0",
+                "micromatch": "3.1.10",
+                "minimist": "1.2.0",
+                "walker": "1.0.7"
             }
         },
         "sax": {
@@ -7442,10 +7442,10 @@
             "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
             "dev": true,
             "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-extendable": "^0.1.1",
-                "is-plain-object": "^2.0.3",
-                "split-string": "^3.0.1"
+                "extend-shallow": "2.0.1",
+                "is-extendable": "0.1.1",
+                "is-plain-object": "2.0.4",
+                "split-string": "3.1.0"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -7454,7 +7454,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 }
             }
@@ -7465,7 +7465,7 @@
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "dev": true,
             "requires": {
-                "shebang-regex": "^1.0.0"
+                "shebang-regex": "1.0.0"
             }
         },
         "shebang-regex": {
@@ -7504,14 +7504,14 @@
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
             "dev": true,
             "requires": {
-                "base": "^0.11.1",
-                "debug": "^2.2.0",
-                "define-property": "^0.2.5",
-                "extend-shallow": "^2.0.1",
-                "map-cache": "^0.2.2",
-                "source-map": "^0.5.6",
-                "source-map-resolve": "^0.5.0",
-                "use": "^3.1.0"
+                "base": "0.11.2",
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "map-cache": "0.2.2",
+                "source-map": "0.5.7",
+                "source-map-resolve": "0.5.2",
+                "use": "3.1.1"
             },
             "dependencies": {
                 "debug": {
@@ -7529,7 +7529,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 },
                 "extend-shallow": {
@@ -7538,7 +7538,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 },
                 "ms": {
@@ -7561,9 +7561,9 @@
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
             "dev": true,
             "requires": {
-                "define-property": "^1.0.0",
-                "isobject": "^3.0.0",
-                "snapdragon-util": "^3.0.1"
+                "define-property": "1.0.0",
+                "isobject": "3.0.1",
+                "snapdragon-util": "3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -7572,7 +7572,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^1.0.0"
+                        "is-descriptor": "1.0.2"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -7581,7 +7581,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-data-descriptor": {
@@ -7590,7 +7590,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "^6.0.0"
+                        "kind-of": "6.0.2"
                     }
                 },
                 "is-descriptor": {
@@ -7599,9 +7599,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "^1.0.0",
-                        "is-data-descriptor": "^1.0.0",
-                        "kind-of": "^6.0.2"
+                        "is-accessor-descriptor": "1.0.0",
+                        "is-data-descriptor": "1.0.0",
+                        "kind-of": "6.0.2"
                     }
                 }
             }
@@ -7612,7 +7612,7 @@
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "dev": true,
             "requires": {
-                "kind-of": "^3.2.0"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -7621,7 +7621,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -7637,11 +7637,11 @@
             "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
             "dev": true,
             "requires": {
-                "atob": "^2.1.1",
-                "decode-uri-component": "^0.2.0",
-                "resolve-url": "^0.2.1",
-                "source-map-url": "^0.4.0",
-                "urix": "^0.1.0"
+                "atob": "2.1.2",
+                "decode-uri-component": "0.2.0",
+                "resolve-url": "0.2.1",
+                "source-map-url": "0.4.0",
+                "urix": "0.1.0"
             }
         },
         "source-map-support": {
@@ -7650,8 +7650,8 @@
             "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
             "dev": true,
             "requires": {
-                "buffer-from": "^1.0.0",
-                "source-map": "^0.6.0"
+                "buffer-from": "1.1.0",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "source-map": {
@@ -7674,8 +7674,8 @@
             "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
             "dev": true,
             "requires": {
-                "spdx-expression-parse": "^3.0.0",
-                "spdx-license-ids": "^3.0.0"
+                "spdx-expression-parse": "3.0.0",
+                "spdx-license-ids": "3.0.3"
             }
         },
         "spdx-exceptions": {
@@ -7690,8 +7690,8 @@
             "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
             "dev": true,
             "requires": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
+                "spdx-exceptions": "2.2.0",
+                "spdx-license-ids": "3.0.3"
             }
         },
         "spdx-license-ids": {
@@ -7706,7 +7706,7 @@
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
             "dev": true,
             "requires": {
-                "extend-shallow": "^3.0.0"
+                "extend-shallow": "3.0.2"
             }
         },
         "sprintf-js": {
@@ -7721,15 +7721,15 @@
             "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
             "dev": true,
             "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
+                "asn1": "0.2.4",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.2",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.2",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "safer-buffer": "2.1.2",
+                "tweetnacl": "0.14.5"
             }
         },
         "stack-utils": {
@@ -7744,8 +7744,8 @@
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
             "dev": true,
             "requires": {
-                "define-property": "^0.2.5",
-                "object-copy": "^0.1.0"
+                "define-property": "0.2.5",
+                "object-copy": "0.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -7754,7 +7754,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "^0.1.0"
+                        "is-descriptor": "0.1.6"
                     }
                 }
             }
@@ -7771,8 +7771,8 @@
             "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
             "dev": true,
             "requires": {
-                "astral-regex": "^1.0.0",
-                "strip-ansi": "^4.0.0"
+                "astral-regex": "1.0.0",
+                "strip-ansi": "4.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -7787,7 +7787,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "3.0.0"
                     }
                 }
             }
@@ -7798,8 +7798,8 @@
             "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
             "dev": true,
             "requires": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -7814,7 +7814,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^3.0.0"
+                        "ansi-regex": "3.0.0"
                     }
                 }
             }
@@ -7825,7 +7825,7 @@
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
             "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.1"
             }
         },
         "strip-ansi": {
@@ -7834,7 +7834,7 @@
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "^2.0.0"
+                "ansi-regex": "2.1.1"
             }
         },
         "strip-bom": {
@@ -7855,7 +7855,7 @@
             "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
             "dev": true,
             "requires": {
-                "has-flag": "^3.0.0"
+                "has-flag": "3.0.0"
             }
         },
         "symbol-tree": {
@@ -7870,10 +7870,10 @@
             "integrity": "sha512-gwf0S2fFsANC55fSeSqpb8BYk6w3FDvwZxfNjeF6FRgvFa43r+7wRiA/Q0IxoRU37wB/LE8IQ4221BsNucTaCA==",
             "dev": true,
             "requires": {
-                "arrify": "^1.0.1",
-                "minimatch": "^3.0.4",
-                "read-pkg-up": "^4.0.0",
-                "require-main-filename": "^1.0.1"
+                "arrify": "1.0.1",
+                "minimatch": "3.0.4",
+                "read-pkg-up": "4.0.0",
+                "require-main-filename": "1.0.1"
             }
         },
         "throat": {
@@ -7888,7 +7888,7 @@
             "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
             "dev": true,
             "requires": {
-                "os-tmpdir": "~1.0.2"
+                "os-tmpdir": "1.0.2"
             }
         },
         "tmpl": {
@@ -7909,7 +7909,7 @@
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
             "dev": true,
             "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -7918,7 +7918,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                     }
                 }
             }
@@ -7929,10 +7929,10 @@
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
             "dev": true,
             "requires": {
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "regex-not": "^1.0.2",
-                "safe-regex": "^1.1.0"
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "regex-not": "1.0.2",
+                "safe-regex": "1.1.0"
             }
         },
         "to-regex-range": {
@@ -7941,8 +7941,8 @@
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
             "dev": true,
             "requires": {
-                "is-number": "^3.0.0",
-                "repeat-string": "^1.6.1"
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1"
             }
         },
         "tough-cookie": {
@@ -7951,8 +7951,8 @@
             "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
             "dev": true,
             "requires": {
-                "psl": "^1.1.28",
-                "punycode": "^2.1.1"
+                "psl": "1.1.31",
+                "punycode": "2.1.1"
             }
         },
         "tr46": {
@@ -7961,7 +7961,7 @@
             "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
             "dev": true,
             "requires": {
-                "punycode": "^2.1.0"
+                "punycode": "2.1.1"
             }
         },
         "trim-right": {
@@ -7976,15 +7976,15 @@
             "integrity": "sha512-h6ZCZiA1EQgjczxq+uGLXQlNgeg02WWJBbeT8j6nyIBRQdglqbvzDoHahTEIiS6Eor6x8mK6PfZ7brQ9Q6tzHw==",
             "dev": true,
             "requires": {
-                "bs-logger": "0.x",
-                "buffer-from": "1.x",
-                "fast-json-stable-stringify": "2.x",
-                "json5": "2.x",
-                "make-error": "1.x",
-                "mkdirp": "0.x",
-                "resolve": "1.x",
-                "semver": "^5.5",
-                "yargs-parser": "10.x"
+                "bs-logger": "0.2.6",
+                "buffer-from": "1.1.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json5": "2.1.0",
+                "make-error": "1.3.4",
+                "mkdirp": "0.5.1",
+                "resolve": "1.11.0",
+                "semver": "5.5.0",
+                "yargs-parser": "10.1.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -7999,7 +7999,7 @@
                     "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
                     "dev": true,
                     "requires": {
-                        "camelcase": "^4.1.0"
+                        "camelcase": "4.1.0"
                     }
                 }
             }
@@ -8010,14 +8010,14 @@
             "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
             "dev": true,
             "requires": {
-                "arrify": "^1.0.0",
-                "buffer-from": "^1.1.0",
-                "diff": "^3.1.0",
-                "make-error": "^1.1.1",
-                "minimist": "^1.2.0",
-                "mkdirp": "^0.5.1",
-                "source-map-support": "^0.5.6",
-                "yn": "^2.0.0"
+                "arrify": "1.0.1",
+                "buffer-from": "1.1.0",
+                "diff": "3.5.0",
+                "make-error": "1.3.4",
+                "minimist": "1.2.0",
+                "mkdirp": "0.5.1",
+                "source-map-support": "0.5.6",
+                "yn": "2.0.0"
             }
         },
         "tslib": {
@@ -8032,19 +8032,19 @@
             "integrity": "sha512-pflx87WfVoYepTet3xLfDOLDm9Jqi61UXIKePOuca0qoAZyrGWonDG9VTbji58Fy+8gciUn8Bt7y69+KEVjc/w==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.0.0",
-                "builtin-modules": "^1.1.1",
-                "chalk": "^2.3.0",
-                "commander": "^2.12.1",
-                "diff": "^3.2.0",
-                "glob": "^7.1.1",
-                "js-yaml": "^3.13.1",
-                "minimatch": "^3.0.4",
-                "mkdirp": "^0.5.1",
-                "resolve": "^1.3.2",
-                "semver": "^5.3.0",
-                "tslib": "^1.8.0",
-                "tsutils": "^2.29.0"
+                "@babel/code-frame": "7.0.0",
+                "builtin-modules": "1.1.1",
+                "chalk": "2.4.2",
+                "commander": "2.20.0",
+                "diff": "3.5.0",
+                "glob": "7.1.3",
+                "js-yaml": "3.13.1",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "resolve": "1.11.0",
+                "semver": "5.5.0",
+                "tslib": "1.10.0",
+                "tsutils": "2.29.0"
             }
         },
         "tsutils": {
@@ -8053,7 +8053,7 @@
             "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
             "dev": true,
             "requires": {
-                "tslib": "^1.8.1"
+                "tslib": "1.10.0"
             }
         },
         "tunnel-agent": {
@@ -8062,7 +8062,7 @@
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "dev": true,
             "requires": {
-                "safe-buffer": "^5.0.1"
+                "safe-buffer": "5.1.1"
             }
         },
         "tweetnacl": {
@@ -8077,7 +8077,7 @@
             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
             "dev": true,
             "requires": {
-                "prelude-ls": "~1.1.2"
+                "prelude-ls": "1.1.2"
             }
         },
         "typescript": {
@@ -8092,8 +8092,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "commander": "~2.20.0",
-                "source-map": "~0.6.1"
+                "commander": "2.20.0",
+                "source-map": "0.6.1"
             },
             "dependencies": {
                 "commander": {
@@ -8118,10 +8118,10 @@
             "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
             "dev": true,
             "requires": {
-                "arr-union": "^3.1.0",
-                "get-value": "^2.0.6",
-                "is-extendable": "^0.1.1",
-                "set-value": "^0.4.3"
+                "arr-union": "3.1.0",
+                "get-value": "2.0.6",
+                "is-extendable": "0.1.1",
+                "set-value": "0.4.3"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -8130,7 +8130,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "^0.1.0"
+                        "is-extendable": "0.1.1"
                     }
                 },
                 "set-value": {
@@ -8139,10 +8139,10 @@
                     "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-extendable": "^0.1.1",
-                        "is-plain-object": "^2.0.1",
-                        "to-object-path": "^0.3.0"
+                        "extend-shallow": "2.0.1",
+                        "is-extendable": "0.1.1",
+                        "is-plain-object": "2.0.4",
+                        "to-object-path": "0.3.0"
                     }
                 }
             }
@@ -8153,8 +8153,8 @@
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
             "dev": true,
             "requires": {
-                "has-value": "^0.3.1",
-                "isobject": "^3.0.0"
+                "has-value": "0.3.1",
+                "isobject": "3.0.1"
             },
             "dependencies": {
                 "has-value": {
@@ -8163,9 +8163,9 @@
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
                     "dev": true,
                     "requires": {
-                        "get-value": "^2.0.3",
-                        "has-values": "^0.1.4",
-                        "isobject": "^2.0.0"
+                        "get-value": "2.0.6",
+                        "has-values": "0.1.4",
+                        "isobject": "2.1.0"
                     },
                     "dependencies": {
                         "isobject": {
@@ -8193,7 +8193,7 @@
             "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
             "dev": true,
             "requires": {
-                "punycode": "^2.1.0"
+                "punycode": "2.1.1"
             }
         },
         "urix": {
@@ -8220,8 +8220,8 @@
             "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.2",
-                "object.getownpropertydescriptors": "^2.0.3"
+                "define-properties": "1.1.3",
+                "object.getownpropertydescriptors": "2.0.3"
             }
         },
         "uuid": {
@@ -8236,8 +8236,8 @@
             "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
             "dev": true,
             "requires": {
-                "spdx-correct": "^3.0.0",
-                "spdx-expression-parse": "^3.0.0"
+                "spdx-correct": "3.1.0",
+                "spdx-expression-parse": "3.0.0"
             }
         },
         "verror": {
@@ -8246,9 +8246,9 @@
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "dev": true,
             "requires": {
-                "assert-plus": "^1.0.0",
+                "assert-plus": "1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
+                "extsprintf": "1.3.0"
             }
         },
         "w3c-hr-time": {
@@ -8257,7 +8257,7 @@
             "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
             "dev": true,
             "requires": {
-                "browser-process-hrtime": "^0.1.2"
+                "browser-process-hrtime": "0.1.3"
             }
         },
         "walker": {
@@ -8266,7 +8266,7 @@
             "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
             "dev": true,
             "requires": {
-                "makeerror": "1.0.x"
+                "makeerror": "1.0.11"
             }
         },
         "webidl-conversions": {
@@ -8296,9 +8296,9 @@
             "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
             "dev": true,
             "requires": {
-                "lodash.sortby": "^4.7.0",
-                "tr46": "^1.0.1",
-                "webidl-conversions": "^4.0.2"
+                "lodash.sortby": "4.7.0",
+                "tr46": "1.0.1",
+                "webidl-conversions": "4.0.2"
             }
         },
         "which": {
@@ -8307,7 +8307,7 @@
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
             "dev": true,
             "requires": {
-                "isexe": "^2.0.0"
+                "isexe": "2.0.0"
             }
         },
         "which-module": {
@@ -8328,8 +8328,8 @@
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "dev": true,
             "requires": {
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1"
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1"
             },
             "dependencies": {
                 "is-fullwidth-code-point": {
@@ -8338,7 +8338,7 @@
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "^1.0.0"
+                        "number-is-nan": "1.0.1"
                     }
                 },
                 "string-width": {
@@ -8347,9 +8347,9 @@
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                     "dev": true,
                     "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
                     }
                 }
             }
@@ -8366,9 +8366,9 @@
             "integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.11",
-                "imurmurhash": "^0.1.4",
-                "signal-exit": "^3.0.2"
+                "graceful-fs": "4.1.15",
+                "imurmurhash": "0.1.4",
+                "signal-exit": "3.0.2"
             }
         },
         "ws": {
@@ -8377,7 +8377,7 @@
             "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
             "dev": true,
             "requires": {
-                "async-limiter": "~1.0.0"
+                "async-limiter": "1.0.0"
             }
         },
         "xml-name-validator": {
@@ -8398,18 +8398,18 @@
             "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
             "dev": true,
             "requires": {
-                "cliui": "^4.0.0",
-                "decamelize": "^1.2.0",
-                "find-up": "^3.0.0",
-                "get-caller-file": "^1.0.1",
-                "os-locale": "^3.0.0",
-                "require-directory": "^2.1.1",
-                "require-main-filename": "^1.0.1",
-                "set-blocking": "^2.0.0",
-                "string-width": "^2.0.0",
-                "which-module": "^2.0.0",
-                "y18n": "^3.2.1 || ^4.0.0",
-                "yargs-parser": "^11.1.1"
+                "cliui": "4.1.0",
+                "decamelize": "1.2.0",
+                "find-up": "3.0.0",
+                "get-caller-file": "1.0.3",
+                "os-locale": "3.1.0",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "2.1.1",
+                "which-module": "2.0.0",
+                "y18n": "4.0.0",
+                "yargs-parser": "11.1.1"
             }
         },
         "yargs-parser": {
@@ -8418,8 +8418,8 @@
             "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
             "dev": true,
             "requires": {
-                "camelcase": "^5.0.0",
-                "decamelize": "^1.2.0"
+                "camelcase": "5.3.1",
+                "decamelize": "1.2.0"
             }
         },
         "yn": {

--- a/src/LuaAST.ts
+++ b/src/LuaAST.ts
@@ -26,6 +26,7 @@ export enum SyntaxKind {
 
     // Expression
     StringLiteral,
+    MultilineStringLiteral,
     NumericLiteral,
     NilKeyword,
     DotsKeyword,
@@ -610,12 +611,27 @@ export interface StringLiteral extends Expression {
     value: string;
 }
 
+export interface MultilineStringLiteral extends Expression {
+    kind: SyntaxKind.MultilineStringLiteral;
+    value: string;
+}
+
 export function isStringLiteral(node: Node): node is StringLiteral {
-    return node.kind === SyntaxKind.StringLiteral;
+    return node.kind === SyntaxKind.StringLiteral || node.kind === SyntaxKind.MultilineStringLiteral;
 }
 
 export function createStringLiteral(value: string, tsOriginal?: ts.Node, parent?: Node): StringLiteral {
     const expression = createNode(SyntaxKind.StringLiteral, tsOriginal, parent) as StringLiteral;
+    expression.value = value as string;
+    return expression;
+}
+
+export function createMultilineStringLiteral(
+    value: string,
+    tsOriginal?: ts.Node,
+    parent?: Node
+): MultilineStringLiteral {
+    const expression = createNode(SyntaxKind.MultilineStringLiteral, tsOriginal, parent) as MultilineStringLiteral;
     expression.value = value as string;
     return expression;
 }

--- a/src/LuaPrinter.ts
+++ b/src/LuaPrinter.ts
@@ -425,6 +425,8 @@ export class LuaPrinter {
         switch (expression.kind) {
             case tstl.SyntaxKind.StringLiteral:
                 return this.printStringLiteral(expression as tstl.StringLiteral);
+            case tstl.SyntaxKind.MultilineStringLiteral:
+                return this.printMultilineStringLiteral(expression as tstl.MultilineStringLiteral);
             case tstl.SyntaxKind.NumericLiteral:
                 return this.printNumericLiteral(expression as tstl.NumericLiteral);
             case tstl.SyntaxKind.NilKeyword:
@@ -461,6 +463,23 @@ export class LuaPrinter {
 
     public printStringLiteral(expression: tstl.StringLiteral): SourceNode {
         return this.createSourceNode(expression, `"${expression.value}"`);
+    }
+
+    public printMultilineStringLiteral(expression: tstl.MultilineStringLiteral): SourceNode {
+        const chunks = [];
+
+        const braces = ["\\]"];
+        while (expression.value.match(new RegExp(braces.join("")))) {
+            braces.push("=\\]");
+        }
+
+        const bracesSeparators = [...new Array(braces.length - 1)].map(() => "=").join("");
+
+        chunks.push(`[${bracesSeparators}[`);
+        chunks.push(expression.value);
+        chunks.push(`]${bracesSeparators}]`);
+
+        return this.createSourceNode(expression, chunks);
     }
 
     public printNumericLiteral(expression: tstl.NumericLiteral): SourceNode {

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -659,11 +659,12 @@ export function getFunctionContextType(type: ts.Type, checker: ts.TypeChecker): 
     return reduceContextTypes(signatureDeclarations.map(s => getDeclarationContextType(s, checker)));
 }
 
-export function escapeString(text: string): string {
+export function escapeString(text: string, exclude: RegExp[] = []): string {
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String
     const escapeSequences: Array<[RegExp, string]> = [
         [/[\\]/g, "\\\\"],
-        [/[\']/g, "\\'"],
+        [/\\'/g, "\\'"],
+        [/[\`]/g, "\\\\`"],
         [/[\"]/g, '\\"'],
         [/[\n]/g, "\\n"],
         [/[\r]/g, "\\r"],
@@ -674,8 +675,14 @@ export function escapeString(text: string): string {
         [/[\0]/g, "\\0"],
     ];
 
+    const filteredEscapeSequences = escapeSequences.filter(([seq]) => {
+        return !exclude.some(ex => {
+            return ex.source === seq.source;
+        });
+    });
+
     if (text.length > 0) {
-        for (const [regex, replacement] of escapeSequences) {
+        for (const [regex, replacement] of filteredEscapeSequences) {
             text = text.replace(regex, replacement);
         }
     }

--- a/test/translation/__snapshots__/transformation.spec.ts.snap
+++ b/test/translation/__snapshots__/transformation.spec.ts.snap
@@ -3,18 +3,24 @@
 exports[`Transformation (callNamespace) 1`] = `"Namespace:myFunction()"`;
 
 exports[`Transformation (characterEscapeSequence) 1`] = `
-"local quoteInDoubleQuotes = \\"\\\\' \\\\' \\\\'\\"
-local quoteInTemplateString = \\"\\\\' \\\\' \\\\'\\"
+"local quoteInQuotes = \\"' ' '\\"
+local quoteInDoubleQuotes = \\"' ' '\\"
+local quoteInTemplateString = [[' ' ']]
 local doubleQuoteInQuotes = \\"\\\\\\" \\\\\\" \\\\\\"\\"
 local doubleQuoteInDoubleQuotes = \\"\\\\\\" \\\\\\" \\\\\\"\\"
-local doubleQuoteInTemplateString = \\"\\\\\\" \\\\\\" \\\\\\"\\"
-local backQuoteInQuotes = \\"\` \` \`\\"
-local backQuoteInDoubleQuotes = \\"\` \` \`\\"
-local backQuoteInTemplateString = \\"\` \` \`\\"
-local escapedCharsInQuotes = \\"\\\\\\\\ \\\\0 \\\\b \\\\t \\\\n \\\\v \\\\f \\\\\\" \\\\' \`\\"
-local escapedCharsInDoubleQUotes = \\"\\\\\\\\ \\\\0 \\\\b \\\\t \\\\n \\\\v \\\\f \\\\\\" \\\\'\\"
-local escapedCharsInTemplateString = \\"\\\\\\\\ \\\\0 \\\\b \\\\t \\\\n \\\\v \\\\f \\\\\\" \\\\' \`\\"
-local nonEmptyTemplateString = \\"Level 0: \\\\n\\\\t \\" .. \\"Level 1: \\\\n\\\\t\\\\t \\" .. \\"Level 3: \\\\n\\\\t\\\\t\\\\t \\" .. \\"Last level \\\\n --\\" .. \\" \\\\n --\\" .. \\" \\\\n --\\" .. \\" \\\\n --\\""
+local doubleQuoteInTemplateString = [[\\" \\" \\"]]
+local backQuoteInQuotes = \\"\\\\\\\\\` \\\\\\\\\` \\\\\\\\\`\\"
+local backQuoteInDoubleQuotes = \\"\\\\\\\\\` \\\\\\\\\` \\\\\\\\\`\\"
+local backQuoteInTemplateString = [[\\\\\\\\\` \\\\\\\\\` \\\\\\\\\`]]
+local escapedCharsInQuotes = \\"\\\\\\\\ \\\\0 \\\\b \\\\t \\\\n \\\\v \\\\f \\\\\\" ' \\\\\\\\\`\\"
+local escapedCharsInDoubleQUotes = \\"\\\\\\\\ \\\\0 \\\\b \\\\t \\\\n \\\\v \\\\f \\\\\\" ' \\\\\\\\\`\\"
+local escapedCharsInTemplateString = [[\\\\ \\\\0 \\\\b \\\\t \\\\n \\\\v \\\\f \\" ' \\\\\\\\\`]]
+local nonEmptyTemplateString = [[Level 0: \\\\n\\\\t ]] .. [[Level 1: \\\\n\\\\t\\\\t ]] .. [[Level 3: \\\\n\\\\t\\\\t\\\\t ]] .. \\"Last level \\\\n --\\" .. [[ \\\\n --]] .. [[ \\\\n --]] .. [[ \\\\n --]]
+local templateStringWithDoubleBraces = [=[[[]]]=]
+local templateStringWithTripleBraces = [==[[=[]=]]==]
+local templateStringWithMultipleLines = [[
+\\\\n newline
+]]"
 `;
 
 exports[`Transformation (classExtension1) 1`] = `

--- a/test/translation/transformation/characterEscapeSequence.ts
+++ b/test/translation/transformation/characterEscapeSequence.ts
@@ -1,16 +1,23 @@
-let quoteInDoubleQuotes = "' ' '";
-let quoteInTemplateString = `' ' '`;
+let quoteInQuotes = '\' \' \'';   // "' ' '"
+let quoteInDoubleQuotes = "' ' '";   // "' ' '"
+let quoteInTemplateString = `' ' '`; // [[' ' ']]
 
-let doubleQuoteInQuotes = '" " "';
-let doubleQuoteInDoubleQuotes = "\" \" \"";
-let doubleQuoteInTemplateString = `" " "`;
+let doubleQuoteInQuotes = '" " "';          // "\" \" \""
+let doubleQuoteInDoubleQuotes = "\" \" \""; // "\" \" \""
+let doubleQuoteInTemplateString = `" " "`;  // [[" " "]]
 
-let backQuoteInQuotes = "` ` `";
-let backQuoteInDoubleQuotes = "` ` `";
-let backQuoteInTemplateString = `\` \` \``;
+let backQuoteInQuotes = '` ` `';            // "` ` `"
+let backQuoteInDoubleQuotes = "` ` `";      // "` ` `"
+let backQuoteInTemplateString = `\` \` \``; // [[` ` `]]
 
-let escapedCharsInQuotes = '\\ \0 \b \t \n \v \f \" \' \`';
-let escapedCharsInDoubleQUotes = "\\ \0 \b \t \n \v \f \" \'";
-let escapedCharsInTemplateString = `\\ \0 \b \t \n \v \f \" \' \``;
+let escapedCharsInQuotes = '\\ \0 \b \t \n \v \f \" \' \`'; // "\\ \0 \b \t \n \v \f \" ' `"
+let escapedCharsInDoubleQUotes = "\\ \0 \b \t \n \v \f \" \' \`"; // "\\ \0 \b \t \n \v \f \" ' `"
+let escapedCharsInTemplateString = `\\ \0 \b \t \\n \v \f \" \' \``; // [[\\ \0 \b \t \n \v \f \" ' `]]
 
-let nonEmptyTemplateString = `Level 0: \n\t ${`Level 1: \n\t\t ${`Level 3: \n\t\t\t ${"Last level \n --"} \n --`} \n --`} \n --`;
+let nonEmptyTemplateString = `Level 0: \\n\t ${`Level 1: \\n\t\t ${`Level 3: \\n\t\t\t ${"Last level \n --"} \\n --`} \\n --`} \\n --`;
+
+let templateStringWithDoubleBraces = `[[]]`; // [=[[[]]]=]
+let templateStringWithTripleBraces = `[=[]=]`; // [==[[=[]=]]==]
+let templateStringWithMultipleLines = `
+\\n newline
+`;


### PR DESCRIPTION
edit:

The only equivalent string type TS has to `[=*[ ... ]=*]` where nothing can be escaped is ``String.raw`...` ``. However, the added code complexity is not worth the benefits of supporting template literals as multiline strings in Lua (and assuming they are equivalent).

The only benefit of transpiling template literals into multiline strings is to have a pretty output.

For those, searching for a way to make things pretty, I recommend passing the output through some sort of prettier, not just for strings, but for the general output of tstl.


- ~~All template literals are now transpiled into `[=*[ ... ]=*]`~~

- ~~Newlines within template literals are tricky, ideally String.raw would be
  handy to distinguish between escaped- and non-escaped newlines (`\n`)~~

- ~~Added three tests to cover growing multiline string (increasing number of
  `=`'s)~~

- ~~NoSubstitutionTemplateLiteral is now covered by MultilineStringLiteral~~