### PR TITLE
Fixed referencing named function expressions

### DIFF
--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -3679,7 +3679,7 @@ export class LuaTransformer {
             const symbol = this.checker.getSymbolAtLocation(node.name);
             if (symbol) {
                 const symbolId = this.symbolIds.get(symbol);
-                if (symbolId && scope.referencedSymbols.has(symbolId)) {
+                if (symbolId !== undefined && scope.referencedSymbols.has(symbolId)) {
                     const nameIdentifier = this.transformIdentifier(node.name);
                     return this.createImmediatelyInvokedFunctionExpression(
                         [tstl.createVariableDeclarationStatement(nameIdentifier, functionExpression)],

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -3675,10 +3675,12 @@ export class LuaTransformer {
             node
         );
 
+        //Handle named function expressions which reference themselves
         if (ts.isFunctionExpression(node) && node.name && scope.referencedSymbols) {
             const symbol = this.checker.getSymbolAtLocation(node.name);
             if (symbol) {
                 const symbolId = this.symbolIds.get(symbol);
+                //Only wrap if the name is actually referenced inside the function
                 if (symbolId !== undefined && scope.referencedSymbols.has(symbolId)) {
                     const nameIdentifier = this.transformIdentifier(node.name);
                     return this.createImmediatelyInvokedFunctionExpression(

--- a/test/unit/functions.spec.ts
+++ b/test/unit/functions.spec.ts
@@ -610,3 +610,12 @@ test.each([{}, { noHoisting: true }])("@vararg global", compilerOptions => {
 
     expect(util.executeLua(lua)).toBe("ABCD");
 });
+
+test("named function expression reference", () => {
+    const code = `
+        const y = function x(inp: string) {
+            return inp + typeof x;
+        };
+        return y("foo-");`;
+    expect(util.transpileAndExecute(code)).toBe("foo-function");
+});


### PR DESCRIPTION
fixes #669

```ts
const y = function x() {
    x();
}
```
=>
```lua
local y
y = (function()
    local function x(self)
        x(_G)
    end
    return x
end)()
```