### PR TITLE
Support omitted declarations for destructured tuples

### DIFF
--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -1943,7 +1943,9 @@ export class LuaTransformer {
             // For nested bindings and object bindings, fall back to transformBindingPattern
             if (
                 ts.isObjectBindingPattern(statement.name) ||
-                statement.name.elements.some(elem => !ts.isBindingElement(elem) || !ts.isIdentifier(elem.name))
+                statement.name.elements.some(
+                    elem => (!ts.isBindingElement(elem) || !ts.isIdentifier(elem.name)) && !ts.isOmittedExpression(elem)
+                )
             ) {
                 const statements = [];
                 let table: tstl.Identifier;
@@ -1968,7 +1970,13 @@ export class LuaTransformer {
             }
 
             // Disallow ellipsis destruction
-            if (statement.name.elements.some(elem => !ts.isBindingElement(elem) || elem.dotDotDotToken !== undefined)) {
+            if (
+                statement.name.elements.some(
+                    elem =>
+                        (!ts.isBindingElement(elem) || elem.dotDotDotToken !== undefined) &&
+                        !ts.isOmittedExpression(elem)
+                )
+            ) {
                 throw TSTLErrors.ForbiddenEllipsisDestruction(statement);
             }
 

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -832,8 +832,14 @@ export function isWithinLiteralAssignmentStatement(node: ts.Node): boolean {
     if (!node.parent) {
         return false;
     }
-    if (ts.isArrayLiteralExpression(node.parent) || ts.isObjectLiteralExpression(node.parent)) {
+    if (
+        ts.isArrayLiteralExpression(node.parent) ||
+        ts.isArrayBindingPattern(node.parent) ||
+        ts.isObjectLiteralExpression(node.parent)
+    ) {
         return isWithinLiteralAssignmentStatement(node.parent);
+    } else if (isInDestructingAssignment(node)) {
+        return true;
     } else if (ts.isBinaryExpression(node.parent) && node.parent.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
         return true;
     } else {

--- a/test/unit/tuples.spec.ts
+++ b/test/unit/tuples.spec.ts
@@ -122,7 +122,7 @@ test("Tuple Return Destruct Declaration", () => {
     const code = `
         /** @tupleReturn */
         function tuple(): [number, number, number] { return [3,5,1]; }
-        const [a,b,c] = tuple();
+        const [,b,c] = tuple();
         return b;`;
 
     const lua = util.transpileString(code);


### PR DESCRIPTION
Functions marked as `@tupleReturn` now correctly support omitted declarations, e.g.:

TypeScript:
```
const [,,c] = tupleFunction();
```

Lua:
```
local ____, ____, c = tupleFunction();
```

Unlike prior to this PR where the result would be:
```
local ____ = tupleFunction();
local c = ____[3];
```