### PR TITLE
@noSelf changed to not affect merged namespaces

### DIFF
--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -337,19 +337,25 @@ export function getCustomDecorators(type: ts.Type, checker: ts.TypeChecker): Map
     return decMap;
 }
 
-export function getCustomFileDirectives(file: ts.SourceFile): Map<DecoratorKind, Decorator> {
-    const decMap = new Map<DecoratorKind, Decorator>();
-    if (file.statements.length > 0) {
-        const tags = ts.getJSDocTags(file.statements[0]);
-        for (const tag of tags) {
-            const tagName = tag.tagName.escapedText as string;
-            if (Decorator.isValid(tagName)) {
-                const dec = new Decorator(tagName, tag.comment ? tag.comment.split(" ") : []);
-                decMap.set(dec.kind, dec);
-            }
+export function getCustomNodeDirectives(node: ts.Node): Map<DecoratorKind, Decorator> {
+    const directivesMap = new Map<DecoratorKind, Decorator>();
+
+    ts.getJSDocTags(node).forEach(tag => {
+        const tagName = tag.tagName.escapedText as string;
+        if (Decorator.isValid(tagName)) {
+            const dec = new Decorator(tagName, tag.comment ? tag.comment.split(" ") : []);
+            directivesMap.set(dec.kind, dec);
         }
+    });
+
+    return directivesMap;
+}
+
+export function getCustomFileDirectives(file: ts.SourceFile): Map<DecoratorKind, Decorator> {
+    if (file.statements.length > 0) {
+        return getCustomNodeDirectives(file.statements[0]);
     }
-    return decMap;
+    return new Map();
 }
 
 export function getCustomSignatureDirectives(
@@ -596,8 +602,7 @@ export function hasNoSelfAncestor(declaration: ts.Declaration, checker: ts.TypeC
     if (ts.isSourceFile(scopeDeclaration)) {
         return getCustomFileDirectives(scopeDeclaration).has(DecoratorKind.NoSelfInFile);
     }
-    const scopeType = checker.getTypeAtLocation(scopeDeclaration);
-    if (scopeType && getCustomDecorators(scopeType, checker).has(DecoratorKind.NoSelf)) {
+    if (getCustomNodeDirectives(scopeDeclaration).has(DecoratorKind.NoSelf)) {
         return true;
     }
     return hasNoSelfAncestor(scopeDeclaration, checker);
@@ -634,8 +639,7 @@ export function getDeclarationContextType(
             return ContextType.NonVoid;
         }
 
-        const scopeType = checker.getTypeAtLocation(scopeDeclaration);
-        if (scopeType && getCustomDecorators(scopeType, checker).has(DecoratorKind.NoSelf)) {
+        if (getCustomNodeDirectives(scopeDeclaration).has(DecoratorKind.NoSelf)) {
             return ContextType.Void;
         }
         return ContextType.NonVoid;

--- a/test/unit/assignments/functionPermutations.ts
+++ b/test/unit/assignments/functionPermutations.ts
@@ -133,6 +133,22 @@ export const selfTestFunctions: TestFunction[] = [
         }
         const anonFunctionNestedInNoSelfClass = (new AnonFunctionNestedInNoSelfClass).method();`,
     },
+    {
+        value: "anonMethodClassMergedNoSelfNS.method",
+        definition: `class AnonMethodClassMergedNoSelfNS { method(s: string): string { return s; } }
+            /** @noSelf */ namespace AnonMethodClassMergedNoSelfNS { export function nsFunc(s: string) { return s; } }
+            const anonMethodClassMergedNoSelfNS = new AnonMethodClassMergedNoSelfNS();`,
+    },
+    {
+        value: "AnonFuncNSMergedNoSelfClass.nsFunc",
+        definition: `/** @noSelf */ class AnonFuncNSMergedNoSelfClass { method(s: string): string { return s; } }
+            namespace AnonFuncNSMergedNoSelfClass { export function nsFunc(s: string) { return s; } }`,
+    },
+    {
+        value: "SelfAnonFuncNSMergedNoSelfNS.nsFuncSelf",
+        definition: `namespace SelfAnonFuncNSMergedNoSelfNS { export function nsFuncSelf(s: string): string { return s; } }
+        /** @noSelf */ namespace SelfAnonFuncNSMergedNoSelfNS { export function nsFuncNoSelf(s: string) { return s; } }`,
+    },
 ];
 
 export const noSelfTestFunctions: TestFunction[] = [
@@ -262,6 +278,22 @@ export const noSelfTestFunctions: TestFunction[] = [
         }
         const anonFunctionNestedInClassInNoSelfNs =
             (new AnonFunctionNestedInClassInNoSelfNs.AnonFunctionNestedInClass).method();`,
+    },
+    {
+        value: "noSelfAnonMethodClassMergedNS.method",
+        definition: `/** @noSelf */ class NoSelfAnonMethodClassMergedNS { method(s: string): string { return s; } }
+            namespace NoSelfAnonMethodClassMergedNS { export function nsFunc(s: string) { return s; } }
+            const noSelfAnonMethodClassMergedNS = new NoSelfAnonMethodClassMergedNS();`,
+    },
+    {
+        value: "NoSelfAnonFuncNSMergedClass.nsFunc",
+        definition: `class NoSelfAnonFuncNSMergedClass { method(s: string): string { return s; } }
+        /** @noSelf */ namespace NoSelfAnonFuncNSMergedClass { export function nsFunc(s: string) { return s; } }`,
+    },
+    {
+        value: "NoSelfAnonFuncNSMergedSelfNS.nsFuncNoSelf",
+        definition: `namespace NoSelfAnonFuncNSMergedSelfNS { export function nsFuncSelf(s: string): string { return s; } }
+        /** @noSelf */ namespace NoSelfAnonFuncNSMergedSelfNS { export function nsFuncNoSelf(s: string) { return s; } }`,
     },
 ];
 


### PR DESCRIPTION
fixes #686

Previously, if a namespace or class was decorated with `@noSelf`, this affected all declarations merged with it. This changes that behavior so, for example, methods in a class merged with a `@noSelf` decorated namespace will retain their `self` parameter.

Example:
```ts
declare class A {
    method(s: string): void;
}

/** @noSelf */
declare namespace A {
    export function noSelf(s: string): void;
}

declare namespace A {
    export function hasSelf(s: string): void;
}

const c = new A();
c.method("foo");
A.noSelf("bar");
A.hasSelf("baz");
```
=>
```lua
local c = A.new()
c:method("foo")
A.noSelf("bar")
A:hasSelf("baz")
```