### PR TITLE
class field initialization order

### DIFF
--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -1237,10 +1237,7 @@ export class LuaTransformer {
             return undefined;
         }
 
-        const bodyWithFieldInitializers: tstl.Statement[] = this.transformClassInstanceFields(
-            classDeclaration,
-            instanceFields
-        );
+        const bodyWithFieldInitializers: tstl.Statement[] = [];
 
         // Check for field declarations in constructor
         const constructorFieldsDeclarations = statement.parameters.filter(p => p.modifiers !== undefined);
@@ -1274,6 +1271,8 @@ export class LuaTransformer {
                 bodyWithFieldInitializers.push(assignment);
             }
         }
+
+        bodyWithFieldInitializers.push(...this.transformClassInstanceFields(classDeclaration, instanceFields));
 
         // function className.constructor(self, params) ... end
 

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -1253,7 +1253,8 @@ export class LuaTransformer {
 
         const classInstanceFields = this.transformClassInstanceFields(classDeclaration, instanceFields);
 
-        // If there are field initializers and the first statement is a super call, hoist the super call to the top
+        // If there are field initializers and the first statement is a super call,
+        // move super call between default assignments and initializers
         if (
             (constructorFieldsDeclarations.length > 0 || classInstanceFields.length > 0) &&
             statement.body &&

--- a/test/unit/classes/classes.spec.ts
+++ b/test/unit/classes/classes.spec.ts
@@ -89,26 +89,22 @@ test("ClassConstructorAssignmentDefault", () => {
 });
 
 test("ClassConstructorPropertyInitiailizationOrder", () => {
-    const result = util.transpileAndExecute(
-        `class Test {
+    util.testFunction`
+        class Test {
             public foo = this.bar;
             constructor(public bar: string) {}
         }
-        return (new Test("baz")).foo;`
-    );
-
-    expect(result).toBe("baz");
+        return (new Test("baz")).foo;
+    `.expectToMatchJsResult();
 });
 
 test("ClassConstructorPropertyInitiailizationFalsey", () => {
-    const result = util.transpileAndExecute(
-        `class Test {
+    util.testFunction`
+        class Test {
             constructor(public foo = true) {}
         }
-        return (new Test(false)).foo;`
-    );
-
-    expect(result).toBe(false);
+        return (new Test(false)).foo;
+    `.expectToMatchJsResult();
 });
 
 test("ClassNewNoBrackets", () => {

--- a/test/unit/classes/classes.spec.ts
+++ b/test/unit/classes/classes.spec.ts
@@ -88,6 +88,18 @@ test("ClassConstructorAssignmentDefault", () => {
     expect(result).toBe(3);
 });
 
+test("ClassConstructorPropertyInitiailizationOrder", () => {
+    const result = util.transpileAndExecute(
+        `class Test {
+            public foo = this.bar;
+            constructor(public bar: string) {}
+        }
+        return (new Test("baz")).foo;`
+    );
+
+    expect(result).toBe("baz");
+});
+
 test("ClassNewNoBrackets", () => {
     const result = util.transpileAndExecute(
         `class a {

--- a/test/unit/classes/classes.spec.ts
+++ b/test/unit/classes/classes.spec.ts
@@ -100,6 +100,17 @@ test("ClassConstructorPropertyInitiailizationOrder", () => {
     expect(result).toBe("baz");
 });
 
+test("ClassConstructorPropertyInitiailizationFalsey", () => {
+    const result = util.transpileAndExecute(
+        `class Test {
+            constructor(public foo = true) {}
+        }
+        return (new Test(false)).foo;`
+    );
+
+    expect(result).toBe(false);
+});
+
 test("ClassNewNoBrackets", () => {
     const result = util.transpileAndExecute(
         `class a {


### PR DESCRIPTION
fixes #697

This PR also addresses issues which arose with code like this:
```ts
class Test {
    constructor(public bar = true) {}
}
const result = (new Test(false)).bar;
console.log(result);
```
=>
```lua
Test = {}
Test.name = "Test"
Test.__index = Test
Test.prototype = {}
Test.prototype.__index = Test.prototype
Test.prototype.constructor = Test
function Test.new(...)
    local self = setmetatable({}, Test.prototype)
    self:____constructor(...)
    return self
end
function Test.prototype.____constructor(self, bar)
    self.bar = bar or true
    if bar == nil then
        bar = true
    end
end
local result = Test.new(false).bar
print(result)
```

There are 2 problems here:
- `bar` will incorrectly be assign `true`
- The default value assignment to `bar` is done twice

These are corrected by placing default assignments above field initializers and removing the `or true` assignment to constructor fields:
```lua
function Test.prototype.____constructor(self, bar)
    if bar == nil then
        bar = true
    end
    self.bar = bar
end
```
