### PR TITLE
Fix LuaTable

### DIFF
--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -4665,12 +4665,9 @@ export class LuaTransformer {
 
         const argumentType = this.checker.getTypeAtLocation(expression.argumentExpression);
         const type = this.checker.getTypeAtLocation(expression.expression);
-        const decorators = new Map();
-        if (type && type.symbol) {
-            tsHelper.collectCustomDecorators(type.symbol, this.checker, decorators);
-            if (decorators.has(DecoratorKind.LuaTable)) {
-                throw TSTLErrors.UnsupportedKind("LuaTable access expression", expression.kind, expression);
-            }
+        const decorators = tsHelper.getCustomDecorators(type, this.checker);
+        if (decorators.has(DecoratorKind.LuaTable)) {
+            throw TSTLErrors.UnsupportedKind("LuaTable access expression", expression.kind, expression);
         }
 
         if (

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -5450,18 +5450,13 @@ export class LuaTransformer {
     }
 
     protected getLuaTablePropertyName(node: ts.LeftHandSideExpression): string {
-        let methodName: string;
-        switch (node.kind) {
-            case ts.SyntaxKind.PropertyAccessExpression:
-                methodName = (node as ts.PropertyAccessExpression).name.text;
-                break;
-            case ts.SyntaxKind.Identifier:
-                methodName = (node as ts.Identifier).text;
-                break;
-            default:
-                throw TSTLErrors.UnsupportedKind("LuaTable access expression", node.kind, node);
+        if (ts.isPropertyAccessExpression(node)) {
+            return node.name.text;
+        } else if (ts.isIdentifier(node)) {
+            return node.text;
+        } else {
+            throw TSTLErrors.UnsupportedKind("LuaTable access expression", node.kind, node);
         }
-        return methodName;
     }
 
     protected transformLuaLibFunction(

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -5016,19 +5016,19 @@ export class LuaTransformer {
     protected transformLuaTableExpressionAsExpressionStatement(expression: ts.CallExpression): tstl.Statement {
         const methodName = this.getLuaTablePropertyName(expression.expression);
         const signature = this.checker.getResolvedSignature(expression);
-        const tableAccessExpression = this.transformExpression(expression.expression);
+        const leftHandSideExpression = this.transformExpression(expression.expression);
         const params = this.transformArguments(expression.arguments, signature);
 
         switch (methodName) {
             case "get":
                 return tstl.createVariableDeclarationStatement(
                     tstl.createAnonymousIdentifier(expression),
-                    tstl.createTableIndexExpression(tableAccessExpression, params[0], expression),
+                    tstl.createTableIndexExpression(leftHandSideExpression, params[0], expression),
                     expression
                 );
             case "set":
                 return tstl.createAssignmentStatement(
-                    tstl.createTableIndexExpression(tableAccessExpression, params[0], expression),
+                    tstl.createTableIndexExpression(leftHandSideExpression, params[0], expression),
                     params.splice(1),
                     expression
                 );

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -4617,7 +4617,7 @@ export class LuaTransformer {
         }
     }
 
-    protected transformLuaTableProperty(node: ts.PropertyAccessExpression): tstl.Expression {
+    protected transformLuaTableProperty(node: ts.PropertyAccessExpression): tstl.UnaryExpression {
         const [luaTable, propertyName] = this.parseLuaTableExpression(node);
         switch (propertyName) {
             case "length":
@@ -5034,7 +5034,7 @@ export class LuaTransformer {
             case "get":
                 return tstl.createTableIndexExpression(luaTable, params[0], expression);
             default:
-                throw TSTLErrors.UnsupportedProperty("LuaTable", methodName, expression);
+                throw TSTLErrors.ForbiddenLuaTableUseException("Unsupported method.", methodName, expression);
         }
     }
 

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -5012,19 +5012,19 @@ export class LuaTransformer {
     protected transformLuaTableExpressionAsExpressionStatement(expression: ts.CallExpression): tstl.Statement {
         const methodName = this.getLuaTablePropertyName(expression.expression);
         const signature = this.checker.getResolvedSignature(expression);
-        const leftHandSideExpression = this.transformExpression(expression.expression);
+        const luaTable = this.transformExpression(expression.expression);
         const params = this.transformArguments(expression.arguments, signature);
 
         switch (methodName) {
             case "get":
                 return tstl.createVariableDeclarationStatement(
                     tstl.createAnonymousIdentifier(expression),
-                    tstl.createTableIndexExpression(leftHandSideExpression, params[0], expression),
+                    tstl.createTableIndexExpression(luaTable, params[0], expression),
                     expression
                 );
             case "set":
                 return tstl.createAssignmentStatement(
-                    tstl.createTableIndexExpression(leftHandSideExpression, params[0], expression),
+                    tstl.createTableIndexExpression(luaTable, params[0], expression),
                     params.splice(1),
                     expression
                 );
@@ -5036,12 +5036,12 @@ export class LuaTransformer {
     protected transformLuaTableCallExpression(expression: ts.CallExpression): tstl.Expression {
         const methodName = this.getLuaTablePropertyName(expression.expression);
         const signature = this.checker.getResolvedSignature(expression);
-        const tableAccessExpression = this.transformExpression(expression.expression);
+        const luaTable = this.transformExpression(expression.expression);
         const params = this.transformArguments(expression.arguments, signature);
 
         switch (methodName) {
             case "get":
-                return tstl.createTableIndexExpression(tableAccessExpression, params[0], expression);
+                return tstl.createTableIndexExpression(luaTable, params[0], expression);
             default:
                 throw TSTLErrors.UnsupportedProperty("LuaTable", methodName, expression);
         }

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -4996,9 +4996,6 @@ export class LuaTransformer {
                 if (callArguments.length !== 2) {
                     throw TSTLErrors.ForbiddenLuaTableUseException("Two parameters are required for set().", original);
                 }
-                if (original.parent.kind !== ts.SyntaxKind.ExpressionStatement) {
-                    throw TSTLErrors.ForbiddenLuaTableSetExpression(original);
-                }
                 break;
         }
     }

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -4617,7 +4617,7 @@ export class LuaTransformer {
         }
     }
 
-    protected transformLuaTableProperty(node: ts.PropertyAccessExpression): tstl.UnaryExpression {
+    protected transformLuaTableProperty(node: ts.PropertyAccessExpression): tstl.Expression {
         const [luaTable, propertyName] = this.parseLuaTableExpression(node);
         switch (propertyName) {
             case "length":
@@ -5034,7 +5034,7 @@ export class LuaTransformer {
             case "get":
                 return tstl.createTableIndexExpression(luaTable, params[0], expression);
             default:
-                throw TSTLErrors.ForbiddenLuaTableUseException("Unsupported method.", methodName, expression);
+                throw TSTLErrors.UnsupportedProperty("LuaTable", methodName, expression);
         }
     }
 

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -2165,16 +2165,12 @@ export class LuaTransformer {
             );
         }
 
-        if (
-            ts.isExpressionStatement(statement) &&
-            ts.isCallExpression(statement.expression) &&
-            ts.isPropertyAccessExpression(statement.expression.expression)
-        ) {
-            const ownerType = this.checker.getTypeAtLocation(statement.expression.expression.expression);
+        if (ts.isCallExpression(expression) && ts.isPropertyAccessExpression(expression.expression)) {
+            const ownerType = this.checker.getTypeAtLocation(expression.expression.expression);
             const classDecorators = tsHelper.getCustomDecorators(ownerType, this.checker);
             if (classDecorators.has(DecoratorKind.LuaTable)) {
-                this.validateLuaTableCall(statement.expression);
-                return this.transformLuaTableExpressionAsExpressionStatement(statement.expression);
+                this.validateLuaTableCall(expression);
+                return this.transformLuaTableExpressionAsExpressionStatement(expression);
             }
         }
 

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -5445,8 +5445,6 @@ export class LuaTransformer {
     protected getLuaTablePropertyName(node: ts.LeftHandSideExpression): string {
         if (ts.isPropertyAccessExpression(node)) {
             return node.name.text;
-        } else if (ts.isIdentifier(node)) {
-            return node.text;
         } else {
             throw TSTLErrors.UnsupportedKind("LuaTable access expression", node.kind, node);
         }

--- a/src/TSTLErrors.ts
+++ b/src/TSTLErrors.ts
@@ -13,12 +13,6 @@ export const ForbiddenEllipsisDestruction = (node: ts.Node) =>
 export const ForbiddenForIn = (node: ts.Node) =>
     new TranspileError(`Iterating over arrays with 'for ... in' is not allowed.`, node);
 
-export const ForbiddenLuaTableSetExpression = (node: ts.Node) =>
-    new TranspileError(
-        `A '@luaTable' object's 'set()' method can only be used as a Statement, not an Expression.`,
-        node
-    );
-
 export const ForbiddenLuaTableNonDeclaration = (node: ts.Node) =>
     new TranspileError(`Classes with the '@luaTable' decorator must be declared.`, node);
 

--- a/test/unit/decorators/luaTable.spec.ts
+++ b/test/unit/decorators/luaTable.spec.ts
@@ -129,6 +129,14 @@ test.each([tableLibClass, tableLibInterface])("Cannot use ElementAccessExpressio
     );
 });
 
+test.each([tableLibClass, tableLibInterface])("Cannot isolate LuaTable methods", tableLib => {
+    test.each([`set`, `get`])("Cannot isolate LuaTable method (%p)", propertyName => {
+        expect(() => util.transpileString(`${tableLib} let property = tbl.${propertyName}`)).toThrowExactError(
+            TSTLErrors.UnsupportedProperty("LuaTable", propertyName, util.nodeStub)
+        );
+    });
+});
+
 test.each([tableLibClass])("LuaTable functional tests", tableLib => {
     test.each<[string, any]>([
         [`const t = new Table(); t.set("field", "value"); return t.get("field");`, "value"],

--- a/test/unit/decorators/luaTable.spec.ts
+++ b/test/unit/decorators/luaTable.spec.ts
@@ -1,3 +1,4 @@
+import * as ts from "typescript";
 import * as TSTLErrors from "../../../src/TSTLErrors";
 import * as util from "../../util";
 
@@ -40,15 +41,15 @@ test.each([tableLibClass, tableLibInterface])("LuaTable set() cannot be used in 
     );
 });
 
-test.each([tableLibClass, tableLibInterface])("LuaTables cannot have other methods", tableLib => {
+test.each([tableLibClass, tableLibInterface])("LuaTables cannot have other members", tableLib => {
     expect(() => util.transpileString(tableLib + `tbl.other()`)).toThrowExactError(
-        TSTLErrors.ForbiddenLuaTableUseException("Unsupported method.", util.nodeStub)
+        TSTLErrors.UnsupportedProperty("LuaTable", "other", util.nodeStub)
     );
 });
 
-test.each([tableLibClass, tableLibInterface])("LuaTables cannot have other methods", tableLib => {
+test.each([tableLibClass, tableLibInterface])("LuaTables cannot have other members", tableLib => {
     expect(() => util.transpileString(tableLib + `let x = tbl.other()`)).toThrowExactError(
-        TSTLErrors.ForbiddenLuaTableUseException("Unsupported method.", util.nodeStub)
+        TSTLErrors.UnsupportedProperty("LuaTable", "other", util.nodeStub)
     );
 });
 
@@ -113,12 +114,28 @@ test.each([tableLibClass])("Cannot extend LuaTable class", tableLib => {
     });
 });
 
+test.each([tableLibClass, tableLibInterface])("Cannot use ElementAccessExpression on a LuaTable", tableLib => {
+    test.each([`tbl["get"]("field")`, `tbl["set"]("field")`, `tbl["length"]`])(
+        "Cannot use ElementAccessExpression on a LuaTable (%p)",
+        code => {
+            expect(() => util.transpileString(tableLib + code)).toThrowExactError(
+                TSTLErrors.UnsupportedKind(
+                    "LuaTable access expression",
+                    ts.SyntaxKind.ElementAccessExpression,
+                    util.nodeStub
+                )
+            );
+        }
+    );
+});
+
 test.each([tableLibClass])("LuaTable functional tests", tableLib => {
     test.each<[string, any]>([
         [`const t = new Table(); t.set("field", "value"); return t.get("field");`, "value"],
         [`const t = new Table(); t.set("field", 0); return t.get("field");`, 0],
         [`const t = new Table(); t.set(1, true); return t.length`, 1],
         [`const t = new Table(); t.set(t.length + 1, true); t.set(t.length + 1, true); return t.length`, 2],
+        [`const k = "k"; const t = { data: new Table() }; t.data.set(k, 3); return t.data.get(k);`, 3],
     ])("LuaTable test (%p)", (code, expectedReturnValue) => {
         expect(util.transpileAndExecute(code, undefined, undefined, tableLib)).toBe(expectedReturnValue);
     });

--- a/test/unit/decorators/luaTable.spec.ts
+++ b/test/unit/decorators/luaTable.spec.ts
@@ -35,11 +35,14 @@ test.each([tableLibClass])("LuaTables cannot be constructed with arguments", tab
     );
 });
 
-test.each([tableLibClass, tableLibInterface])("LuaTable set() cannot be used in an expression position", tableLib => {
-    expect(() => util.transpileString(tableLib + `const exp = tbl.set("value", 5)`)).toThrowExactError(
-        TSTLErrors.ForbiddenLuaTableSetExpression(util.nodeStub)
-    );
-});
+test.each([tableLibClass, tableLibInterface])(
+    "LuaTable set() cannot be used in a LuaTable call expression",
+    tableLib => {
+        expect(() => util.transpileString(tableLib + `const exp = tbl.set("value", 5)`)).toThrowExactError(
+            TSTLErrors.UnsupportedProperty("LuaTable", "set", util.nodeStub)
+        );
+    }
+);
 
 test.each([tableLibClass, tableLibInterface])("LuaTables cannot have other members", tableLib => {
     expect(() => util.transpileString(tableLib + `tbl.other()`)).toThrowExactError(


### PR DESCRIPTION
Closes #699

Also added a rule preventing LuaTables from being accessed via ElementAccessExpressions.

```diff
  /** @LuaTable */
  declare class LuaTable<K extends {} = {}, V = any> {
    readonly length: number;
    set(key: K, value: V): void;
    get(key: K): V;
  }
  
  const k = "k"
  const t = { data: new LuaTable() }
+ const v = t.data.get(k) // --> local v = t.data[k]
+ t.data.set(k,v) // --> t.data[k] = v
+ const v2 = t.data.get(k).x; // --> local v2 = t.data[k].x
- const v3 = t.data["get"](k)
- t.data["set"](k, v)
```

Removed a lot of casting to track down the bug.