### PR TITLE
Preserving order in Map and Set using doubly linked lists

### DIFF
--- a/src/lualib/Map.ts
+++ b/src/lualib/Map.ts
@@ -86,7 +86,7 @@ Map = class Map<K, V> {
     }
 
     public has(key: K): boolean {
-        return this.items.get(key) !== undefined;
+        return this.nextKey.get(key) !== undefined || this.lastKey === key;
     }
 
     public set(key: K, value: V): this {

--- a/src/lualib/Map.ts
+++ b/src/lualib/Map.ts
@@ -39,6 +39,8 @@ Map = class Map<K, V> {
         this.items = {};
         this.nextKey = {};
         this.previousKey = {};
+        this.firstKey = undefined;
+        this.lastKey = undefined;
         this.size = 0;
         return;
     }
@@ -60,6 +62,9 @@ Map = class Map<K, V> {
             } else if (previous) {
                 this.lastKey = previous;
                 this.nextKey[previous as any] = undefined;
+            } else {
+                this.firstKey = undefined;
+                this.lastKey = undefined;
             }
 
             this.nextKey[key as any] = undefined;

--- a/src/lualib/Map.ts
+++ b/src/lualib/Map.ts
@@ -2,14 +2,14 @@ Map = class Map<K, V> {
     public static [Symbol.species] = Map;
     public [Symbol.toStringTag] = "Map";
 
-    private items: LuaTable<K, V> = new LuaTable();
+    private items = new LuaTable<K, V>();
     public size = 0;
 
     // Key-order variables
     private firstKey: K | undefined;
     private lastKey: K | undefined;
-    private nextKey: LuaTable<K, K> = new LuaTable();
-    private previousKey: LuaTable<K, K> = new LuaTable();
+    private nextKey = new LuaTable<K, K>();
+    private previousKey = new LuaTable<K, K>();
 
     constructor(entries?: Iterable<readonly [K, V]> | Array<readonly [K, V]>) {
         if (entries === undefined) return;

--- a/src/lualib/Set.ts
+++ b/src/lualib/Set.ts
@@ -2,8 +2,6 @@ Set = class Set<T> {
     public static [Symbol.species] = Set;
     public [Symbol.toStringTag] = "Set";
 
-    // Key type is actually T
-    private items: { [key: string]: boolean } = {};
     public size = 0;
 
     // Key-order variables
@@ -39,7 +37,6 @@ Set = class Set<T> {
         if (isNewValue) {
             this.size++;
         }
-        this.items[value as any] = true;
 
         // Do order bookkeeping
         if (this.firstKey === undefined) {
@@ -55,9 +52,10 @@ Set = class Set<T> {
     }
 
     public clear(): void {
-        this.items = {};
         this.nextKey = {};
         this.previousKey = {};
+        this.firstKey = undefined;
+        this.lastKey = undefined;
         this.size = 0;
         return;
     }
@@ -79,12 +77,15 @@ Set = class Set<T> {
             } else if (previous) {
                 this.lastKey = previous;
                 this.nextKey[previous as any] = undefined;
+            } else {
+                this.firstKey = undefined;
+                this.lastKey = undefined;
             }
 
             this.nextKey[value as any] = undefined;
             this.previousKey[value as any] = undefined;
         }
-        this.items[value as any] = undefined;
+
         return contains;
     }
 
@@ -95,7 +96,7 @@ Set = class Set<T> {
     }
 
     public has(value: T): boolean {
-        return this.items[value as any] === true;
+        return this.nextKey[value as any] !== undefined || this.lastKey === value;
     }
 
     public [Symbol.iterator](): IterableIterator<T> {
@@ -103,43 +104,46 @@ Set = class Set<T> {
     }
 
     public entries(): IterableIterator<[T, T]> {
-        const items = this.items;
-        let key: T;
+        const nextKey = this.nextKey;
+        let key: T = this.firstKey;
         return {
             [Symbol.iterator](): IterableIterator<[T, T]> {
                 return this;
             },
             next(): IteratorResult<[T, T]> {
-                [key] = next(items, key);
-                return { done: !key, value: [key, key] };
+                const result = { done: !key, value: [key, key] as [T, T] };
+                key = nextKey[key as any];
+                return result;
             },
         };
     }
 
     public keys(): IterableIterator<T> {
-        const items = this.items;
-        let key: T;
+        const nextKey = this.nextKey;
+        let key: T = this.firstKey;
         return {
             [Symbol.iterator](): IterableIterator<T> {
                 return this;
             },
             next(): IteratorResult<T> {
-                [key] = next(items, key);
-                return { done: !key, value: key };
+                const result = { done: !key, value: key };
+                key = nextKey[key as any];
+                return result;
             },
         };
     }
 
     public values(): IterableIterator<T> {
-        const items = this.items;
-        let key: T;
+        const nextKey = this.nextKey;
+        let key: T = this.firstKey;
         return {
             [Symbol.iterator](): IterableIterator<T> {
                 return this;
             },
             next(): IteratorResult<T> {
-                [key] = next(items, key);
-                return { done: !key, value: key };
+                const result = { done: !key, value: key };
+                key = nextKey[key as any];
+                return result;
             },
         };
     }

--- a/src/lualib/Set.ts
+++ b/src/lualib/Set.ts
@@ -6,8 +6,8 @@ Set = class Set<T> {
 
     private firstKey: T | undefined;
     private lastKey: T | undefined;
-    private nextKey: LuaTable<T, T> = new LuaTable();
-    private previousKey: LuaTable<T, T> = new LuaTable();
+    private nextKey = new LuaTable<T, T>();
+    private previousKey = new LuaTable<T, T>();
 
     constructor(values?: Iterable<T> | T[]) {
         if (values === undefined) return;

--- a/src/lualib/Set.ts
+++ b/src/lualib/Set.ts
@@ -28,9 +28,8 @@ Set = class Set<T> {
             }
         } else {
             const array = values as T[];
-            this.size = array.length;
             for (const value of array) {
-                this.items[value as any] = true;
+                this.add(value);
             }
         }
     }

--- a/src/lualib/WeakMap.ts
+++ b/src/lualib/WeakMap.ts
@@ -2,8 +2,7 @@ WeakMap = class WeakMap<K extends object, V> {
     public static [Symbol.species] = WeakMap;
     public [Symbol.toStringTag] = "WeakMap";
 
-    // Type of key is actually K
-    private items: { [key: string]: V } = {};
+    private items = new LuaTable<K, V>();
 
     constructor(entries?: Iterable<readonly [K, V]> | Array<readonly [K, V]>) {
         setmetatable(this.items, { __mode: "k" });
@@ -19,31 +18,31 @@ WeakMap = class WeakMap<K extends object, V> {
                     break;
                 }
                 const value: [K, V] = result.value; // Ensures index is offset when tuple is accessed
-                this.set(value[0], value[1]);
+                this.items.set(value[0], value[1]);
             }
         } else {
             for (const kvp of entries as Array<[K, V]>) {
-                this.items[kvp[0] as any] = kvp[1];
+                this.items.set(kvp[0], kvp[1]);
             }
         }
     }
 
     public delete(key: K): boolean {
         const contains = this.has(key);
-        this.items[key as any] = undefined;
+        this.items.set(key, undefined);
         return contains;
     }
 
     public get(key: K): V | undefined {
-        return this.items[key as any];
+        return this.items.get(key);
     }
 
     public has(key: K): boolean {
-        return this.items[key as any] !== undefined;
+        return this.items.get(key) !== undefined;
     }
 
     public set(key: K, value: V): this {
-        this.items[key as any] = value;
+        this.items.set(key, value);
         return this;
     }
 };

--- a/src/lualib/WeakSet.ts
+++ b/src/lualib/WeakSet.ts
@@ -2,8 +2,7 @@ WeakSet = class WeakSet<T extends object> {
     public static [Symbol.species] = WeakSet;
     public [Symbol.toStringTag] = "WeakSet";
 
-    // Key type is actually T
-    private items: { [key: string]: boolean } = {};
+    private items = new LuaTable<T, boolean>();
 
     constructor(values?: Iterable<T> | T[]) {
         setmetatable(this.items, { __mode: "k" });
@@ -18,27 +17,27 @@ WeakSet = class WeakSet<T extends object> {
                 if (result.done) {
                     break;
                 }
-                this.add(result.value);
+                this.items.set(result.value, true);
             }
         } else {
             for (const value of values as T[]) {
-                this.items[value as any] = true;
+                this.items.set(value, true);
             }
         }
     }
 
     public add(value: T): this {
-        this.items[value as any] = true;
+        this.items.set(value, true);
         return this;
     }
 
     public delete(value: T): boolean {
         const contains = this.has(value);
-        this.items[value as any] = undefined;
+        this.items.set(value, undefined);
         return contains;
     }
 
     public has(value: T): boolean {
-        return this.items[value as any] === true;
+        return this.items.get(value) === true;
     }
 };

--- a/src/lualib/declarations/luatable.d.ts
+++ b/src/lualib/declarations/luatable.d.ts
@@ -1,0 +1,6 @@
+/** @LuaTable */
+declare class LuaTable<K, V> {
+    public readonly length: number;
+    public set(key: K, value: V): void;
+    public get(key: K): V | undefined;
+}

--- a/src/lualib/declarations/luatable.d.ts
+++ b/src/lualib/declarations/luatable.d.ts
@@ -1,6 +1,6 @@
 /** @LuaTable */
-declare class LuaTable<K, V> {
+declare class LuaTable<K extends {}, V> {
     public readonly length: number;
-    public set(key: K, value: V): void;
+    public set(key: K, value: V | undefined): void;
     public get(key: K): V | undefined;
 }

--- a/test/unit/builtins/map.spec.ts
+++ b/test/unit/builtins/map.spec.ts
@@ -135,3 +135,51 @@ test("map size", () => {
     expect(util.transpileAndExecute(`let m = new Map([[1,2],[3,4]]); m.clear(); return m.size;`)).toBe(0);
     expect(util.transpileAndExecute(`let m = new Map([[1,2],[3,4]]); m.delete(3); return m.size;`)).toBe(1);
 });
+
+test("map.entries() preserves insertion order", () => {
+    util.testFunction`
+        const mymap = new Map();
+        
+        mymap.set("x", 1);
+        mymap.set("a", 2);
+        mymap.set(4, 3);
+        mymap.set(1, 4);
+        mymap.set("a", 5);
+
+        return [...mymap.entries()];
+    `
+        .expectToMatchJsResult()
+        .expectToEqual([["x", 1], ["a", 5], [4, 3], [1, 4]]);
+});
+
+test("map.keys() preserves insertion order", () => {
+    util.testFunction`
+        const mymap = new Map();
+        
+        mymap.set("x", 1);
+        mymap.set("a", 2);
+        mymap.set(4, 3);
+        mymap.set(1, 4);
+        mymap.set("a", 5);
+
+        return [...mymap.keys()];
+    `
+        .expectToMatchJsResult()
+        .expectToEqual(["x", "a", 4, 1]);
+});
+
+test("map.values() preserves insertion order", () => {
+    util.testFunction`
+        const mymap = new Map();
+
+        mymap.set("x", 1);
+        mymap.set("a", 2);
+        mymap.set(4, 3);
+        mymap.set(1, 4);
+        mymap.set("a", 5);
+
+        return [...mymap.values()];
+    `
+        .expectToMatchJsResult()
+        .expectToEqual([1, 5, 3, 4]);
+});

--- a/test/unit/builtins/map.spec.ts
+++ b/test/unit/builtins/map.spec.ts
@@ -92,9 +92,28 @@ test("map has false", () => {
     expect(contains).toBe(false);
 });
 
-test("map has null", () => {
-    const contains = util.transpileAndExecute(`let mymap = new Map([["a", "c"]]); return mymap.has(null);`);
-    expect(contains).toBe(false);
+test.each([
+    `[["a", null]]`,
+    `[["b", "c"], ["a", null]]`,
+    `[["a", null], ["b", "c"]]`,
+    `[["b", "c"], ["a", null], ["x", "y"]]`,
+])("map (%p) has null", entries => {
+    util.testFunction`
+        let mymap = new Map(${entries});
+        return mymap.has("a");
+    `.expectToMatchJsResult();
+});
+
+test.each([
+    `[["a", undefined]]`,
+    `[["b", "c"], ["a", undefined]]`,
+    `[["a", undefined], ["b", "c"]]`,
+    `[["b", "c"], ["a", undefined], ["x", "y"]]`,
+])("map (%p) has undefined", entries => {
+    util.testFunction`
+        let mymap = new Map(${entries});
+        return mymap.has("a");
+    `.expectToMatchJsResult();
 });
 
 test("map keys", () => {

--- a/test/unit/builtins/map.spec.ts
+++ b/test/unit/builtins/map.spec.ts
@@ -136,15 +136,21 @@ test("map size", () => {
     expect(util.transpileAndExecute(`let m = new Map([[1,2],[3,4]]); m.delete(3); return m.size;`)).toBe(1);
 });
 
+const testMapConstructionCode = `
+    const mymap = new Map();
+            
+    mymap.set("x", 1);
+    mymap.set("a", 2);
+    mymap.set(4, 3);
+    mymap.set("b", 6);
+    mymap.set(1, 4);
+    mymap.set("a", 5);
+    
+    mymap.delete("b")`;
+
 test("map.entries() preserves insertion order", () => {
     util.testFunction`
-        const mymap = new Map();
-        
-        mymap.set("x", 1);
-        mymap.set("a", 2);
-        mymap.set(4, 3);
-        mymap.set(1, 4);
-        mymap.set("a", 5);
+        ${testMapConstructionCode}
 
         return [...mymap.entries()];
     `
@@ -154,13 +160,7 @@ test("map.entries() preserves insertion order", () => {
 
 test("map.keys() preserves insertion order", () => {
     util.testFunction`
-        const mymap = new Map();
-        
-        mymap.set("x", 1);
-        mymap.set("a", 2);
-        mymap.set(4, 3);
-        mymap.set(1, 4);
-        mymap.set("a", 5);
+        ${testMapConstructionCode}
 
         return [...mymap.keys()];
     `
@@ -170,13 +170,7 @@ test("map.keys() preserves insertion order", () => {
 
 test("map.values() preserves insertion order", () => {
     util.testFunction`
-        const mymap = new Map();
-
-        mymap.set("x", 1);
-        mymap.set("a", 2);
-        mymap.set(4, 3);
-        mymap.set(1, 4);
-        mymap.set("a", 5);
+        ${testMapConstructionCode}
 
         return [...mymap.values()];
     `

--- a/test/unit/builtins/map.spec.ts
+++ b/test/unit/builtins/map.spec.ts
@@ -136,44 +136,63 @@ test("map size", () => {
     expect(util.transpileAndExecute(`let m = new Map([[1,2],[3,4]]); m.delete(3); return m.size;`)).toBe(1);
 });
 
-const testMapConstructionCode = `
-    const mymap = new Map();
+const iterationMethods = ["entries", "keys", "values"];
+
+test.each(iterationMethods)("map.%s() preserves insertion order", iterationMethod => {
+    util.testFunction`
+        const mymap = new Map();
             
-    mymap.set("x", 1);
-    mymap.set("a", 2);
-    mymap.set(4, 3);
-    mymap.set("b", 6);
-    mymap.set(1, 4);
-    mymap.set("a", 5);
-    
-    mymap.delete("b")`;
+        mymap.set("x", 1);
+        mymap.set("a", 2);
+        mymap.set(4, 3);
+        mymap.set("b", 6);
+        mymap.set(1, 4);
+        mymap.set("a", 5);
+        
+        mymap.delete("b");
 
-test("map.entries() preserves insertion order", () => {
-    util.testFunction`
-        ${testMapConstructionCode}
-
-        return [...mymap.entries()];
-    `
-        .expectToMatchJsResult()
-        .expectToEqual([["x", 1], ["a", 5], [4, 3], [1, 4]]);
+        return [...mymap.${iterationMethod}()];
+    `.expectToMatchJsResult();
 });
 
-test("map.keys() preserves insertion order", () => {
+test.each(iterationMethods)("map.%s() preserves insertion order after removing last", iterationMethod => {
     util.testFunction`
-        ${testMapConstructionCode}
+        const mymap = new Map();
+            
+        mymap.set("x", 1);
+        mymap.set("a", 2);
+        mymap.set(4, 3);
+        
+        mymap.delete(4);
 
-        return [...mymap.keys()];
-    `
-        .expectToMatchJsResult()
-        .expectToEqual(["x", "a", 4, 1]);
+        return [...mymap.${iterationMethod}()];
+    `.expectToMatchJsResult();
 });
 
-test("map.values() preserves insertion order", () => {
+test.each(iterationMethods)("map.%s() preserves insertion order after removing first", iterationMethod => {
     util.testFunction`
-        ${testMapConstructionCode}
+        const mymap = new Map();
+            
+        mymap.set("x", 1);
+        mymap.set("a", 2);
+        mymap.set(4, 3);
+        
+        mymap.delete("x");
 
-        return [...mymap.values()];
-    `
-        .expectToMatchJsResult()
-        .expectToEqual([1, 5, 3, 4]);
+        return [...mymap.${iterationMethod}()];
+    `.expectToMatchJsResult();
+});
+
+test.each(iterationMethods)("map.%s() preserves insertion order after removing all", iterationMethod => {
+    util.testFunction`
+        const mymap = new Map();
+            
+        mymap.set("x", 1);
+        mymap.set("a", 2);
+        
+        mymap.delete("a");
+        mymap.delete("x");
+
+        return [...mymap.${iterationMethod}()];
+    `.expectToMatchJsResult();
 });

--- a/test/unit/builtins/map.spec.ts
+++ b/test/unit/builtins/map.spec.ts
@@ -156,62 +156,63 @@ test("map size", () => {
 });
 
 const iterationMethods = ["entries", "keys", "values"];
-
-test.each(iterationMethods)("map.%s() preserves insertion order", iterationMethod => {
-    util.testFunction`
-        const mymap = new Map();
+describe.each(iterationMethods)("map.%s() preserves insertion order", iterationMethod => {
+    test("basic", () => {
+        util.testFunction`
+            const mymap = new Map();
+                
+            mymap.set("x", 1);
+            mymap.set("a", 2);
+            mymap.set(4, 3);
+            mymap.set("b", 6);
+            mymap.set(1, 4);
+            mymap.set("a", 5);
             
-        mymap.set("x", 1);
-        mymap.set("a", 2);
-        mymap.set(4, 3);
-        mymap.set("b", 6);
-        mymap.set(1, 4);
-        mymap.set("a", 5);
-        
-        mymap.delete("b");
+            mymap.delete("b");
 
-        return [...mymap.${iterationMethod}()];
-    `.expectToMatchJsResult();
-});
+            return [...mymap.${iterationMethod}()];
+        `.expectToMatchJsResult();
+    });
 
-test.each(iterationMethods)("map.%s() preserves insertion order after removing last", iterationMethod => {
-    util.testFunction`
-        const mymap = new Map();
+    test("after removing last", () => {
+        util.testFunction`
+            const mymap = new Map();
+                
+            mymap.set("x", 1);
+            mymap.set("a", 2);
+            mymap.set(4, 3);
             
-        mymap.set("x", 1);
-        mymap.set("a", 2);
-        mymap.set(4, 3);
-        
-        mymap.delete(4);
+            mymap.delete(4);
 
-        return [...mymap.${iterationMethod}()];
-    `.expectToMatchJsResult();
-});
+            return [...mymap.${iterationMethod}()];
+        `.expectToMatchJsResult();
+    });
 
-test.each(iterationMethods)("map.%s() preserves insertion order after removing first", iterationMethod => {
-    util.testFunction`
-        const mymap = new Map();
+    test("after removing first", () => {
+        util.testFunction`
+            const mymap = new Map();
+                
+            mymap.set("x", 1);
+            mymap.set("a", 2);
+            mymap.set(4, 3);
             
-        mymap.set("x", 1);
-        mymap.set("a", 2);
-        mymap.set(4, 3);
-        
-        mymap.delete("x");
+            mymap.delete("x");
 
-        return [...mymap.${iterationMethod}()];
-    `.expectToMatchJsResult();
-});
+            return [...mymap.${iterationMethod}()];
+        `.expectToMatchJsResult();
+    });
 
-test.each(iterationMethods)("map.%s() preserves insertion order after removing all", iterationMethod => {
-    util.testFunction`
-        const mymap = new Map();
+    test("after removing all", () => {
+        util.testFunction`
+            const mymap = new Map();
+                
+            mymap.set("x", 1);
+            mymap.set("a", 2);
             
-        mymap.set("x", 1);
-        mymap.set("a", 2);
-        
-        mymap.delete("a");
-        mymap.delete("x");
+            mymap.delete("a");
+            mymap.delete("x");
 
-        return [...mymap.${iterationMethod}()];
-    `.expectToMatchJsResult();
+            return [...mymap.${iterationMethod}()];
+        `.expectToMatchJsResult();
+    });
 });

--- a/test/unit/builtins/set.spec.ts
+++ b/test/unit/builtins/set.spec.ts
@@ -120,3 +120,45 @@ test.each([
 ])("set size (%p)", code => {
     util.testFunction`${code}; return m.size`.expectToMatchJsResult();
 });
+
+test("set.entries() preserves insertion order", () => {
+    util.testFunction`
+        const myset = new Set();
+        myset.add("x");
+        myset.add("a");
+        myset.add(4);
+        myset.add(1);
+
+        return [...myset.entries()];
+    `
+        .expectToMatchJsResult()
+        .expectToEqual([["x", "x"], ["a", "a"], [4, 4], [1, 1]]);
+});
+
+test("set.keys() preserves insertion order", () => {
+    util.testFunction`
+        const myset = new Set();
+        myset.add("x");
+        myset.add("a");
+        myset.add(4);
+        myset.add(1);
+
+        return [...myset.keys()];
+    `
+        .expectToMatchJsResult()
+        .expectToEqual(["x", "a", 4, 1]);
+});
+
+test("set.values() preserves insertion order", () => {
+    util.testFunction`
+        const myset = new Set();
+        myset.add("x");
+        myset.add("a");
+        myset.add(4);
+        myset.add(1);
+
+        return [...myset.values()];
+    `
+        .expectToMatchJsResult()
+        .expectToEqual(["x", "a", 4, 1]);
+});

--- a/test/unit/builtins/set.spec.ts
+++ b/test/unit/builtins/set.spec.ts
@@ -121,13 +121,20 @@ test.each([
     util.testFunction`${code}; return m.size`.expectToMatchJsResult();
 });
 
+const testSetConstructionCode = `
+    const myset = new Set();
+
+    myset.add("x");
+    myset.add("a");
+    myset.add(4);
+    myset.add("b");
+    myset.add(1);
+
+    myset.delete("b");`;
+
 test("set.entries() preserves insertion order", () => {
     util.testFunction`
-        const myset = new Set();
-        myset.add("x");
-        myset.add("a");
-        myset.add(4);
-        myset.add(1);
+        ${testSetConstructionCode}
 
         return [...myset.entries()];
     `
@@ -137,11 +144,7 @@ test("set.entries() preserves insertion order", () => {
 
 test("set.keys() preserves insertion order", () => {
     util.testFunction`
-        const myset = new Set();
-        myset.add("x");
-        myset.add("a");
-        myset.add(4);
-        myset.add(1);
+        ${testSetConstructionCode}
 
         return [...myset.keys()];
     `
@@ -151,11 +154,7 @@ test("set.keys() preserves insertion order", () => {
 
 test("set.values() preserves insertion order", () => {
     util.testFunction`
-        const myset = new Set();
-        myset.add("x");
-        myset.add("a");
-        myset.add(4);
-        myset.add(1);
+        ${testSetConstructionCode}
 
         return [...myset.values()];
     `

--- a/test/unit/builtins/set.spec.ts
+++ b/test/unit/builtins/set.spec.ts
@@ -79,6 +79,18 @@ test("set has", () => {
     `.expectToMatchJsResult();
 });
 
+test("set has after deleting keys", () => {
+    util.testFunction`
+        let myset = new Set(["a", "c"]);
+        const results = [myset.has("c")];
+        myset.delete("c");
+        results.push(myset.has("c"));
+        myset.delete("a");
+        results.push(myset.has("a"))
+        return results;
+    `.expectToMatchJsResult();
+});
+
 test("set has false", () => {
     util.testFunction`
         let myset = new Set();
@@ -121,43 +133,63 @@ test.each([
     util.testFunction`${code}; return m.size`.expectToMatchJsResult();
 });
 
-const testSetConstructionCode = `
-    const myset = new Set();
+const iterationMethods = ["entries", "keys", "values"];
 
-    myset.add("x");
-    myset.add("a");
-    myset.add(4);
-    myset.add("b");
-    myset.add(1);
-
-    myset.delete("b");`;
-
-test("set.entries() preserves insertion order", () => {
+test.each(iterationMethods)("set.%s() preserves insertion order", iterationMethod => {
     util.testFunction`
-        ${testSetConstructionCode}
+        const myset = new Set();
+            
+        myset.add("x");
+        myset.add("a");
+        myset.add(4);
+        myset.add("b");
+        myset.add(1);
+        myset.add("a");
+        
+        myset.delete("b");
 
-        return [...myset.entries()];
-    `
-        .expectToMatchJsResult()
-        .expectToEqual([["x", "x"], ["a", "a"], [4, 4], [1, 1]]);
+        return [...myset.${iterationMethod}()];
+    `.expectToMatchJsResult();
 });
 
-test("set.keys() preserves insertion order", () => {
+test.each(iterationMethods)("set.%s() preserves insertion order after removing last", iterationMethod => {
     util.testFunction`
-        ${testSetConstructionCode}
+        const myset = new Set();
+            
+        myset.add("x");
+        myset.add("a");
+        myset.add(4);
+        
+        myset.delete(4);
 
-        return [...myset.keys()];
-    `
-        .expectToMatchJsResult()
-        .expectToEqual(["x", "a", 4, 1]);
+        return [...myset.${iterationMethod}()];
+    `.expectToMatchJsResult();
 });
 
-test("set.values() preserves insertion order", () => {
+test.each(iterationMethods)("set.%s() preserves insertion order after removing first", iterationMethod => {
     util.testFunction`
-        ${testSetConstructionCode}
+        const myset = new Set();
+            
+        myset.add("x");
+        myset.add("a");
+        myset.add(4);
+        
+        myset.delete("x");
 
-        return [...myset.values()];
-    `
-        .expectToMatchJsResult()
-        .expectToEqual(["x", "a", 4, 1]);
+        return [...myset.${iterationMethod}()];
+    `.expectToMatchJsResult();
+});
+
+test.each(iterationMethods)("set.%s() preserves insertion order after removing all", iterationMethod => {
+    util.testFunction`
+        const myset = new Set();
+            
+        myset.add("x");
+        myset.add("a");
+        
+        myset.delete("a");
+        myset.delete("x");
+
+        return [...myset.${iterationMethod}()];
+    `.expectToMatchJsResult();
 });

--- a/test/unit/builtins/set.spec.ts
+++ b/test/unit/builtins/set.spec.ts
@@ -134,62 +134,63 @@ test.each([
 });
 
 const iterationMethods = ["entries", "keys", "values"];
-
-test.each(iterationMethods)("set.%s() preserves insertion order", iterationMethod => {
-    util.testFunction`
-        const myset = new Set();
+describe.each(iterationMethods)("set.%s() preserves insertion order", iterationMethod => {
+    test("basic", () => {
+        util.testFunction`
+            const myset = new Set();
+                
+            myset.add("x");
+            myset.add("a");
+            myset.add(4);
+            myset.add("b");
+            myset.add(1);
+            myset.add("a");
             
-        myset.add("x");
-        myset.add("a");
-        myset.add(4);
-        myset.add("b");
-        myset.add(1);
-        myset.add("a");
-        
-        myset.delete("b");
+            myset.delete("b");
 
-        return [...myset.${iterationMethod}()];
-    `.expectToMatchJsResult();
-});
+            return [...myset.${iterationMethod}()];
+        `.expectToMatchJsResult();
+    });
 
-test.each(iterationMethods)("set.%s() preserves insertion order after removing last", iterationMethod => {
-    util.testFunction`
-        const myset = new Set();
+    test("after removing last", () => {
+        util.testFunction`
+            const myset = new Set();
+                
+            myset.add("x");
+            myset.add("a");
+            myset.add(4);
             
-        myset.add("x");
-        myset.add("a");
-        myset.add(4);
-        
-        myset.delete(4);
+            myset.delete(4);
 
-        return [...myset.${iterationMethod}()];
-    `.expectToMatchJsResult();
-});
+            return [...myset.${iterationMethod}()];
+        `.expectToMatchJsResult();
+    });
 
-test.each(iterationMethods)("set.%s() preserves insertion order after removing first", iterationMethod => {
-    util.testFunction`
-        const myset = new Set();
+    test("after removing first", () => {
+        util.testFunction`
+            const myset = new Set();
+                
+            myset.add("x");
+            myset.add("a");
+            myset.add(4);
             
-        myset.add("x");
-        myset.add("a");
-        myset.add(4);
-        
-        myset.delete("x");
+            myset.delete("x");
 
-        return [...myset.${iterationMethod}()];
-    `.expectToMatchJsResult();
-});
+            return [...myset.${iterationMethod}()];
+        `.expectToMatchJsResult();
+    });
 
-test.each(iterationMethods)("set.%s() preserves insertion order after removing all", iterationMethod => {
-    util.testFunction`
-        const myset = new Set();
+    test("after removing all", () => {
+        util.testFunction`
+            const myset = new Set();
+                
+            myset.add("x");
+            myset.add("a");
             
-        myset.add("x");
-        myset.add("a");
-        
-        myset.delete("a");
-        myset.delete("x");
+            myset.delete("a");
+            myset.delete("x");
 
-        return [...myset.${iterationMethod}()];
-    `.expectToMatchJsResult();
+            return [...myset.${iterationMethod}()];
+        `.expectToMatchJsResult();
+    });
 });


### PR DESCRIPTION
Code complicates a bit with the extra list bookkeeping. This does preserve O(1) insert and deletes. Iteration is still O(n), although it does include some extra table lookups, so probably more like O(2n) compared to the O(n) it was before.