### PR TITLE
Allow throwing arbitrary types and add builtin error classes

### DIFF
--- a/src/LuaLib.ts
+++ b/src/LuaLib.ts
@@ -64,7 +64,6 @@ export enum LuaLibFeature {
 const luaLibDependencies: { [lib in LuaLibFeature]?: LuaLibFeature[] } = {
     ArrayFlat: [LuaLibFeature.ArrayConcat],
     ArrayFlatMap: [LuaLibFeature.ArrayConcat],
-    Error: [LuaLibFeature.ArrayMap],
     InstanceOf: [LuaLibFeature.Symbol],
     Iterator: [LuaLibFeature.Symbol],
     ObjectFromEntries: [LuaLibFeature.Iterator, LuaLibFeature.Symbol],

--- a/src/LuaLib.ts
+++ b/src/LuaLib.ts
@@ -64,6 +64,7 @@ export enum LuaLibFeature {
 const luaLibDependencies: { [lib in LuaLibFeature]?: LuaLibFeature[] } = {
     ArrayFlat: [LuaLibFeature.ArrayConcat],
     ArrayFlatMap: [LuaLibFeature.ArrayConcat],
+    Error: [LuaLibFeature.FunctionCall],
     InstanceOf: [LuaLibFeature.Symbol],
     Iterator: [LuaLibFeature.Symbol],
     ObjectFromEntries: [LuaLibFeature.Iterator, LuaLibFeature.Symbol],

--- a/src/LuaLib.ts
+++ b/src/LuaLib.ts
@@ -64,6 +64,7 @@ export enum LuaLibFeature {
 const luaLibDependencies: { [lib in LuaLibFeature]?: LuaLibFeature[] } = {
     ArrayFlat: [LuaLibFeature.ArrayConcat],
     ArrayFlatMap: [LuaLibFeature.ArrayConcat],
+    Error: [LuaLibFeature.ArrayPush, LuaLibFeature.ArrayMap, LuaLibFeature.Index],
     InstanceOf: [LuaLibFeature.Symbol],
     Iterator: [LuaLibFeature.Symbol],
     ObjectFromEntries: [LuaLibFeature.Iterator, LuaLibFeature.Symbol],

--- a/src/LuaLib.ts
+++ b/src/LuaLib.ts
@@ -25,6 +25,7 @@ export enum LuaLibFeature {
     ClassIndex = "ClassIndex",
     ClassNewIndex = "ClassNewIndex",
     Decorate = "Decorate",
+    Error = "Error",
     FunctionApply = "FunctionApply",
     FunctionBind = "FunctionBind",
     FunctionCall = "FunctionCall",

--- a/src/LuaLib.ts
+++ b/src/LuaLib.ts
@@ -64,7 +64,7 @@ export enum LuaLibFeature {
 const luaLibDependencies: { [lib in LuaLibFeature]?: LuaLibFeature[] } = {
     ArrayFlat: [LuaLibFeature.ArrayConcat],
     ArrayFlatMap: [LuaLibFeature.ArrayConcat],
-    Error: [LuaLibFeature.ArrayPush, LuaLibFeature.ArrayMap, LuaLibFeature.Index],
+    Error: [LuaLibFeature.ArrayMap],
     InstanceOf: [LuaLibFeature.Symbol],
     Iterator: [LuaLibFeature.Symbol],
     ObjectFromEntries: [LuaLibFeature.Iterator, LuaLibFeature.Symbol],

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -2847,15 +2847,14 @@ export class LuaTransformer {
     }
 
     public transformThrowStatement(statement: ts.ThrowStatement): StatementVisitResult {
-        const error = tstl.createIdentifier("error");
-        if (statement.expression === undefined) {
-            return tstl.createExpressionStatement(tstl.createCallExpression(error, []), statement);
-        } else {
-            return tstl.createExpressionStatement(
-                tstl.createCallExpression(error, [this.transformExpression(statement.expression)]),
-                statement
-            );
+        const parameters: tstl.Expression[] = [];
+        if (statement.expression) {
+            parameters.push(this.transformExpression(statement.expression));
         }
+        return tstl.createExpressionStatement(
+            tstl.createCallExpression(tstl.createIdentifier("error"), parameters),
+            statement
+        );
     }
 
     public transformContinueStatement(statement: ts.ContinueStatement): StatementVisitResult {

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -2848,9 +2848,11 @@ export class LuaTransformer {
 
     public transformThrowStatement(statement: ts.ThrowStatement): StatementVisitResult {
         const parameters: tstl.Expression[] = [];
+
         if (statement.expression) {
             parameters.push(this.transformExpression(statement.expression));
         }
+
         return tstl.createExpressionStatement(
             tstl.createCallExpression(tstl.createIdentifier("error"), parameters),
             statement

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -2843,19 +2843,14 @@ export class LuaTransformer {
     }
 
     public transformThrowStatement(statement: ts.ThrowStatement): StatementVisitResult {
+        const error = tstl.createIdentifier("error");
         if (statement.expression === undefined) {
-            throw TSTLErrors.InvalidThrowExpression(statement);
-        }
-
-        const type = this.checker.getTypeAtLocation(statement.expression);
-        if (tsHelper.isStringType(type, this.checker, this.program)) {
-            const error = tstl.createIdentifier("error");
+            return tstl.createExpressionStatement(tstl.createCallExpression(error, []), statement);
+        } else {
             return tstl.createExpressionStatement(
                 tstl.createCallExpression(error, [this.transformExpression(statement.expression)]),
                 statement
             );
-        } else {
-            throw TSTLErrors.InvalidThrowExpression(statement.expression);
         }
     }
 
@@ -4208,6 +4203,7 @@ export class LuaTransformer {
 
         const expressionType = this.checker.getTypeAtLocation(expression.expression);
         if (tsHelper.isStandardLibraryType(expressionType, undefined, this.program)) {
+            this.checkForLuaLibType(expressionType);
             const result = this.transformGlobalFunctionCall(expression);
             if (result) {
                 return result;
@@ -5516,6 +5512,42 @@ export class LuaTransformer {
                     return;
                 case "WeakSet":
                     this.importLuaLibFeature(LuaLibFeature.WeakSet);
+                    return;
+                case "Error":
+                    this.importLuaLibFeature(LuaLibFeature.Error);
+                    return;
+                case "ErrorConstructor":
+                    this.importLuaLibFeature(LuaLibFeature.Error);
+                    return;
+                case "RangeError":
+                    this.importLuaLibFeature(LuaLibFeature.Error);
+                    return;
+                case "RangeErrorConstructor":
+                    this.importLuaLibFeature(LuaLibFeature.Error);
+                    return;
+                case "ReferenceError":
+                    this.importLuaLibFeature(LuaLibFeature.Error);
+                    return;
+                case "ReferenceErrorConstructor":
+                    this.importLuaLibFeature(LuaLibFeature.Error);
+                    return;
+                case "SyntaxError":
+                    this.importLuaLibFeature(LuaLibFeature.Error);
+                    return;
+                case "SyntaxErrorConstructor":
+                    this.importLuaLibFeature(LuaLibFeature.Error);
+                    return;
+                case "TypeError":
+                    this.importLuaLibFeature(LuaLibFeature.Error);
+                    return;
+                case "TypeErrorConstructor":
+                    this.importLuaLibFeature(LuaLibFeature.Error);
+                    return;
+                case "URIError":
+                    this.importLuaLibFeature(LuaLibFeature.Error);
+                    return;
+                case "URIErrorConstructor":
+                    this.importLuaLibFeature(LuaLibFeature.Error);
                     return;
             }
         }

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -5518,6 +5518,7 @@ export class LuaTransformer {
                     this.importLuaLibFeature(LuaLibFeature.WeakSet);
                     return;
             }
+
             if (tsHelper.isBuiltinErrorTypeName(name)) {
                 this.importLuaLibFeature(LuaLibFeature.Error);
             }

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -2851,6 +2851,7 @@ export class LuaTransformer {
 
         if (statement.expression) {
             parameters.push(this.transformExpression(statement.expression));
+            parameters.push(tstl.createNumericLiteral(0));
         }
 
         return tstl.createExpressionStatement(

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -3679,7 +3679,10 @@ export class LuaTransformer {
             className = tstl.createAnonymousIdentifier();
         }
 
+        this.pushScope(ScopeType.Function);
         const classDeclaration = this.transformClassDeclaration(expression, className);
+        this.popScope();
+
         return this.createImmediatelyInvokedFunctionExpression(
             this.statementVisitResultToArray(classDeclaration),
             className,

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -5503,7 +5503,8 @@ export class LuaTransformer {
 
     protected checkForLuaLibType(type: ts.Type): void {
         if (type.symbol) {
-            switch (this.checker.getFullyQualifiedName(type.symbol)) {
+            const name = this.checker.getFullyQualifiedName(type.symbol);
+            switch (name) {
                 case "Map":
                     this.importLuaLibFeature(LuaLibFeature.Map);
                     return;
@@ -5516,42 +5517,9 @@ export class LuaTransformer {
                 case "WeakSet":
                     this.importLuaLibFeature(LuaLibFeature.WeakSet);
                     return;
-                case "Error":
-                    this.importLuaLibFeature(LuaLibFeature.Error);
-                    return;
-                case "ErrorConstructor":
-                    this.importLuaLibFeature(LuaLibFeature.Error);
-                    return;
-                case "RangeError":
-                    this.importLuaLibFeature(LuaLibFeature.Error);
-                    return;
-                case "RangeErrorConstructor":
-                    this.importLuaLibFeature(LuaLibFeature.Error);
-                    return;
-                case "ReferenceError":
-                    this.importLuaLibFeature(LuaLibFeature.Error);
-                    return;
-                case "ReferenceErrorConstructor":
-                    this.importLuaLibFeature(LuaLibFeature.Error);
-                    return;
-                case "SyntaxError":
-                    this.importLuaLibFeature(LuaLibFeature.Error);
-                    return;
-                case "SyntaxErrorConstructor":
-                    this.importLuaLibFeature(LuaLibFeature.Error);
-                    return;
-                case "TypeError":
-                    this.importLuaLibFeature(LuaLibFeature.Error);
-                    return;
-                case "TypeErrorConstructor":
-                    this.importLuaLibFeature(LuaLibFeature.Error);
-                    return;
-                case "URIError":
-                    this.importLuaLibFeature(LuaLibFeature.Error);
-                    return;
-                case "URIErrorConstructor":
-                    this.importLuaLibFeature(LuaLibFeature.Error);
-                    return;
+            }
+            if (tsHelper.isBuiltinErrorTypeName(name)) {
+                this.importLuaLibFeature(LuaLibFeature.Error);
             }
         }
     }

--- a/src/LuaTransformer.ts
+++ b/src/LuaTransformer.ts
@@ -613,6 +613,10 @@ export class LuaTransformer {
         // Get type that is extended
         const extendsType = tsHelper.getExtendedType(statement, this.checker);
 
+        if (extendsType) {
+            this.checkForLuaLibType(extendsType);
+        }
+
         if (!(isExtension || isMetaExtension) && extendsType) {
             // Non-extensions cannot extend extension classes
             const extendsDecorators = tsHelper.getCustomDecorators(extendsType, this.checker);

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -33,6 +33,7 @@ const defaultArrayCallMethodNames = new Set<string>([
     "flatMap",
 ]);
 
+// TODO [2019-09-27/Perry]: Refactor lualib detection to consistent map
 const builtinErrorTypeNames = new Set([
     "Error",
     "ErrorConstructor",

--- a/src/TSHelper.ts
+++ b/src/TSHelper.ts
@@ -33,6 +33,21 @@ const defaultArrayCallMethodNames = new Set<string>([
     "flatMap",
 ]);
 
+const builtinErrorTypeNames = new Set([
+    "Error",
+    "ErrorConstructor",
+    "RangeError",
+    "RangeErrorConstructor",
+    "ReferenceError",
+    "ReferenceErrorConstructor",
+    "SyntaxError",
+    "SyntaxErrorConstructor",
+    "TypeError",
+    "TypeErrorConstructor",
+    "URIError",
+    "URIErrorConstructor",
+]);
+
 export function getExtendedTypeNode(
     node: ts.ClassLikeDeclarationBase,
     checker: ts.TypeChecker
@@ -1040,4 +1055,8 @@ export function formatPathToLuaPath(filePath: string): string {
         filePath = filePath.replace(/\.\\/g, "").replace(/\\/g, ".");
     }
     return filePath.replace(/\.\//g, "").replace(/\//g, ".");
+}
+
+export function isBuiltinErrorTypeName(name: string): boolean {
+    return builtinErrorTypeNames.has(name);
 }

--- a/src/TSTLErrors.ts
+++ b/src/TSTLErrors.ts
@@ -54,9 +54,6 @@ export const InvalidPropertyCall = (node: ts.Node) =>
 export const InvalidElementCall = (node: ts.Node) =>
     new TranspileError(`Tried to transpile a non-element call as an element call.`, node);
 
-export const InvalidThrowExpression = (node: ts.Node) =>
-    new TranspileError(`Invalid throw expression, only strings can be thrown.`, node);
-
 export const ForbiddenStaticClassPropertyName = (node: ts.Node, name: string) =>
     new TranspileError(`Cannot use "${name}" as a static class property or method name.`, node);
 

--- a/src/lualib/Error.ts
+++ b/src/lualib/Error.ts
@@ -1,6 +1,6 @@
-interface ErrorType<T> extends Function {
+interface ErrorType {
     name: string;
-    new (...args: any[]): T;
+    new (...args: any[]): Error;
 }
 
 function __TS__GetErrorStack(constructor: Function): string {
@@ -32,7 +32,7 @@ function __TS__WrapErrorToString<T extends Error>(getDescription: (this: T) => s
     };
 }
 
-function __TS__InitErrorClass<T>(Type: ErrorType<T>, name: string): any {
+function __TS__InitErrorClass(Type: ErrorType, name: string): any {
     Type.name = name;
     return setmetatable(Type, {
         __call: (_self: any, message: string) => new Type(message),
@@ -40,7 +40,7 @@ function __TS__InitErrorClass<T>(Type: ErrorType<T>, name: string): any {
 }
 
 Error = __TS__InitErrorClass(
-    class {
+    class implements Error {
         public name = "Error";
         public stack: string;
 

--- a/src/lualib/Error.ts
+++ b/src/lualib/Error.ts
@@ -6,6 +6,11 @@ type TSTLCapturedErrorStack = Array<{
     currentline: number;
 }>;
 
+interface ErrorType<T> extends Function {
+    name: string;
+    new (...args: any[]): T;
+}
+
 function __TS__GetErrorStack(constructor: Function): TSTLCapturedErrorStack {
     const functionFrames = [];
     let level = 1;
@@ -49,7 +54,7 @@ function __TS__GetErrorString(this: void, error: Error): string {
     return error.message !== "" ? `${error.name}: ${error.message}` : error.name;
 }
 
-function __TS__InitErrorClass(Type: any, name?: string): any {
+function __TS__InitErrorClass<T>(Type: ErrorType<T>, name?: string): any {
     if (name) {
         Type.name = name;
     }

--- a/src/lualib/Error.ts
+++ b/src/lualib/Error.ts
@@ -20,8 +20,14 @@ function __TS__GetErrorStack(constructor: Function): string {
     return debug.traceback(undefined, level);
 }
 
-function __TS__GetErrorString(this: void, error: Error): string {
-    return error.message !== "" ? `${error.name}: ${error.message}` : error.name;
+function __TS__GetErrorString(this: void, errorObj: Error): string {
+    const description = errorObj.message !== "" ? `${errorObj.name}: ${errorObj.message}` : errorObj.name;
+    const caller = debug.getinfo(3, "f");
+    if (_VERSION === "Lua 5.1" || (caller && caller.func !== error)) {
+        return description;
+    } else {
+        return `${description}\n${errorObj.stack}`;
+    }
 }
 
 function __TS__InitErrorClass<T>(Type: ErrorType<T>, name: string): any {

--- a/src/lualib/Error.ts
+++ b/src/lualib/Error.ts
@@ -24,7 +24,7 @@ function __TS__GetErrorString(this: void, error: Error): string {
     return error.message !== "" ? `${error.name}: ${error.message}` : error.name;
 }
 
-function __TS__InitErrorClass<T>(Type: ErrorType<T>, name?: string): any {
+function __TS__InitErrorClass<T>(Type: ErrorType<T>, name: string): any {
     if (name) {
         Type.name = name;
     }
@@ -34,7 +34,7 @@ function __TS__InitErrorClass<T>(Type: ErrorType<T>, name?: string): any {
 }
 
 Error = __TS__InitErrorClass(
-    class Error {
+    class {
         public name = "Error";
         public message: string;
         public stack: string;
@@ -42,9 +42,11 @@ Error = __TS__InitErrorClass(
         constructor(message = "") {
             this.message = message;
             this.stack = __TS__GetErrorStack((this.constructor as any).new);
-            getmetatable(this).__tostring = __TS__GetErrorString;
+            const mt = getmetatable(this);
+            mt.__tostring = mt.__tostring || __TS__GetErrorString;
         }
-    }
+    },
+    "Error"
 );
 
 for (const errorName of ["RangeError", "ReferenceError", "SyntaxError", "TypeError", "URIError"]) {

--- a/src/lualib/Error.ts
+++ b/src/lualib/Error.ts
@@ -31,9 +31,7 @@ function __TS__GetErrorString(this: void, errorObj: Error): string {
 }
 
 function __TS__InitErrorClass<T>(Type: ErrorType<T>, name: string): any {
-    if (name) {
-        Type.name = name;
-    }
+    Type.name = name;
     return setmetatable(Type, {
         __call: (_self: any, message: string) => new Type(message),
     });
@@ -46,8 +44,10 @@ Error = __TS__InitErrorClass(
 
         constructor(public message = "") {
             this.stack = __TS__GetErrorStack((this.constructor as any).new);
-            const mt = getmetatable(this);
-            mt.__tostring = mt.__tostring || __TS__GetErrorString;
+        }
+
+        public toString(): string {
+            return __TS__GetErrorString(this);
         }
     },
     "Error"
@@ -57,6 +57,10 @@ for (const errorName of ["RangeError", "ReferenceError", "SyntaxError", "TypeErr
     globalThis[errorName] = __TS__InitErrorClass(
         class extends Error {
             public name = errorName;
+
+            public toString(): string {
+                return __TS__GetErrorString(this);
+            }
         },
         errorName
     );

--- a/src/lualib/Error.ts
+++ b/src/lualib/Error.ts
@@ -13,7 +13,11 @@ function __TS__GetErrorStack(constructor: Function): TSTLCapturedErrorStack {
     while (true) {
         const info = debug.getinfo(level, "f");
         level += 1;
-        if (!info || info.func === constructor) {
+        if (info.func === constructor) {
+            break;
+        } else if (!info) {
+            // constructor not in call stack
+            level = 1;
             break;
         }
     }

--- a/src/lualib/Error.ts
+++ b/src/lualib/Error.ts
@@ -1,0 +1,93 @@
+Error = class {
+    public static captureStackTrace(targetObject: {}, depth: number): void {
+        targetObject["stack"] = debug.traceback(undefined, depth);
+    }
+
+    public message: string;
+    public name: string;
+    public stack?: string;
+
+    constructor(message?: string, name?: string) {
+        this.message = message || "";
+        this.name = name || "Error";
+        Error["captureStackTrace"](this, name ? 5 : 4);
+    }
+
+    public __tostring(): string {
+        return `${this.name}: ${this.message}`;
+    }
+} as any;
+
+setmetatable(Error, { __call: (_self: any, message: string) => new Error(message) });
+
+/** Standard error types */
+
+RangeError = class extends Error {
+    constructor(message?: string) {
+        // @ts-ignore
+        super(message, "RangeError");
+    }
+    public __tostring(): string {
+        return `${this.name}: ${this.message}`;
+    }
+} as any;
+setmetatable(RangeError, {
+    __call: (_self: any, message: string) => new RangeError(message),
+    __index: getmetatable(RangeError),
+});
+
+ReferenceError = class extends Error {
+    constructor(message?: string) {
+        // @ts-ignore
+        super(message, "ReferenceError");
+    }
+    public __tostring(): string {
+        return `${this.name}: ${this.message}`;
+    }
+} as any;
+setmetatable(ReferenceError, {
+    __call: (_self: any, message: string) => new ReferenceError(message),
+    __index: getmetatable(ReferenceError),
+});
+
+SyntaxError = class extends Error {
+    constructor(message?: string) {
+        // @ts-ignore
+        super(message, "SyntaxError");
+    }
+    public __tostring(): string {
+        return `${this.name}: ${this.message}`;
+    }
+} as any;
+setmetatable(SyntaxError, {
+    __call: (_self: any, message: string) => new SyntaxError(message),
+    __index: getmetatable(SyntaxError),
+});
+
+TypeError = class extends Error {
+    constructor(message?: string) {
+        // @ts-ignore
+        super(message, "TypeError");
+    }
+    public __tostring(): string {
+        return `${this.name}: ${this.message}`;
+    }
+} as any;
+setmetatable(TypeError, {
+    __call: (_self: any, message: string) => new TypeError(message),
+    __index: getmetatable(TypeError),
+});
+
+URIError = class extends Error {
+    constructor(message?: string) {
+        // @ts-ignore
+        super(message, "URIError");
+    }
+    public __tostring(): string {
+        return `${this.name}: ${this.message}`;
+    }
+} as any;
+setmetatable(URIError, {
+    __call: (_self: any, message: string) => new URIError(message),
+    __index: getmetatable(URIError),
+});

--- a/src/lualib/Error.ts
+++ b/src/lualib/Error.ts
@@ -4,7 +4,6 @@ type TSTLCapturedErrorStack = Array<{
     source: string;
     short_src: string;
     currentline: number;
-    func: Function;
 }>;
 
 function __TS__GetErrorStack(constructor: Function): TSTLCapturedErrorStack {
@@ -13,11 +12,11 @@ function __TS__GetErrorStack(constructor: Function): TSTLCapturedErrorStack {
     while (true) {
         const info = debug.getinfo(level, "f");
         level += 1;
-        if (info.func === constructor) {
-            break;
-        } else if (!info) {
+        if (!info) {
             // constructor not in call stack
             level = 1;
+            break;
+        } else if (info.func === constructor) {
             break;
         }
     }
@@ -42,7 +41,7 @@ function __TS__ConvertErrorStack(stack: TSTLCapturedErrorStack): string {
             }
         })
         .join("\n");
-    const transform = (globalThis as any).__TS__SourceMapTransform;
+    const transform = globalThis.__TS__SourceMapTransform;
     return transform ? transform(info) : info;
 }
 
@@ -53,7 +52,6 @@ function __TS__GetErrorString(this: void, error: Error): string {
 function __TS__InitErrorClass(Type: any): any {
     Type.prototype.__tostring = __TS__GetErrorString;
     return setmetatable(Type, {
-        __index: getmetatable(Type),
         __call: (_self: any, message: string) => new Type(message),
     });
 }

--- a/src/lualib/Error.ts
+++ b/src/lualib/Error.ts
@@ -39,7 +39,7 @@ Error = __TS__InitErrorClass(
         public message: string;
         public stack: string;
 
-        constructor(message = "") {
+        constructor(public message = "") {
             this.message = message;
             this.stack = __TS__GetErrorStack((this.constructor as any).new);
             const mt = getmetatable(this);

--- a/src/lualib/Error.ts
+++ b/src/lualib/Error.ts
@@ -36,11 +36,9 @@ function __TS__InitErrorClass<T>(Type: ErrorType<T>, name: string): any {
 Error = __TS__InitErrorClass(
     class {
         public name = "Error";
-        public message: string;
         public stack: string;
 
         constructor(public message = "") {
-            this.message = message;
             this.stack = __TS__GetErrorStack((this.constructor as any).new);
             const mt = getmetatable(this);
             mt.__tostring = mt.__tostring || __TS__GetErrorString;

--- a/src/lualib/Error.ts
+++ b/src/lualib/Error.ts
@@ -16,6 +16,7 @@ function __TS__GetErrorStack(constructor: Function): string {
             break;
         }
     }
+
     return debug.traceback(undefined, level);
 }
 

--- a/src/lualib/SourceMapTraceBack.ts
+++ b/src/lualib/SourceMapTraceBack.ts
@@ -1,22 +1,5 @@
 // TODO: In the future, change this to __TS__RegisterFileInfo and provide tstl interface to
 // get some metadata about transpilation.
-
-function __TS__SourceMapTransform(trace: string): string {
-    const sourceMaps = globalThis.__TS__sourcemap;
-    if (sourceMaps) {
-        const [result] = string.gsub(trace, "(%S+).lua:(%d+)", (file, line) => {
-            const fileSourceMap = sourceMaps[file + ".lua"];
-            if (fileSourceMap && fileSourceMap[line]) {
-                return `${file}.ts:${fileSourceMap[line]}`;
-            }
-            return `${file}.lua:${line}`;
-        });
-        return result;
-    } else {
-        return trace;
-    }
-}
-
 function __TS__SourceMapTraceBack(this: void, fileName: string, sourceMap: { [line: number]: number }): void {
     globalThis.__TS__sourcemap = globalThis.__TS__sourcemap || {};
     globalThis.__TS__sourcemap[fileName] = sourceMap;
@@ -25,7 +8,15 @@ function __TS__SourceMapTraceBack(this: void, fileName: string, sourceMap: { [li
         globalThis.__TS__originalTraceback = debug.traceback;
         debug.traceback = (thread, message, level) => {
             const trace = globalThis.__TS__originalTraceback(thread, message, level);
-            return __TS__SourceMapTransform(trace);
+            const [result] = string.gsub(trace, "(%S+).lua:(%d+)", (file, line) => {
+                const fileSourceMap = globalThis.__TS__sourcemap[file + ".lua"];
+                if (fileSourceMap && fileSourceMap[line]) {
+                    return `${file}.ts:${fileSourceMap[line]}`;
+                }
+                return `${file}.lua:${line}`;
+            });
+
+            return result;
         };
     }
 }

--- a/src/lualib/SourceMapTraceBack.ts
+++ b/src/lualib/SourceMapTraceBack.ts
@@ -1,5 +1,22 @@
 // TODO: In the future, change this to __TS__RegisterFileInfo and provide tstl interface to
 // get some metadata about transpilation.
+
+function __TS__SourceMapTransform(trace: string): string {
+    const sourceMaps = globalThis.__TS__sourcemap;
+    if (sourceMaps) {
+        const [result] = string.gsub(trace, "(%S+).lua:(%d+)", (file, line) => {
+            const fileSourceMap = sourceMaps[file + ".lua"];
+            if (fileSourceMap && fileSourceMap[line]) {
+                return `${file}.ts:${fileSourceMap[line]}`;
+            }
+            return `${file}.lua:${line}`;
+        });
+        return result;
+    } else {
+        return trace;
+    }
+}
+
 function __TS__SourceMapTraceBack(this: void, fileName: string, sourceMap: { [line: number]: number }): void {
     globalThis.__TS__sourcemap = globalThis.__TS__sourcemap || {};
     globalThis.__TS__sourcemap[fileName] = sourceMap;
@@ -8,15 +25,7 @@ function __TS__SourceMapTraceBack(this: void, fileName: string, sourceMap: { [li
         globalThis.__TS__originalTraceback = debug.traceback;
         debug.traceback = (thread, message, level) => {
             const trace = globalThis.__TS__originalTraceback(thread, message, level);
-            const [result] = string.gsub(trace, "(%S+).lua:(%d+)", (file, line) => {
-                const fileSourceMap = globalThis.__TS__sourcemap[file + ".lua"];
-                if (fileSourceMap && fileSourceMap[line]) {
-                    return `${file}.ts:${fileSourceMap[line]}`;
-                }
-                return `${file}.lua:${line}`;
-            });
-
-            return result;
+            return __TS__SourceMapTransform(trace);
         };
     }
 }

--- a/src/lualib/declarations/debug.d.ts
+++ b/src/lualib/declarations/debug.d.ts
@@ -2,4 +2,5 @@
 
 declare namespace debug {
     function traceback(...args: any[]): string;
+    function getinfo(i: number, what?: string): any;
 }

--- a/src/lualib/declarations/debug.d.ts
+++ b/src/lualib/declarations/debug.d.ts
@@ -2,5 +2,19 @@
 
 declare namespace debug {
     function traceback(...args: any[]): string;
-    function getinfo(i: number, what?: string): any;
+
+    interface FunctionInfo<T extends Function = Function> {
+        func: T;
+        name?: string;
+        namewhat: "global" | "local" | "method" | "field" | "";
+        source: string;
+        short_src: string;
+        linedefined: number;
+        lastlinedefined: number;
+        what: "Lua" | "C" | "main";
+        currentline: number;
+        nups: number;
+    }
+
+    function getinfo(i: number, what?: string): Partial<FunctionInfo>;
 }

--- a/src/lualib/declarations/debug.d.ts
+++ b/src/lualib/declarations/debug.d.ts
@@ -1,5 +1,8 @@
 /** @noSelfInFile */
 
+declare const _VERSION: string;
+declare function error(...args: any[]): never;
+
 declare namespace debug {
     function traceback(...args: any[]): string;
 

--- a/src/lualib/declarations/global.d.ts
+++ b/src/lualib/declarations/global.d.ts
@@ -10,6 +10,7 @@ declare function type(
     value: any
 ): "nil" | "number" | "string" | "boolean" | "table" | "function" | "thread" | "userdata";
 declare function setmetatable<T extends object>(table: T, metatable: any): T;
+declare function getmetatable<T extends object>(table: T): any;
 declare function rawget<T, K extends keyof T>(table: T, key: K): T[K];
 declare function rawset<T, K extends keyof T>(table: T, key: K, val: T[K]): void;
 /** @tupleReturn */

--- a/test/unit/error.spec.ts
+++ b/test/unit/error.spec.ts
@@ -371,7 +371,7 @@ test("extending from Error with custom toString()", () => {
     `.expectToMatchJsResult();
 });
 
-test.each(["Error", "RangeError", "MyError"])("get stack from error", errorType => {
+test.each(["Error", "RangeError", "MyError"])("get stack from %s", errorType => {
     const stack = util.testFunction`
         class MyError extends Error {
             public name = "MyError";

--- a/test/unit/error.spec.ts
+++ b/test/unit/error.spec.ts
@@ -325,17 +325,7 @@ test.each([
 ])("test builtin error properties", errorType => {
     util.testFunction`
         const error = ${errorType}();
-        return error.name;
-    `.expectToMatchJsResult();
-
-    util.testFunction`
-        const error = ${errorType}();
-        return error.message;
-    `.expectToMatchJsResult();
-
-    util.testFunction`
-        const error = ${errorType}();
-        return error.toString();
+        return { name: error.name, message: error.message, string: error.toString() };
     `.expectToMatchJsResult();
 });
 

--- a/test/unit/error.spec.ts
+++ b/test/unit/error.spec.ts
@@ -1,5 +1,4 @@
 import * as util from "../util";
-import * as tstl from "../../src";
 
 test("throwString", () => {
     util.testFunction`
@@ -289,11 +288,11 @@ test("return from nested finally", () => {
 
 test("throw and catch custom error object", () => {
     util.testFunction`
-      try {
-          throw { x: "Hello error object!" };
-      } catch (error) {
-          return error.x;
-      }
+        try {
+            throw { x: "Hello error object!" };
+        } catch (error) {
+            return error.x;
+        }
     `.expectToMatchJsResult();
 });
 
@@ -310,9 +309,7 @@ test.each(["Error", "RangeError", "ReferenceError", "SyntaxError", "TypeError", 
                     throw Error("This error serves to prevent false positives from .expectNoExecutionError()");
                 }
             }
-        `
-            .expectNoExecutionError()
-            .expectToMatchJsResult();
+        `.expectToMatchJsResult();
     }
 );
 
@@ -329,9 +326,7 @@ test.each(["Error", "RangeError", "ReferenceError", "SyntaxError", "TypeError", 
                     throw Error("This error serves to prevent false positives from .expectNoExecutionError()");
                 }
             }
-        `
-            .expectNoExecutionError()
-            .expectToMatchJsResult();
+        `.expectToMatchJsResult();
     }
 );
 
@@ -350,15 +345,11 @@ test("subclass Error", () => {
                 throw Error("This error serves to prevent false positives from .expectNoExecutionError()");
             }
         }
-    `
-        .expectNoExecutionError()
-        .expectToMatchJsResult();
+    `.expectToMatchJsResult();
 });
 
-test.each([["Error", false], ["Error", true], ["RangeError", false], ["MyError", false]] as Array<[string, boolean]>)(
-    "get stack from error",
-    (errorType, sourceMapTraceback) => {
-        const stack = util.testFunction`
+test.each(["Error", "RangeError", "MyError"])("get stack from error", errorType => {
+    const stack = util.testFunction`
         class MyError extends Error {
             public name = "MyError";
         }
@@ -374,12 +365,8 @@ test.each([["Error", false], ["Error", true], ["RangeError", false], ["MyError",
                 throw Error("This error serves to prevent false positives from .expectNoExecutionError()");
             }
         }
-    `
-            .setOptions({ sourceMapTraceback, luaLibImport: tstl.LuaLibImportKind.Inline })
-            .expectNoExecutionError()
-            .getLuaExecutionResult();
+    `.getLuaExecutionResult();
 
-        expect(stack).toMatch("innerFunctionThatThrows");
-        expect(stack).toMatch("outerFunctionThatThrows");
-    }
-);
+    expect(stack).toMatch("innerFunctionThatThrows");
+    expect(stack).toMatch("outerFunctionThatThrows");
+});

--- a/test/unit/error.spec.ts
+++ b/test/unit/error.spec.ts
@@ -296,14 +296,10 @@ test("throw and catch custom error object", () => {
     `.expectToMatchJsResult();
 });
 
-test.each(["Error", "RangeError", "ReferenceError", "SyntaxError", "TypeError", "URIError", "MyError"])(
+test.each(["Error", "RangeError", "ReferenceError", "SyntaxError", "TypeError", "URIError"])(
     "throw builtin Errors as classes",
     errorType => {
         util.testFunction`
-            class MyError extends Error {
-                name: "MyError"
-            }
-
             try {
                 throw new ${errorType}("message")
             } catch (error) {
@@ -348,7 +344,7 @@ test("subclass Error", () => {
             throw new MyError();
         } catch (error) {
             if (error instanceof Error) {
-                return error.name;
+                return \'\$error\';
             } else {
                 throw TypeError();
             }

--- a/test/unit/error.spec.ts
+++ b/test/unit/error.spec.ts
@@ -297,31 +297,28 @@ test.each([
     `() => "error function"`,
 ])("throw and catch %s", error => {
     util.testFunction`
-            try {
-                throw ${error};
-            } catch (error) {
-                if (typeof error == 'function') {
-                    return error();
-                } else {
-                    return error;
-                }
+        try {
+            throw ${error};
+        } catch (error) {
+            if (typeof error == 'function') {
+                return error();
+            } else {
+                return error;
             }
+        }
         `.expectToMatchJsResult();
 });
 
 const builtinErrors = ["Error", "RangeError", "ReferenceError", "SyntaxError", "TypeError", "URIError"];
 
-test.each([...builtinErrors, ...builtinErrors.map(type => `new ${type}`)])(
-    "test builtin error %s",
-    errorType => {
-        util.testFunction`
-        const error = ${errorType}();
-        return { name: error.name, message: error.message, string: error.toString() };
-    `.expectToMatchJsResult();
-    }
-);
+test.each([...builtinErrors, ...builtinErrors.map(type => `new ${type}`)])("test builtin error %s", errorType => {
+    util.testFunction`
+            const error = ${errorType}();
+            return { name: error.name, message: error.message, string: error.toString() };
+        `.expectToMatchJsResult();
+});
 
-test.each([...builtinErrors, `CustomError`])("get stack from %s", errorType => {
+test.each([...builtinErrors, "CustomError"])("get stack from %s", errorType => {
     const stack = util.testFunction`
         class CustomError extends Error {
             public name = "CustomError";
@@ -334,7 +331,7 @@ test.each([...builtinErrors, `CustomError`])("get stack from %s", errorType => {
         outerFunction();
         
         return stack;
-    `.getLuaExecutionResult();
+        `.getLuaExecutionResult();
 
     expect(stack).toMatch("innerFunction");
     expect(stack).toMatch("outerFunction");

--- a/test/unit/error.spec.ts
+++ b/test/unit/error.spec.ts
@@ -1,4 +1,5 @@
 import * as util from "../util";
+import * as tstl from "../../src";
 
 test("throwString", () => {
     util.testFunction`
@@ -354,8 +355,10 @@ test("subclass Error", () => {
         .expectToMatchJsResult();
 });
 
-test.each(["Error", "RangeError", "MyError"])("get stack from error", errorType => {
-    const stack = util.testFunction`
+test.each([["Error", false], ["Error", true], ["RangeError", false], ["MyError", false]] as Array<[string, boolean]>)(
+    "get stack from error",
+    (errorType, sourceMapTraceback) => {
+        const stack = util.testFunction`
         class MyError extends Error {
             name: "MyError"
         }
@@ -373,9 +376,11 @@ test.each(["Error", "RangeError", "MyError"])("get stack from error", errorType 
             }
         }
     `
-        .expectNoExecutionError()
-        .getLuaExecutionResult();
+            .setOptions({ sourceMapTraceback, luaLibImport: tstl.LuaLibImportKind.Inline })
+            .expectNoExecutionError()
+            .getLuaExecutionResult();
 
-    expect(stack).toMatch("innerFunctionThatThrows");
-    expect(stack).toMatch("outerFunctionThatThrows");
-});
+        expect(stack).toMatch("innerFunctionThatThrows");
+        expect(stack).toMatch("outerFunctionThatThrows");
+    }
+);

--- a/test/unit/error.spec.ts
+++ b/test/unit/error.spec.ts
@@ -354,7 +354,9 @@ test("extending from Error", () => {
 test("extending from Error with custom toString()", () => {
     util.testFunction`
         class MyError extends Error {
-            toString(){ return "Custom error message";  }
+            toString() {
+            	return "Custom error message";
+            }
         }
         
         try {

--- a/test/unit/error.spec.ts
+++ b/test/unit/error.spec.ts
@@ -290,12 +290,12 @@ test.each([`"Hello error string!"`, `42`, `true`, `false`, `undefined`, `{ x: "H
     "throw and catch custom error object",
     error => {
         util.testFunction`
-        try {
-            throw ${error};
-        } catch (error) {
-            return error;
-        }
-    `.expectToMatchJsResult();
+            try {
+                throw ${error};
+            } catch (error) {
+                return error;
+            }
+        `.expectToMatchJsResult();
     }
 );
 
@@ -333,10 +333,28 @@ test.each(["Error", "RangeError", "ReferenceError", "SyntaxError", "TypeError", 
     }
 );
 
-test("subclass Error", () => {
+test("extending from Error", () => {
     util.testFunction`
         class MyError extends Error {
             public name = "MyError";
+        }
+        
+        try {
+            throw new MyError();
+        } catch (error) {
+            if (error instanceof Error) {
+                return error.toString();
+            } else {
+                throw Error("This error serves to prevent false positives from .expectNoExecutionError()");
+            }
+        }
+    `.expectToMatchJsResult();
+});
+
+test("extending from Error with custom toString()", () => {
+    util.testFunction`
+        class MyError extends Error {
+            toString(){ return "Custom error message";  }
         }
         
         try {

--- a/test/unit/error.spec.ts
+++ b/test/unit/error.spec.ts
@@ -339,12 +339,27 @@ test.each([
         `.expectToMatchJsResult();
 });
 
-test.each(["Error", "RangeError", "CustomError"])("get stack from %s", errorType => {
+test.each([
+    "Error",
+    "RangeError",
+    "ReferenceError",
+    "SyntaxError",
+    "TypeError",
+    "URIError",
+    "new Error",
+    "new RangeError",
+    "new ReferenceError",
+    "new SyntaxError",
+    "new TypeError",
+    "new URIError",
+    "new CustomError",
+])("get stack from %s", errorType => {
     const stack = util.testFunction`
         class CustomError extends Error {
-            public name = "MyError";
+            public name = "CustomError";
         }
-        function innerFunctionThatThrows() { throw new ${errorType}(); }
+
+        function innerFunctionThatThrows() { throw ${errorType}(); }
         function outerFunctionThatThrows() { innerFunctionThatThrows(); }
 
         try {

--- a/test/unit/error.spec.ts
+++ b/test/unit/error.spec.ts
@@ -307,7 +307,7 @@ test.each(["Error", "RangeError", "ReferenceError", "SyntaxError", "TypeError", 
                 if (error instanceof Error) {
                     return \`\${error}\`;
                 } else {
-                    throw TypeError();
+                    throw Error("This error serves to prevent false positives from .expectNoExecutionError()");
                 }
             }
         `
@@ -326,7 +326,7 @@ test.each(["Error", "RangeError", "ReferenceError", "SyntaxError", "TypeError", 
                 if (error instanceof Error) {
                     return \`\${error}\`;
                 } else {
-                    throw TypeError();
+                    throw Error("This error serves to prevent false positives from .expectNoExecutionError()");
                 }
             }
         `
@@ -347,7 +347,7 @@ test("subclass Error", () => {
             if (error instanceof Error) {
                 return \'\$error\';
             } else {
-                throw TypeError();
+                throw Error("This error serves to prevent false positives from .expectNoExecutionError()");
             }
         }
     `
@@ -362,7 +362,6 @@ test.each([["Error", false], ["Error", true], ["RangeError", false], ["MyError",
         class MyError extends Error {
             name: "MyError"
         }
-
         function innerFunctionThatThrows() { throw new ${errorType}(); }
         function outerFunctionThatThrows() { innerFunctionThatThrows(); }
 
@@ -372,7 +371,7 @@ test.each([["Error", false], ["Error", true], ["RangeError", false], ["MyError",
             if (error instanceof Error) {
                 return error.stack;
             } else {
-                throw TypeError();
+                throw Error("This error serves to prevent false positives from .expectNoExecutionError()");
             }
         }
     `

--- a/test/unit/error.spec.ts
+++ b/test/unit/error.spec.ts
@@ -345,3 +345,16 @@ test("get stack from builtin error object", () => {
     expect(stack).toMatch("innerFunctionThatThrows");
     expect(stack).toMatch("outerFunctionThatThrows");
 });
+
+test("subclass Error", () => {
+    const code = `
+        class MyError extends Error { }
+        
+        try {
+            throw new MyError();
+        } catch (error) {
+            return error instanceof Error;
+        }
+    `;
+    expect(util.transpileAndExecute(code)).toBe(true);
+});

--- a/test/unit/error.spec.ts
+++ b/test/unit/error.spec.ts
@@ -289,7 +289,7 @@ test("return from nested finally", () => {
 test("throw and catch custom error object", () => {
     const code = `
       try {
-          throw {x: "Hello error object!"};
+          throw { x: "Hello error object!" };
       } catch (error) {
           return error.x;
       }

--- a/test/unit/error.spec.ts
+++ b/test/unit/error.spec.ts
@@ -296,10 +296,14 @@ test("throw and catch custom error object", () => {
     `.expectToMatchJsResult();
 });
 
-test.each(["Error", "RangeError", "ReferenceError", "SyntaxError", "TypeError", "URIError"])(
+test.each(["Error", "RangeError", "ReferenceError", "SyntaxError", "TypeError", "URIError", "MyError"])(
     "throw builtin Errors as classes",
     errorType => {
         util.testFunction`
+            class MyError extends Error {
+                name: "MyError"
+            }
+
             try {
                 throw new ${errorType}("message")
             } catch (error) {
@@ -315,16 +319,12 @@ test.each(["Error", "RangeError", "ReferenceError", "SyntaxError", "TypeError", 
     }
 );
 
-test.each(["Error", "RangeError", "ReferenceError", "SyntaxError", "TypeError", "URIError", "MyError"])(
+test.each(["Error", "RangeError", "ReferenceError", "SyntaxError", "TypeError", "URIError"])(
     "throw builtin Errors as functions",
     errorType => {
         util.testFunction`
-            class MyError extends Error {
-                name: "MyError"
-            }
-
             try {
-                throw new ${errorType}("message")
+                throw ${errorType}("message")
             } catch (error) {
                 if (error instanceof Error) {
                     return \`\${error}\`;

--- a/test/unit/error.spec.ts
+++ b/test/unit/error.spec.ts
@@ -315,12 +315,16 @@ test.each(["Error", "RangeError", "ReferenceError", "SyntaxError", "TypeError", 
     }
 );
 
-test.each(["Error", "RangeError", "ReferenceError", "SyntaxError", "TypeError", "URIError"])(
+test.each(["Error", "RangeError", "ReferenceError", "SyntaxError", "TypeError", "URIError", "MyError"])(
     "throw builtin Errors as functions",
     errorType => {
         util.testFunction`
+            class MyError extends Error {
+                name: "MyError"
+            }
+
             try {
-                throw ${errorType}("message")
+                throw new ${errorType}("message")
             } catch (error) {
                 if (error instanceof Error) {
                     return \`\${error}\`;

--- a/test/unit/error.spec.ts
+++ b/test/unit/error.spec.ts
@@ -360,7 +360,7 @@ test.each([["Error", false], ["Error", true], ["RangeError", false], ["MyError",
     (errorType, sourceMapTraceback) => {
         const stack = util.testFunction`
         class MyError extends Error {
-            name: "MyError"
+            public name = "MyError";
         }
         function innerFunctionThatThrows() { throw new ${errorType}(); }
         function outerFunctionThatThrows() { innerFunctionThatThrows(); }

--- a/test/unit/error.spec.ts
+++ b/test/unit/error.spec.ts
@@ -306,16 +306,16 @@ test.each([
                 return error;
             }
         }
-        `.expectToMatchJsResult();
+    `.expectToMatchJsResult();
 });
 
 const builtinErrors = ["Error", "RangeError", "ReferenceError", "SyntaxError", "TypeError", "URIError"];
 
-test.each([...builtinErrors, ...builtinErrors.map(type => `new ${type}`)])("test builtin error %s", errorType => {
+test.each([...builtinErrors, ...builtinErrors.map(type => `new ${type}`)])("%s properties", errorType => {
     util.testFunction`
-            const error = ${errorType}();
-            return { name: error.name, message: error.message, string: error.toString() };
-        `.expectToMatchJsResult();
+        const error = ${errorType}();
+        return { name: error.name, message: error.message, string: error.toString() };
+    `.expectToMatchJsResult();
 });
 
 test.each([...builtinErrors, "CustomError"])("get stack from %s", errorType => {
@@ -331,7 +331,7 @@ test.each([...builtinErrors, "CustomError"])("get stack from %s", errorType => {
         outerFunction();
         
         return stack;
-        `.getLuaExecutionResult();
+    `.getLuaExecutionResult();
 
     expect(stack).toMatch("innerFunction");
     expect(stack).toMatch("outerFunction");

--- a/test/unit/error.spec.ts
+++ b/test/unit/error.spec.ts
@@ -326,17 +326,17 @@ test.each([
     util.testFunction`
         const error = ${errorType}();
         return error.name;
-        `.expectToMatchJsResult();
+    `.expectToMatchJsResult();
 
     util.testFunction`
         const error = ${errorType}();
         return error.message;
-        `.expectToMatchJsResult();
+    `.expectToMatchJsResult();
 
     util.testFunction`
-            const error = ${errorType}();
-            return error.toString();
-        `.expectToMatchJsResult();
+        const error = ${errorType}();
+        return error.toString();
+    `.expectToMatchJsResult();
 });
 
 test.each([

--- a/test/unit/error.spec.ts
+++ b/test/unit/error.spec.ts
@@ -295,7 +295,7 @@ test.each([
     `undefined`,
     `{ x: "error object" }`,
     `() => "error function"`,
-])("throw and catch arbitrary types", error => {
+])("throw and catch %s", error => {
     util.testFunction`
             try {
                 throw ${error};
@@ -312,7 +312,7 @@ test.each([
 const builtinErrors = ["Error", "RangeError", "ReferenceError", "SyntaxError", "TypeError", "URIError"];
 
 test.each([...builtinErrors, ...builtinErrors.map(type => `new ${type}`)])(
-    "test builtin error properties",
+    "test builtin error %s",
     errorType => {
         util.testFunction`
         const error = ${errorType}();

--- a/test/unit/error.spec.ts
+++ b/test/unit/error.spec.ts
@@ -286,15 +286,18 @@ test("return from nested finally", () => {
     expect(util.transpileAndExecute(code)).toBe("finally AB");
 });
 
-test("throw and catch custom error object", () => {
-    util.testFunction`
+test.each([`"Hello error string!"`, `42`, `true`, `false`, `undefined`, `{ x: "Hello error object!" }`])(
+    "throw and catch custom error object",
+    error => {
+        util.testFunction`
         try {
-            throw { x: "Hello error object!" };
+            throw ${error};
         } catch (error) {
-            return error.x;
+            return error;
         }
     `.expectToMatchJsResult();
-});
+    }
+);
 
 test.each(["Error", "RangeError", "ReferenceError", "SyntaxError", "TypeError", "URIError"])(
     "throw builtin Errors as classes",
@@ -304,7 +307,7 @@ test.each(["Error", "RangeError", "ReferenceError", "SyntaxError", "TypeError", 
                 throw new ${errorType}("message")
             } catch (error) {
                 if (error instanceof Error) {
-                    return \`\${error}\`;
+                    return error.toString();
                 } else {
                     throw Error("This error serves to prevent false positives from .expectNoExecutionError()");
                 }
@@ -321,7 +324,7 @@ test.each(["Error", "RangeError", "ReferenceError", "SyntaxError", "TypeError", 
                 throw ${errorType}("message")
             } catch (error) {
                 if (error instanceof Error) {
-                    return \`\${error}\`;
+                    return error.toString();
                 } else {
                     throw Error("This error serves to prevent false positives from .expectNoExecutionError()");
                 }
@@ -333,14 +336,14 @@ test.each(["Error", "RangeError", "ReferenceError", "SyntaxError", "TypeError", 
 test("subclass Error", () => {
     util.testFunction`
         class MyError extends Error {
-            name: "MyError"
+            public name = "MyError";
         }
         
         try {
             throw new MyError();
         } catch (error) {
             if (error instanceof Error) {
-                return \'\$error\';
+                return error.toString();
             } else {
                 throw Error("This error serves to prevent false positives from .expectNoExecutionError()");
             }

--- a/test/unit/identifiers.spec.ts
+++ b/test/unit/identifiers.spec.ts
@@ -356,7 +356,7 @@ describe("lua keyword as identifier doesn't interfere with lua's value", () => {
             const error = "foobar";
             throw error;`;
 
-        expect(() => util.transpileAndExecute(code)).toThrow(/^LUA ERROR: .+ foobar$/);
+        expect(() => util.transpileAndExecute(code)).toThrow(/^LUA ERROR: foobar$/);
     });
 
     test("variable (assert)", () => {


### PR DESCRIPTION
This PR enables throwing custom error objects and adds the builtin error classes as [defined by JavaScript](https://basarat.gitbooks.io/typescript/docs/types/exceptions.html). Also fixes a bug in `LuaTransformer.transformClassExpression()` where local class definitions had global scope.  

## Example

### Arbitrary errors

```typescript
try {
  throw {x: "Hello error object!"};
} catch (error) {
  console.log(error.x); // -> Hello error object!
}
```

### Builtin errors

```typescript
try {
  throw RangeError("message"); // or new RangeError("message")
} catch (error) {
  if (error instanceof Error) {
    console.log(error); // -> RangeError: message
    console.log(error.name); // -> RangeError
    console.log(error.message); // -> message
    console.log(error.stack); // prints stack trace from where the error was thrown
  }
}
```

### Inheritance

```typescript
class MyError extends Error{
  name: "MyError"
}

try {
  throw new MyError("message");
} catch (error) {
  // same error properties as builtin errors
} 
```

