### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: master
+  pull_request:
 
 jobs:
   lint:
@@ -32,7 +35,7 @@ jobs:
       - run: npm install --global npm@6
       - run: npm ci
       - run: npm run build
-      - run: npx jest --coverage
+      - run: npx jest --maxWorkers 2 --coverage
         env:
           CI: true
       - if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
- `push` event now triggers only on `master` branch, so PRs from local branches won't run workflow twice anymore
- Jest now is executed with `--maxWorkers 2` option that makes it at least twice faster and prevents memory leaks