### PR TITLE
Support non-string errors with SourceMapTraceback

### DIFF
--- a/src/lualib/SourceMapTraceBack.ts
+++ b/src/lualib/SourceMapTraceBack.ts
@@ -8,9 +8,11 @@ function __TS__SourceMapTraceBack(this: void, fileName: string, sourceMap: { [li
         globalThis.__TS__originalTraceback = debug.traceback;
         debug.traceback = (thread, message, level) => {
             const trace = globalThis.__TS__originalTraceback(thread, message, level);
+
             if (typeof trace !== "string") {
                 return trace;
             }
+
             const [result] = string.gsub(trace, "(%S+).lua:(%d+)", (file, line) => {
                 const fileSourceMap = globalThis.__TS__sourcemap[file + ".lua"];
                 if (fileSourceMap && fileSourceMap[line]) {
@@ -18,6 +20,7 @@ function __TS__SourceMapTraceBack(this: void, fileName: string, sourceMap: { [li
                 }
                 return `${file}.lua:${line}`;
             });
+
             return result;
         };
     }

--- a/src/lualib/SourceMapTraceBack.ts
+++ b/src/lualib/SourceMapTraceBack.ts
@@ -7,7 +7,10 @@ function __TS__SourceMapTraceBack(this: void, fileName: string, sourceMap: { [li
     if (globalThis.__TS__originalTraceback === undefined) {
         globalThis.__TS__originalTraceback = debug.traceback;
         debug.traceback = (thread, message, level) => {
-            const trace = globalThis.__TS__originalTraceback(thread, message, level);
+            let trace = globalThis.__TS__originalTraceback(thread, message, level);
+            if (typeof trace !== "string") {
+                trace = globalThis.__TS__originalTraceback(trace.toString(), 3);
+            }
             const [result] = string.gsub(trace, "(%S+).lua:(%d+)", (file, line) => {
                 const fileSourceMap = globalThis.__TS__sourcemap[file + ".lua"];
                 if (fileSourceMap && fileSourceMap[line]) {
@@ -15,7 +18,6 @@ function __TS__SourceMapTraceBack(this: void, fileName: string, sourceMap: { [li
                 }
                 return `${file}.lua:${line}`;
             });
-
             return result;
         };
     }

--- a/src/lualib/SourceMapTraceBack.ts
+++ b/src/lualib/SourceMapTraceBack.ts
@@ -7,9 +7,9 @@ function __TS__SourceMapTraceBack(this: void, fileName: string, sourceMap: { [li
     if (globalThis.__TS__originalTraceback === undefined) {
         globalThis.__TS__originalTraceback = debug.traceback;
         debug.traceback = (thread, message, level) => {
-            let trace = globalThis.__TS__originalTraceback(thread, message, level);
+            const trace = globalThis.__TS__originalTraceback(thread, message, level);
             if (typeof trace !== "string") {
-                trace = globalThis.__TS__originalTraceback(trace.toString(), 3);
+                return trace;
             }
             const [result] = string.gsub(trace, "(%S+).lua:(%d+)", (file, line) => {
                 const fileSourceMap = globalThis.__TS__sourcemap[file + ".lua"];

--- a/src/lualib/declarations/global.d.ts
+++ b/src/lualib/declarations/global.d.ts
@@ -2,7 +2,7 @@
 
 declare var __TS__sourcemap: Record<number, number> | undefined;
 declare var __TS__originalTraceback:
-    | ((this: void, threadOrMessage?: any, messageOrLevel?: string | number, level?: number) => any)
+    | ((this: void, thread?: any, message?: string, level?: number) => string)
     | undefined;
 
 // Override next declaration so we can omit extra return values

--- a/src/lualib/declarations/global.d.ts
+++ b/src/lualib/declarations/global.d.ts
@@ -2,7 +2,7 @@
 
 declare var __TS__sourcemap: Record<number, number> | undefined;
 declare var __TS__originalTraceback:
-    | ((this: void, thread?: any, message?: string, level?: number) => string)
+    | ((this: void, threadOrMessage?: any, messageOrLevel?: string | number, level?: number) => any)
     | undefined;
 
 // Override next declaration so we can omit extra return values


### PR DESCRIPTION
Currently the custom `debug.traceback` function set for SourceMapTracebacks assumes errors to be invoked with string error messages. However, this is not the case in an `xpcall` context, where `error` may be invoked with any object by the user. 

## Example

### Input

```ts
function f() { throw Error(); }
const [ok, error] = xpcall(() => f(), debug.traceback);
```

### Current Output:

Errors with

```
./.test/test.lua:114: bad argument #1 to 'gsub' (string expected, got table)
stack traceback:
        ./.test/test.lua:113: in function 'debug.traceback'
        [C]: in function 'string.gsub'
        ./.test/test.lua:114: in function 'debug.traceback'
        [C]: in function 'error'
        ./.test/test.lua:138: in function 'f'
        (...tail calls...)
        [C]: in function 'xpcall'
        ./.test/test.ts:15: in main chunk
        [C]: in ?
```

### After PR

Runs correctly and `error` is set to the thrown `Error` object.

