### PR TITLE
Fixed inconsistent scoping of top-level variable declarations

### DIFF
--- a/src/transformation/utils/lua-ast.ts
+++ b/src/transformation/utils/lua-ast.ts
@@ -122,7 +122,6 @@ export function createLocalOrExportedOrGlobalDeclaration(
     let declaration: lua.VariableDeclarationStatement | undefined;
     let assignment: lua.AssignmentStatement | undefined;
 
-    const isVariableDeclaration = tsOriginal !== undefined && ts.isVariableDeclaration(tsOriginal);
     const isFunctionDeclaration = tsOriginal !== undefined && ts.isFunctionDeclaration(tsOriginal);
 
     const identifiers = Array.isArray(lhs) ? lhs : [lhs];
@@ -145,7 +144,7 @@ export function createLocalOrExportedOrGlobalDeclaration(
     } else {
         const insideFunction = findScope(context, ScopeType.Function) !== undefined;
 
-        if (context.isModule || getCurrentNamespace(context) || insideFunction || isVariableDeclaration) {
+        if (context.isModule || getCurrentNamespace(context) || insideFunction) {
             const scope = peekScope(context);
 
             const isPossibleWrappedFunction =

--- a/src/transformation/utils/lua-ast.ts
+++ b/src/transformation/utils/lua-ast.ts
@@ -143,8 +143,9 @@ export function createLocalOrExportedOrGlobalDeclaration(
         }
     } else {
         const insideFunction = findScope(context, ScopeType.Function) !== undefined;
+        const insideBlock = findScope(context, ScopeType.Block) !== undefined;
 
-        if (context.isModule || getCurrentNamespace(context) || insideFunction) {
+        if (context.isModule || getCurrentNamespace(context) || insideFunction || insideBlock) {
             const scope = peekScope(context);
 
             const isPossibleWrappedFunction =

--- a/src/transformation/utils/lua-ast.ts
+++ b/src/transformation/utils/lua-ast.ts
@@ -3,7 +3,6 @@ import * as ts from "typescript";
 import { LuaTarget } from "../../CompilerOptions";
 import * as lua from "../../LuaAST";
 import { TransformationContext } from "../context";
-import { getCurrentNamespace } from "../visitors/namespace";
 import { createExportedIdentifier, getIdentifierExportScope } from "./export";
 import { peekScope, ScopeType } from "./scope";
 import { isFunctionType } from "./typescript";
@@ -145,7 +144,7 @@ export function createLocalOrExportedOrGlobalDeclaration(
         const scope = peekScope(context);
         const isTopLevelVariable = scope.type === ScopeType.File;
 
-        if (context.isModule || getCurrentNamespace(context) || !isTopLevelVariable) {
+        if (context.isModule || !isTopLevelVariable) {
             const isPossibleWrappedFunction =
                 !isFunctionDeclaration &&
                 tsOriginal &&

--- a/src/transformation/visitors/namespace.ts
+++ b/src/transformation/visitors/namespace.ts
@@ -46,8 +46,8 @@ function moduleHasEmittedBody(
     return false;
 }
 
+// Static context -> namespace dictionary keeping the current namespace for each transformation context
 const currentNamespaces = new WeakMap<TransformationContext, ts.ModuleDeclaration | undefined>();
-export const getCurrentNamespace = (context: TransformationContext) => currentNamespaces.get(context);
 
 export const transformModuleDeclaration: FunctionVisitor<ts.ModuleDeclaration> = (node, context) => {
     const annotations = getTypeAnnotations(context, context.checker.getTypeAtLocation(node));

--- a/test/translation/__snapshots__/transformation.spec.ts.snap
+++ b/test/translation/__snapshots__/transformation.spec.ts.snap
@@ -261,6 +261,9 @@ exports[`Transformation (topLevelVariables) 1`] = `
 "obj = {value1 = 1, value2 = 2}
 value1 = obj.value1
 value2 = obj.value2
+obj2 = {value3 = 1, value4 = 2}
+value3 = obj2.value3
+value4 = obj2.value4
 function fun1(self)
 end
 fun2 = function()

--- a/test/translation/__snapshots__/transformation.spec.ts.snap
+++ b/test/translation/__snapshots__/transformation.spec.ts.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Transformation (blockScopeVariables) 1`] = `
+"do
+    local a = 1
+    local b = 1
+    local ____ = {c = 1}
+    local c = ____.c
+end"
+`;
+
 exports[`Transformation (characterEscapeSequence) 1`] = `
 "quoteInDoubleQuotes = \\"' ' '\\"
 quoteInTemplateString = \\"' ' '\\"

--- a/test/translation/__snapshots__/transformation.spec.ts.snap
+++ b/test/translation/__snapshots__/transformation.spec.ts.snap
@@ -1,18 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Transformation (characterEscapeSequence) 1`] = `
-"local quoteInDoubleQuotes = \\"' ' '\\"
-local quoteInTemplateString = \\"' ' '\\"
-local doubleQuoteInQuotes = \\"\\\\\\" \\\\\\" \\\\\\"\\"
-local doubleQuoteInDoubleQuotes = \\"\\\\\\" \\\\\\" \\\\\\"\\"
-local doubleQuoteInTemplateString = \\"\\\\\\" \\\\\\" \\\\\\"\\"
-local backQuoteInQuotes = \\"\` \` \`\\"
-local backQuoteInDoubleQuotes = \\"\` \` \`\\"
-local backQuoteInTemplateString = \\"\` \` \`\\"
-local escapedCharsInQuotes = \\"\\\\\\\\ \\\\0 \\\\b \\\\t \\\\n \\\\v \\\\f \\\\\\" ' \`\\"
-local escapedCharsInDoubleQuotes = \\"\\\\\\\\ \\\\0 \\\\b \\\\t \\\\n \\\\v \\\\f \\\\\\" ' \`\\"
-local escapedCharsInTemplateString = \\"\\\\\\\\ \\\\0 \\\\b \\\\t \\\\n \\\\v \\\\f \\\\\\" ' \`\\"
-local nonEmptyTemplateString = \\"Level 0: \\\\n\\\\t \\" .. \\"Level 1: \\\\n\\\\t\\\\t \\" .. \\"Level 3: \\\\n\\\\t\\\\t\\\\t \\" .. \\"Last level \\\\n --\\" .. \\" \\\\n --\\" .. \\" \\\\n --\\" .. \\" \\\\n --\\""
+"quoteInDoubleQuotes = \\"' ' '\\"
+quoteInTemplateString = \\"' ' '\\"
+doubleQuoteInQuotes = \\"\\\\\\" \\\\\\" \\\\\\"\\"
+doubleQuoteInDoubleQuotes = \\"\\\\\\" \\\\\\" \\\\\\"\\"
+doubleQuoteInTemplateString = \\"\\\\\\" \\\\\\" \\\\\\"\\"
+backQuoteInQuotes = \\"\` \` \`\\"
+backQuoteInDoubleQuotes = \\"\` \` \`\\"
+backQuoteInTemplateString = \\"\` \` \`\\"
+escapedCharsInQuotes = \\"\\\\\\\\ \\\\0 \\\\b \\\\t \\\\n \\\\v \\\\f \\\\\\" ' \`\\"
+escapedCharsInDoubleQuotes = \\"\\\\\\\\ \\\\0 \\\\b \\\\t \\\\n \\\\v \\\\f \\\\\\" ' \`\\"
+escapedCharsInTemplateString = \\"\\\\\\\\ \\\\0 \\\\b \\\\t \\\\n \\\\v \\\\f \\\\\\" ' \`\\"
+nonEmptyTemplateString = \\"Level 0: \\\\n\\\\t \\" .. \\"Level 1: \\\\n\\\\t\\\\t \\" .. \\"Level 3: \\\\n\\\\t\\\\t\\\\t \\" .. \\"Last level \\\\n --\\" .. \\" \\\\n --\\" .. \\" \\\\n --\\" .. \\" \\\\n --\\""
 `;
 
 exports[`Transformation (classExtension1) 1`] = `
@@ -244,7 +244,7 @@ ____exports.foo = \\"bar\\"
 return ____exports"
 `;
 
-exports[`Transformation (modulesVariableNoExport) 1`] = `"local foo = \\"bar\\""`;
+exports[`Transformation (modulesVariableNoExport) 1`] = `"foo = \\"bar\\""`;
 
 exports[`Transformation (namespacePhantom) 1`] = `
 "function nsMember(self)
@@ -254,6 +254,16 @@ end"
 exports[`Transformation (returnDefault) 1`] = `
 "function myFunc(self)
     return
+end"
+`;
+
+exports[`Transformation (topLevelVariables) 1`] = `
+"obj = {value1 = 1, value2 = 2}
+value1 = obj.value1
+value2 = obj.value2
+function fun1(self)
+end
+fun2 = function()
 end"
 `;
 

--- a/test/translation/transformation/blockScopeVariables.ts
+++ b/test/translation/transformation/blockScopeVariables.ts
@@ -1,0 +1,5 @@
+{
+    const a = 1;
+    const [b] = [1];
+    const { c } = { c: 1 };
+}

--- a/test/translation/transformation/topLevelVariables.ts
+++ b/test/translation/transformation/topLevelVariables.ts
@@ -2,6 +2,7 @@ const obj = { value1: 1, value2: 2 };
 const value1 = obj.value1;
 const { value2 } = obj;
 
+let noValueLet;
 let obj2 = { value3: 1, value4: 2 };
 let value3 = obj2.value3;
 let { value4 } = obj2;

--- a/test/translation/transformation/topLevelVariables.ts
+++ b/test/translation/transformation/topLevelVariables.ts
@@ -2,5 +2,9 @@ const obj = { value1: 1, value2: 2 };
 const value1 = obj.value1;
 const { value2 } = obj;
 
+let obj2 = { value3: 1, value4: 2 };
+let value3 = obj2.value3;
+let { value4 } = obj2;
+
 function fun1(): void {}
 const fun2 = () => {};

--- a/test/translation/transformation/topLevelVariables.ts
+++ b/test/translation/transformation/topLevelVariables.ts
@@ -1,0 +1,6 @@
+const obj = { value1: 1, value2: 2 };
+const value1 = obj.value1;
+const { value2 } = obj;
+
+function fun1(): void {}
+const fun2 = () => {};

--- a/test/unit/assignments.spec.ts
+++ b/test/unit/assignments.spec.ts
@@ -1,15 +1,5 @@
 import * as util from "../util";
 
-test("const declaration", () => {
-    const lua = util.testFunction`const foo = true;`.getMainLuaCodeChunk();
-    expect(lua).toContain(`local foo = true`);
-});
-
-test("let declaration", () => {
-    const lua = util.testFunction`let foo = true;`.getMainLuaCodeChunk();
-    expect(lua).toContain(`local foo = true`);
-});
-
 test.each(["const", "let"])("%s declaration not top-level is not global", declarationKind => {
     util.testModule`
         {

--- a/test/unit/assignments.spec.ts
+++ b/test/unit/assignments.spec.ts
@@ -10,14 +10,12 @@ test("let declaration", () => {
     expect(lua).toContain(`local foo = true`);
 });
 
-test("const declaration top-level is global", () => {
-    const lua = util.testModule`const foo = true;`.getMainLuaCodeChunk();
-    expect(lua).toBe(`foo = true`);
-});
-
-test("let declaration top-level is global", () => {
-    const lua = util.testModule`let foo = true;`.getMainLuaCodeChunk();
-    expect(lua).toBe(`foo = true`);
+test.each(["const", "let"])("%s declaration top-level is global", declarationKind => {
+    util.testModule`
+        ${declarationKind} foo = true;
+        // @ts-ignore
+        return (globalThis as any).foo;
+    `.expectToEqual(true);
 });
 
 test("var declaration is disallowed", () => {

--- a/test/unit/assignments.spec.ts
+++ b/test/unit/assignments.spec.ts
@@ -1,13 +1,23 @@
 import * as util from "../util";
 
 test("const declaration", () => {
-    const lua = util.transpileString(`const foo = true;`);
-    expect(lua).toBe(`local foo = true`);
+    const lua = util.testFunction`const foo = true;`.getMainLuaCodeChunk();
+    expect(lua).toContain(`local foo = true`);
 });
 
 test("let declaration", () => {
-    const lua = util.transpileString(`let foo = true;`);
-    expect(lua).toBe(`local foo = true`);
+    const lua = util.testFunction`let foo = true;`.getMainLuaCodeChunk();
+    expect(lua).toContain(`local foo = true`);
+});
+
+test("const declaration top-level is global", () => {
+    const lua = util.testModule`const foo = true;`.getMainLuaCodeChunk();
+    expect(lua).toBe(`foo = true`);
+});
+
+test("let declaration top-level is global", () => {
+    const lua = util.testModule`let foo = true;`.getMainLuaCodeChunk();
+    expect(lua).toBe(`foo = true`);
 });
 
 test("var declaration is disallowed", () => {

--- a/test/unit/assignments.spec.ts
+++ b/test/unit/assignments.spec.ts
@@ -10,6 +10,16 @@ test("let declaration", () => {
     expect(lua).toContain(`local foo = true`);
 });
 
+test.each(["const", "let"])("%s declaration not top-level is not global", declarationKind => {
+    util.testModule`
+        {
+            ${declarationKind} foo = true;
+        }
+        // @ts-ignore
+        return (globalThis as any).foo;
+    `.expectToEqual(undefined);
+});
+
 test.each(["const", "let"])("%s declaration top-level is global", declarationKind => {
     util.testModule`
         ${declarationKind} foo = true;

--- a/test/unit/objectLiteral.spec.ts
+++ b/test/unit/objectLiteral.spec.ts
@@ -8,7 +8,9 @@ test.each([
     { inp: `{[myFunc()]:3,b:"4"}`, out: '{\n    [myFunc(_G)] = 3,\n    b = "4"\n}' },
     { inp: `{x}`, out: `{x = x}` },
 ])("Object Literal (%p)", ({ inp, out }) => {
-    const lua = util.testModule`const myvar = ${inp};`.getMainLuaCodeChunk();
+    const lua = util.testModule`
+        const myvar = ${inp};
+    `.getMainLuaCodeChunk();
     expect(lua).toBe(`myvar = ${out}`);
 });
 

--- a/test/unit/objectLiteral.spec.ts
+++ b/test/unit/objectLiteral.spec.ts
@@ -1,20 +1,23 @@
 import * as util from "../util";
 
-test.each([`{a:3,b:"4"}`, `{"a":3,b:"4"}`, `{["a"]:3,b:"4"}`, `{["a"+123]:3,b:"4"}`])("Object Literal (%p)", inp => {
-    util.testExpression(inp).expectToMatchJsResult();
-});
+test.each([`{ a: 3, b: "4" }`, `{ "a": 3, b: "4" }`, `{ ["a"]: 3, b: "4" }`, `{ ["a" + 123]: 3, b: "4" }`])(
+    "Object Literal (%p)",
+    inp => {
+        util.testExpression(inp).expectToMatchJsResult();
+    }
+);
 
 test("object literal with function call to get key", () => {
     util.testFunction`
         const myFunc = () => "a";
-    	return {[myFunc() + "b"]: 3};
+        return { [myFunc() + "b"]: 3 };
     `.expectToMatchJsResult();
 });
 
 test("object literal with shorthand property", () => {
     util.testFunction`
         const x = 5;
-        return {x};
+        return { x };
     `.expectToMatchJsResult();
 });
 

--- a/test/unit/objectLiteral.spec.ts
+++ b/test/unit/objectLiteral.spec.ts
@@ -22,18 +22,14 @@ describe("property shorthand", () => {
     });
 
     test.each([NaN, Infinity])("should support %p shorthand", identifier => {
-        util.testFunction`return ({ ${identifier} }).${identifier}`.expectToMatchJsResult();
+        util.testExpression`({ ${identifier} }).${identifier}`.expectToMatchJsResult();
     });
 
     test("should support _G shorthand", () => {
-        const luaResult = util.testFunction`
-            return ({ _G })._G.foobar;
-        `
+        util.testExpression`({ _G })._G.foobar`
             .setTsHeader(`declare const _G: any;`)
             .setLuaHeader(`foobar = "foobar"`)
-            .getLuaExecutionResult();
-
-        expect(luaResult).toEqual("foobar");
+            .expectToEqual("foobar");
     });
 
     test("should support export property shorthand", () => {
@@ -55,6 +51,6 @@ test("undefined as object key", () => {
 test.each([`({x: "foobar"}.x)`, `({x: "foobar"}["x"])`, `({x: () => "foobar"}.x())`, `({x: () => "foobar"}["x"]())`])(
     "object literal property access (%p)",
     expression => {
-        util.testFunction`return ${expression}`.expectToMatchJsResult();
+        util.testExpression(expression).expectToMatchJsResult();
     }
 );

--- a/test/unit/objectLiteral.spec.ts
+++ b/test/unit/objectLiteral.spec.ts
@@ -1,17 +1,21 @@
 import * as util from "../util";
 
-test.each([
-    { inp: `{a:3,b:"4"}`, out: '{a = 3, b = "4"}' },
-    { inp: `{"a":3,b:"4"}`, out: '{a = 3, b = "4"}' },
-    { inp: `{["a"]:3,b:"4"}`, out: '{a = 3, b = "4"}' },
-    { inp: `{["a"+123]:3,b:"4"}`, out: '{["a" .. 123] = 3, b = "4"}' },
-    { inp: `{[myFunc()]:3,b:"4"}`, out: '{\n    [myFunc(_G)] = 3,\n    b = "4"\n}' },
-    { inp: `{x}`, out: `{x = x}` },
-])("Object Literal (%p)", ({ inp, out }) => {
-    const lua = util.testModule`
-        const myvar = ${inp};
-    `.getMainLuaCodeChunk();
-    expect(lua).toBe(`myvar = ${out}`);
+test.each([`{a:3,b:"4"}`, `{"a":3,b:"4"}`, `{["a"]:3,b:"4"}`, `{["a"+123]:3,b:"4"}`])("Object Literal (%p)", inp => {
+    util.testExpression(inp).expectToMatchJsResult();
+});
+
+test("object literal with function call to get key", () => {
+    util.testFunction`
+        const myFunc = () => "a";
+    	return {[myFunc() + "b"]: 3};
+    `.expectToMatchJsResult();
+});
+
+test("object literal with shorthand property", () => {
+    util.testFunction`
+        const x = 5;
+        return {x};
+    `.expectToMatchJsResult();
 });
 
 describe("property shorthand", () => {

--- a/test/unit/objectLiteral.spec.ts
+++ b/test/unit/objectLiteral.spec.ts
@@ -8,59 +8,53 @@ test.each([
     { inp: `{[myFunc()]:3,b:"4"}`, out: '{\n    [myFunc(_G)] = 3,\n    b = "4"\n}' },
     { inp: `{x}`, out: `{x = x}` },
 ])("Object Literal (%p)", ({ inp, out }) => {
-    const lua = util.transpileString(`const myvar = ${inp};`);
-    expect(lua).toBe(`local myvar = ${out}`);
+    const lua = util.testModule`const myvar = ${inp};`.getMainLuaCodeChunk();
+    expect(lua).toBe(`myvar = ${out}`);
 });
 
 describe("property shorthand", () => {
     test("should support property shorthand", () => {
-        const result = util.transpileAndExecute(`
+        util.testFunction`
             const x = 1;
             const o = { x };
             return o.x;
-        `);
-
-        expect(result).toBe(1);
+        `.expectToMatchJsResult();
     });
 
     test.each([NaN, Infinity])("should support %p shorthand", identifier => {
-        const result = util.transpileAndExecute(`return ({ ${identifier} }).${identifier}`);
-
-        expect(result).toBe(identifier);
+        util.testFunction`return ({ ${identifier} }).${identifier}`.expectToMatchJsResult();
     });
 
     test("should support _G shorthand", () => {
-        const result = util.transpileAndExecute(
-            `return ({ _G })._G.foobar;`,
-            undefined,
-            `foobar = "foobar"`,
-            "declare const _G: any;"
-        );
+        const luaResult = util.testFunction`
+            return ({ _G })._G.foobar;
+        `
+            .setTsHeader(`declare const _G: any;`)
+            .setLuaHeader(`foobar = "foobar"`)
+            .getLuaExecutionResult();
 
-        expect(result).toBe("foobar");
+        expect(luaResult).toEqual("foobar");
     });
 
     test("should support export property shorthand", () => {
-        const code = `
+        util.testModule`
             export const x = 1;
             const o = { x };
             export const y = o.x;
-        `;
-        expect(util.transpileExecuteAndReturnExport(code, "y")).toBe(1);
+        `.expectToMatchJsResult();
     });
 });
 
 test("undefined as object key", () => {
-    const code = `const foo = {undefined: "foo"};
-        return foo.undefined;`;
-    expect(util.transpileAndExecute(code)).toBe("foo");
+    util.testFunction`
+        const foo = {undefined: "foo"};
+        return foo.undefined;
+    `.expectToMatchJsResult();
 });
 
 test.each([`({x: "foobar"}.x)`, `({x: "foobar"}["x"])`, `({x: () => "foobar"}.x())`, `({x: () => "foobar"}["x"]())`])(
     "object literal property access (%p)",
     expression => {
-        const code = `return ${expression}`;
-        const expectResult = eval(expression);
-        expect(util.transpileAndExecute(code)).toBe(expectResult);
+        util.testFunction`return ${expression}`.expectToMatchJsResult();
     }
 );


### PR DESCRIPTION
We have the convention of treating files without imports or exports as 'global' scripts where all top-level variables are considered global.

Variable declarations however did not adhere to this convention, that has been corrected.

Fixes #720, closes #790 
 