### PR TITLE
fix debug.traceback() return nil in lua5.1

### DIFF
--- a/src/lualib/SourceMapTraceBack.ts
+++ b/src/lualib/SourceMapTraceBack.ts
@@ -7,7 +7,12 @@ function __TS__SourceMapTraceBack(this: void, fileName: string, sourceMap: { [li
     if (globalThis.__TS__originalTraceback === undefined) {
         globalThis.__TS__originalTraceback = debug.traceback;
         debug.traceback = (thread, message, level) => {
-            const trace = globalThis.__TS__originalTraceback(thread, message, level);
+            let trace: string;
+            if (thread === undefined && message === undefined && level === undefined) {
+                trace = globalThis.__TS__originalTraceback();
+            } else {
+                trace = globalThis.__TS__originalTraceback(thread, message, level);
+            }
 
             if (typeof trace !== "string") {
                 return trace;


### PR DESCRIPTION
This is relevant the **debug.traceback** bug in lua5.1.
```
debug.traceback(nil, nil, nil)  -- return nil
```
![QQ截图20200203161823](https://user-images.githubusercontent.com/12658348/73636462-da55f700-46a0-11ea-8f97-5f22e502057b.png)
