### PR TITLE
Error LuaLibFeature should depend on Class

### DIFF
--- a/src/LuaLib.ts
+++ b/src/LuaLib.ts
@@ -73,7 +73,7 @@ export enum LuaLibFeature {
 const luaLibDependencies: { [lib in LuaLibFeature]?: LuaLibFeature[] } = {
     ArrayFlat: [LuaLibFeature.ArrayConcat],
     ArrayFlatMap: [LuaLibFeature.ArrayConcat],
-    Error: [LuaLibFeature.New, LuaLibFeature.FunctionCall],
+    Error: [LuaLibFeature.New, LuaLibFeature.Class, LuaLibFeature.FunctionCall],
     InstanceOf: [LuaLibFeature.Symbol],
     Iterator: [LuaLibFeature.Symbol],
     ObjectFromEntries: [LuaLibFeature.Iterator, LuaLibFeature.Symbol],


### PR DESCRIPTION
When using inline Lua lib, after transpiling
```ts
throw new Error("Hello World");
```
it fails at runtime with `attempt to call a nil value (global '__TS__Class')`.

Repro:
https://typescripttolua.github.io/play.html#src=throw%20new%20Error(%22Hello%20World%22)%3B

This PR should fix that.