### PR TITLE
added wow to typescript declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ The real power of this transpiler is usage together with good declarations for t
 - [Dota 2 Modding](https://github.com/ModDota/API/tree/master/declarations/server)
 - [Defold Game Engine Scripting](https://github.com/dasannikov/DefoldTypeScript/blob/master/defold.d.ts)
 - [LÖVE 2D Game Development](https://github.com/hazzard993/love-typescript-definitions)
+- [World of Warcraft - Addon Development](https://github.com/wartoshika/wow-declarations)
+- [World of Warcraft Classic - Addon Development](https://github.com/wartoshika/wow-classic-declarations)
 
 ## Sublime Text integration
 


### PR DESCRIPTION
I would love to add my declaration files that are compatible with TypeScriptToLua.

During the development process we merged [this pull request](https://github.com/wartoshika/wow-declarations/pull/3) to be compatible to this program.

There are a bunch of people using TypeScript for addon development in World of Warcraft and this could be a great showcase for your readme.

Let me know if i should change anything.

Thanks in advance, wartoshika