### PR TITLE
Resolve exported identifiers in for-in loops

### DIFF
--- a/src/transformation/visitors/loops/for-in.ts
+++ b/src/transformation/visitors/loops/for-in.ts
@@ -4,6 +4,7 @@ import { FunctionVisitor } from "../../context";
 import { ForbiddenForIn, UnsupportedForInVariable } from "../../utils/errors";
 import { isArrayType } from "../../utils/typescript";
 import { transformIdentifier } from "../identifier";
+import { transformAssignment } from "../binary-expression/assignments";
 import { getVariableDeclarationBinding, transformLoopBody } from "./utils";
 
 export const transformForInStatement: FunctionVisitor<ts.ForInStatement> = (statement, context) => {
@@ -33,11 +34,14 @@ export const transformForInStatement: FunctionVisitor<ts.ForInStatement> = (stat
         // Iteration variable becomes ____key
         iterationVariable = lua.createIdentifier("____key");
         // Push variable = ____key to the start of the loop body to match TS scoping
-        const initializer = lua.createAssignmentStatement(
-            transformIdentifier(context, statement.initializer),
-            iterationVariable
+        const assignment = transformAssignment(
+            context,
+            statement.initializer,
+            iterationVariable,
+            statement.initializer
         );
-        body.statements.unshift(initializer);
+
+        body.statements.unshift(...assignment);
     } else {
         // This should never occur
         throw UnsupportedForInVariable(statement.initializer);

--- a/test/unit/modules/modules.spec.ts
+++ b/test/unit/modules/modules.spec.ts
@@ -253,3 +253,22 @@ test("export as specifier shouldn't effect local vars", () => {
         a = 6;
     `.expectToMatchJsResult();
 });
+
+test("export modified in for in loop", () => {
+    util.testModule`
+        export let foo = '';
+        for (foo in { x: true }) {}
+    `
+        .setReturnExport("x")
+        .expectToMatchJsResult();
+});
+
+test("export dependency modified in for in loop", () => {
+    util.testModule`
+        let foo = '';
+        export { foo as bar };
+        for (foo in { x: true }) {}
+    `
+        .setReturnExport("bar")
+        .expectToEqual("x");
+});


### PR DESCRIPTION
Closes #781

Not entirely sure what

```ts
let foo = '';
export { foo as bar };
for (foo in { x: true }) {}
```

is meant to change `bar` to.

TypeScript doesn't change `bar` specifically in for-in loops.