### PR TITLE
Support all for-of assignments and patterns

### DIFF
--- a/src/transformation/utils/errors.ts
+++ b/src/transformation/utils/errors.ts
@@ -130,9 +130,6 @@ export const UnsupportedNonDestructuringLuaIterator = (node: ts.Node) =>
 export const UnresolvableRequirePath = (node: ts.Node, reason: string, path?: string) =>
     new TranspileError(`${reason}. TypeScript path: ${path}.`, node);
 
-export const UnsupportedObjectDestructuringInForOf = (node: ts.Node) =>
-    new TranspileError(`Unsupported object destructuring in for...of statement.`, node);
-
 export const InvalidAmbientIdentifierName = (node: ts.Identifier) =>
     new TranspileError(
         `Invalid ambient identifier name "${node.text}". Ambient identifiers must be valid lua identifiers.`,

--- a/src/transformation/visitors/binary-expression/destructuring-assignments.ts
+++ b/src/transformation/visitors/binary-expression/destructuring-assignments.ts
@@ -46,6 +46,19 @@ export function transformDestructuringAssignment(
     }
 }
 
+export function transformAssignmentPattern(
+    context: TransformationContext,
+    node: ts.AssignmentPattern,
+    root: lua.Expression
+): lua.Statement[] {
+    switch (node.kind) {
+        case ts.SyntaxKind.ObjectLiteralExpression:
+            return transformObjectLiteralAssignmentPattern(context, node, root);
+        case ts.SyntaxKind.ArrayLiteralExpression:
+            return transformArrayLiteralAssignmentPattern(context, node, root);
+    }
+}
+
 function transformArrayDestructuringAssignment(
     context: TransformationContext,
     node: ts.ArrayDestructuringAssignment,

--- a/src/transformation/visitors/binary-expression/destructuring-assignments.ts
+++ b/src/transformation/visitors/binary-expression/destructuring-assignments.ts
@@ -38,12 +38,7 @@ export function transformDestructuringAssignment(
     node: ts.DestructuringAssignment,
     root: lua.Expression
 ): lua.Statement[] {
-    switch (node.left.kind) {
-        case ts.SyntaxKind.ObjectLiteralExpression:
-            return transformObjectDestructuringAssignment(context, node as ts.ObjectDestructuringAssignment, root);
-        case ts.SyntaxKind.ArrayLiteralExpression:
-            return transformArrayDestructuringAssignment(context, node as ts.ArrayDestructuringAssignment, root);
-    }
+    return transformAssignmentPattern(context, node.left, root);
 }
 
 export function transformAssignmentPattern(
@@ -57,14 +52,6 @@ export function transformAssignmentPattern(
         case ts.SyntaxKind.ArrayLiteralExpression:
             return transformArrayLiteralAssignmentPattern(context, node, root);
     }
-}
-
-function transformArrayDestructuringAssignment(
-    context: TransformationContext,
-    node: ts.ArrayDestructuringAssignment,
-    root: lua.Expression
-): lua.Statement[] {
-    return transformArrayLiteralAssignmentPattern(context, node.left, root);
 }
 
 function transformArrayLiteralAssignmentPattern(
@@ -143,14 +130,6 @@ function transformArrayLiteralAssignmentPattern(
                 throw UnsupportedKind("Array Destructure Assignment Element", element.kind, element);
         }
     });
-}
-
-function transformObjectDestructuringAssignment(
-    context: TransformationContext,
-    node: ts.ObjectDestructuringAssignment,
-    root: lua.Expression
-): lua.Statement[] {
-    return transformObjectLiteralAssignmentPattern(context, node.left, root);
 }
 
 function transformObjectLiteralAssignmentPattern(

--- a/src/transformation/visitors/loops/for-of.ts
+++ b/src/transformation/visitors/loops/for-of.ts
@@ -43,6 +43,7 @@ function transformForOfInitializer(
         }
     } else {
         // Assignment to existing variable(s)
+
         if (isAssignmentPattern(initializer)) {
             return transformAssignmentPattern(context, initializer, expression);
         }

--- a/src/transformation/visitors/loops/for-of.ts
+++ b/src/transformation/visitors/loops/for-of.ts
@@ -1,17 +1,11 @@
 import * as ts from "typescript";
 import * as lua from "../../../LuaAST";
-import { cast, castEach } from "../../../utils";
+import { castEach } from "../../../utils";
 import { FunctionVisitor, TransformationContext } from "../../context";
 import { AnnotationKind, getTypeAnnotations, isForRangeType, isLuaIteratorType } from "../../utils/annotations";
-import {
-    InvalidForRangeCall,
-    MissingForOfVariables,
-    UnsupportedNonDestructuringLuaIterator,
-    UnsupportedObjectDestructuringInForOf,
-} from "../../utils/errors";
-import { createUnpackCall } from "../../utils/lua-ast";
+import { InvalidForRangeCall, MissingForOfVariables, UnsupportedNonDestructuringLuaIterator } from "../../utils/errors";
 import { LuaLibFeature, transformLuaLibFunction } from "../../utils/lualib";
-import { isArrayType, isNumberType } from "../../utils/typescript";
+import { isArrayType, isNumberType, isAssignmentPattern } from "../../utils/typescript";
 import { transformArguments } from "../call";
 import { transformIdentifier } from "../identifier";
 import {
@@ -20,6 +14,8 @@ import {
     transformVariableDeclaration,
 } from "../variable-declaration";
 import { getVariableDeclarationBinding, transformLoopBody } from "./utils";
+import { transformAssignment } from "../binary-expression/assignments";
+import { transformAssignmentPattern } from "../binary-expression/destructuring-assignments";
 
 function transformForOfInitializer(
     context: TransformationContext,
@@ -29,15 +25,8 @@ function transformForOfInitializer(
     if (ts.isVariableDeclarationList(initializer)) {
         const binding = getVariableDeclarationBinding(initializer);
         // Declaration of new variable
-        if (ts.isArrayBindingPattern(binding)) {
-            if (binding.elements.length === 0) {
-                // Ignore empty destructuring assignment
-                return [];
-            }
-
+        if (ts.isArrayBindingPattern(binding) || ts.isObjectBindingPattern(binding)) {
             return transformBindingPattern(context, binding, expression);
-        } else if (ts.isObjectBindingPattern(binding)) {
-            throw UnsupportedObjectDestructuringInForOf(initializer);
         }
 
         const variableStatements = transformVariableDeclaration(context, initializer.declarations[0]);
@@ -53,27 +42,12 @@ function transformForOfInitializer(
             throw MissingForOfVariables(initializer);
         }
     } else {
-        // Assignment to existing variable
-        let variables: lua.AssignmentLeftHandSideExpression | lua.AssignmentLeftHandSideExpression[];
-        let valueExpression: lua.Expression = expression;
-        if (ts.isArrayLiteralExpression(initializer)) {
-            if (initializer.elements.length > 0) {
-                valueExpression = createUnpackCall(context, expression, initializer);
-                variables = castEach(
-                    initializer.elements.map(e => context.transformExpression(e)),
-                    lua.isAssignmentLeftHandSideExpression
-                );
-            } else {
-                // Ignore empty destructring assignment
-                return [];
-            }
-        } else if (ts.isObjectLiteralExpression(initializer)) {
-            throw UnsupportedObjectDestructuringInForOf(initializer);
-        } else {
-            variables = cast(context.transformExpression(initializer), lua.isAssignmentLeftHandSideExpression);
+        // Assignment to existing variable(s)
+        if (isAssignmentPattern(initializer)) {
+            return transformAssignmentPattern(context, initializer, expression);
         }
 
-        return [lua.createAssignmentStatement(variables, valueExpression)];
+        return transformAssignment(context, initializer, expression);
     }
 }
 

--- a/test/unit/destructuring.spec.ts
+++ b/test/unit/destructuring.spec.ts
@@ -140,3 +140,28 @@ describe("array destructuring optimization", () => {
             .expectToMatchJsResult();
     });
 });
+
+test.each([
+    ["foo", "['bar']"],
+    ["[foo]", "[['bar']]"],
+    ["{ foo }", "[{ foo: 'bar' }]"],
+])("forof assignment updates dependencies", (initializer, expression) => {
+    util.testModule`
+        let foo = '';
+        export { foo };
+        for (${initializer} of ${expression}) {}
+    `
+        .setReturnExport("foo")
+        .expectToEqual("bar");
+});
+
+test.each([
+    ["const [foo]", "[['bar']]"],
+    ["const { foo }", "[{ foo: 'bar' }]"],
+])("forof variable declaration binding patterns", (initializer, expression) => {
+    util.testFunction`
+        for (${initializer} of ${expression}) {
+            return foo;
+        }
+    `.expectToMatchJsResult();
+});

--- a/test/unit/destructuring.spec.ts
+++ b/test/unit/destructuring.spec.ts
@@ -104,12 +104,12 @@ test.each([
     ["[foo = 'bar']", "[[]]"],
     ["{ foo }", "[{ foo: 'bar' }]"],
     ["{ x: foo }", "[{ x: 'bar' }]"],
-    ["{ foo = 'bar' }", "[{}]"],
+    ["{ foo = 'bar' }", "[{}] as { foo?: string }[]"],
 ])("forof assignment updates dependencies", (initializer, expression) => {
     util.testModule`
         let foo = '';
         export { foo };
-        for (${initializer} of ${expression} as any) {}
+        for (${initializer} of ${expression}) {}
     `
         .setReturnExport("foo")
         .expectToEqual("bar");

--- a/test/unit/destructuring.spec.ts
+++ b/test/unit/destructuring.spec.ts
@@ -141,8 +141,8 @@ describe("array destructuring optimization", () => {
     });
 });
 
-// TODO: Adjust this test to use expectToMatchJsResult() and testCases when TypeScript can correctly handle the code.
-// See Babel's transpiler for how this code is meant to be transpiled.
+// TODO: https://github.com/microsoft/TypeScript/pull/35906
+// Adjust this test to use expectToMatchJsResult() and testCases when this issue is fixed.
 test.each([
     ["foo", "['bar']"],
     ["[foo]", "[['bar']]"],

--- a/test/unit/loops.spec.ts
+++ b/test/unit/loops.spec.ts
@@ -601,3 +601,28 @@ test("for...in with pre-defined variable keeps last value", () => {
         return x;
     `.expectToMatchJsResult();
 });
+
+test.each([
+    ["foo", "['bar']"],
+    ["[foo]", "[['bar']]"],
+    ["{ foo }", "[{ foo: 'bar' }]"],
+])("forof assignment updates dependencies", (initializer, expression) => {
+    util.testModule`
+        let foo = '';
+        export { foo };
+        for (${initializer} of ${expression}) {}
+    `
+        .setReturnExport("foo")
+        .expectToEqual("bar");
+});
+
+test.each([
+    ["const [foo]", "[['bar']]"],
+    ["const { foo }", "[{ foo: 'bar' }]"],
+])("forof variable declaration binding patterns", (initializer, expression) => {
+    util.testFunction`
+        for (${initializer} of ${expression}) {
+            return foo;
+        }
+    `.expectToMatchJsResult();
+});

--- a/test/unit/loops.spec.ts
+++ b/test/unit/loops.spec.ts
@@ -1,10 +1,6 @@
 import * as ts from "typescript";
 import * as tstl from "../../src";
-import {
-    ForbiddenForIn,
-    UnsupportedForTarget,
-    UnsupportedObjectDestructuringInForOf,
-} from "../../src/transformation/utils/errors";
+import { ForbiddenForIn, UnsupportedForTarget } from "../../src/transformation/utils/errors";
 import * as util from "../util";
 
 test("while", () => {
@@ -426,22 +422,6 @@ test("forof array which modifies length", () => {
         }
         return result;
     `.expectToMatchJsResult();
-});
-
-test.each([
-    { initializer: "const {a, b}", vars: "" },
-    { initializer: "const {a: x, b: y}", vars: "" },
-    { initializer: "{a, b}", vars: "let a: string, b: string;" },
-    { initializer: "{a: c, b: d}", vars: "let c: string, d: string;" },
-])("forof object destructuring (%p)", ({ initializer, vars }) => {
-    const code = `
-        declare const arr: {a: string, b: string}[];
-        ${vars}
-        for (${initializer} of arr) {}`;
-
-    expect(() => util.transpileString(code)).toThrow(
-        UnsupportedObjectDestructuringInForOf(ts.createEmptyStatement()).message
-    );
 });
 
 test("forof nested destructuring", () => {

--- a/test/unit/loops.spec.ts
+++ b/test/unit/loops.spec.ts
@@ -601,28 +601,3 @@ test("for...in with pre-defined variable keeps last value", () => {
         return x;
     `.expectToMatchJsResult();
 });
-
-test.each([
-    ["foo", "['bar']"],
-    ["[foo]", "[['bar']]"],
-    ["{ foo }", "[{ foo: 'bar' }]"],
-])("forof assignment updates dependencies", (initializer, expression) => {
-    util.testModule`
-        let foo = '';
-        export { foo };
-        for (${initializer} of ${expression}) {}
-    `
-        .setReturnExport("foo")
-        .expectToEqual("bar");
-});
-
-test.each([
-    ["const [foo]", "[['bar']]"],
-    ["const { foo }", "[{ foo: 'bar' }]"],
-])("forof variable declaration binding patterns", (initializer, expression) => {
-    util.testFunction`
-        for (${initializer} of ${expression}) {
-            return foo;
-        }
-    `.expectToMatchJsResult();
-});


### PR DESCRIPTION
Fixes #780

Also gives support for all kinds of destructuring assignments and binding patterns inside for-of loops.

```ts
for (const { name } of names) {} // now supported
for ({ name } of names) {} // now supported
```