### PR TITLE
fixed paths in source maps

### DIFF
--- a/test/transpile/plugins/printer.ts
+++ b/test/transpile/plugins/printer.ts
@@ -2,7 +2,7 @@ import * as tstl from "../../../src";
 
 const plugin: tstl.Plugin = {
     printer: (program, emitHost, fileName, ...args) => {
-        const result = new tstl.LuaPrinter(program.getCompilerOptions(), emitHost, fileName).print(...args);
+        const result = new tstl.LuaPrinter(emitHost, program, fileName).print(...args);
         result.code = `-- Plugin\n${result.code}`;
         return result;
     },

--- a/test/unit/printer/sourcemaps.spec.ts
+++ b/test/unit/printer/sourcemaps.spec.ts
@@ -159,27 +159,64 @@ test.each([
     }
 });
 
-test("Source map has correct sources", async () => {
+test.each([
+    { fileName: "/proj/foo.ts", config: {}, mapSource: "foo.ts", fullSource: "foo.ts" },
+    {
+        fileName: "/proj/src/foo.ts",
+        config: { outDir: "/proj/dst" },
+        mapSource: "foo.ts",
+        fullSource: "foo.ts",
+    },
+    {
+        fileName: "/proj/src/foo.ts",
+        config: { rootDir: "/proj/src", outDir: "/proj/dst" },
+        mapSource: "../src/foo.ts",
+        fullSource: "../src/foo.ts",
+    },
+    {
+        fileName: "/proj/src/sub/foo.ts",
+        config: { rootDir: "/proj/src", outDir: "/proj/dst" },
+        mapSource: "../../src/sub/foo.ts",
+        fullSource: "../../src/sub/foo.ts",
+    },
+    {
+        fileName: "/proj/src/sub/main.ts",
+        config: { rootDir: "/proj/src", outDir: "/proj/dst", sourceRoot: "bin" },
+        mapSource: "sub/main.ts",
+        fullSource: "bin/sub/main.ts",
+    },
+])("Source map has correct sources (%p)", async ({ fileName, config, mapSource, fullSource }) => {
     const file = util.testModule`
         const foo = "foo"
     `
-        .expectToHaveNoDiagnostics()
+        .setOptions(config)
+        .setMainFileName(fileName)
         .getMainLuaFileResult();
+
+    const sourceMap = JSON.parse(file.sourceMap);
+    expect(sourceMap.sources.length).toBe(1);
+    expect(sourceMap.sources[0]).toBe(mapSource);
 
     const consumer = await new SourceMapConsumer(file.sourceMap);
     expect(consumer.sources.length).toBe(1);
-    expect(consumer.sources[0]).toBe("main.ts");
+    expect(consumer.sources[0]).toBe(fullSource);
 });
 
-test("Source map has correct source root", async () => {
+test.each([
+    { configSourceRoot: undefined, mapSourceRoot: "" },
+    { configSourceRoot: "src", mapSourceRoot: "src/" },
+    { configSourceRoot: "src/", mapSourceRoot: "src/" },
+    { configSourceRoot: "src\\", mapSourceRoot: "src/" },
+])("Source map has correct source root (%p)", async ({ configSourceRoot, mapSourceRoot }) => {
     const file = util.testModule`
         const foo = "foo"
     `
+        .setOptions({ sourceMap: true, sourceRoot: configSourceRoot })
         .expectToHaveNoDiagnostics()
         .getMainLuaFileResult();
 
     const sourceMap = JSON.parse(file.sourceMap);
-    expect(sourceMap.sourceRoot).toBe(".");
+    expect(sourceMap.sourceRoot).toBe(mapSourceRoot);
 });
 
 test.each([

--- a/test/unit/printer/sourcemaps.spec.ts
+++ b/test/unit/printer/sourcemaps.spec.ts
@@ -164,8 +164,8 @@ test.each([
     {
         fileName: "/proj/src/foo.ts",
         config: { outDir: "/proj/dst" },
-        mapSource: "foo.ts",
-        fullSource: "foo.ts",
+        mapSource: "../src/foo.ts",
+        fullSource: "../src/foo.ts",
     },
     {
         fileName: "/proj/src/foo.ts",


### PR DESCRIPTION
- 'sources' now contain full relative paths to original ts file
- 'sourceRoot' is only set if specified explicitly from tsconfig.json

fixes #855