### PR TITLE
Feature/nullish coalescing

### DIFF
--- a/src/transformation/utils/diagnostics.ts
+++ b/src/transformation/utils/diagnostics.ts
@@ -97,8 +97,6 @@ export const unsupportedAccessorInObjectLiteral = createDiagnosticFactory(
     "Accessors in object literal are not supported."
 );
 
-export const unsupportedNullishCoalescing = createDiagnosticFactory("Nullish coalescing is not supported.");
-
 export const unsupportedRightShiftOperator = createDiagnosticFactory(
     "Right shift operator is not supported for target Lua 5.3. Use `>>>` instead."
 );

--- a/src/transformation/visitors/binary-expression/index.ts
+++ b/src/transformation/visitors/binary-expression/index.ts
@@ -2,11 +2,7 @@ import * as ts from "typescript";
 import * as lua from "../../../LuaAST";
 import { FunctionVisitor, TransformationContext } from "../../context";
 import { AnnotationKind, getTypeAnnotations } from "../../utils/annotations";
-import {
-    extensionInvalidInstanceOf,
-    luaTableInvalidInstanceOf,
-    unsupportedNullishCoalescing,
-} from "../../utils/diagnostics";
+import { extensionInvalidInstanceOf, luaTableInvalidInstanceOf } from "../../utils/diagnostics";
 import { createImmediatelyInvokedFunctionExpression, wrapInToStringForConcat } from "../../utils/lua-ast";
 import { LuaLibFeature, transformLuaLibFunction } from "../../utils/lualib";
 import { isStandardLibraryType, isStringType } from "../../utils/typescript";
@@ -137,13 +133,38 @@ export const transformBinaryExpression: FunctionVisitor<ts.BinaryExpression> = (
         }
 
         case ts.SyntaxKind.QuestionQuestionToken: {
-            context.diagnostics.push(unsupportedNullishCoalescing(node.operatorToken));
-            return lua.createBinaryExpression(
-                context.transformExpression(node.left),
-                context.transformExpression(node.right),
-                lua.SyntaxKind.OrOperator,
-                node
-            );
+            const lhsType = context.checker.getTypeAtLocation(node.left);
+            // Check if we can take a shortcut to 'lhs or rhs' if the left-hand side cannot be 'false'.
+            if (
+                lhsType.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown | ts.TypeFlags.Boolean) ||
+                node.left.kind === ts.SyntaxKind.FalseKeyword
+            ) {
+                const lhsIdentifier = lua.createIdentifier("lhs");
+                const nilComparison = lua.createBinaryExpression(
+                    lua.cloneIdentifier(lhsIdentifier),
+                    lua.createNilLiteral(),
+                    lua.SyntaxKind.EqualityOperator
+                );
+                // if ____ == nil then return rhs else return ____ end
+                const ifStatement = lua.createIfStatement(
+                    nilComparison,
+                    lua.createBlock([lua.createReturnStatement([context.transformExpression(node.right)])]),
+                    lua.createBlock([lua.createReturnStatement([lua.cloneIdentifier(lhsIdentifier)])])
+                );
+                // (function(lhs') if lhs' == nil then return rhs else return lhs' end)(lhs)
+                return lua.createCallExpression(
+                    lua.createFunctionExpression(lua.createBlock([ifStatement]), [lhsIdentifier]),
+                    [context.transformExpression(node.left)]
+                );
+            } else {
+                // lhs or rhs
+                return lua.createBinaryExpression(
+                    context.transformExpression(node.left),
+                    context.transformExpression(node.right),
+                    lua.SyntaxKind.OrOperator,
+                    node
+                );
+            }
         }
 
         default:

--- a/test/unit/nullishCoalescing.spec.ts
+++ b/test/unit/nullishCoalescing.spec.ts
@@ -1,11 +1,11 @@
 import * as util from "../util";
 
 test.each(["null", "undefined"])("nullish-coalesing operator returns rhs", nullishValue => {
-    util.testExpression`${nullishValue} ?? "Hello, World!"`.debug().expectToMatchJsResult();
+    util.testExpression`${nullishValue} ?? "Hello, World!"`.expectToMatchJsResult();
 });
 
 test.each([3, "foo", {}, [], true, false])("nullish-coalesing operator returns lhs", value => {
-    util.testExpression`${util.formatCode(value)} ?? "Hello, World!"`.debug().expectToMatchJsResult();
+    util.testExpression`${util.formatCode(value)} ?? "Hello, World!"`.expectToMatchJsResult();
 });
 
 test.each(["any", "unknown"])("nullish-coalesing operator with any/unknown type", type => {
@@ -21,8 +21,22 @@ test.each(["boolean | string", "number | false", "undefined | true"])(
         util.testFunction`
             const unknownType = false as ${unionType};
             return unknownType ?? "This should not be returned!";
-        `
-            .debug()
-            .expectToMatchJsResult();
+        `.expectToMatchJsResult();
     }
 );
+
+test("nullish-coalescing operator with side effect lhs", () => {
+    util.testFunction`
+        let i = 0;
+        const incI = () => ++i;
+        return [i, incI() ?? 3, i];
+    `.expectToMatchJsResult();
+});
+
+test("nullish-coalescing operator with side effect rhs", () => {
+    util.testFunction`
+        let i = 0;
+        const incI = () => ++i;
+        return [i, undefined ?? incI(), i];
+    `.expectToMatchJsResult();
+});

--- a/test/unit/nullishCoalescing.spec.ts
+++ b/test/unit/nullishCoalescing.spec.ts
@@ -1,0 +1,28 @@
+import * as util from "../util";
+
+test.each(["null", "undefined"])("nullish-coalesing operator returns rhs", nullishValue => {
+    util.testExpression`${nullishValue} ?? "Hello, World!"`.debug().expectToMatchJsResult();
+});
+
+test.each([3, "foo", {}, [], true, false])("nullish-coalesing operator returns lhs", value => {
+    util.testExpression`${util.formatCode(value)} ?? "Hello, World!"`.debug().expectToMatchJsResult();
+});
+
+test.each(["any", "unknown"])("nullish-coalesing operator with any/unknown type", type => {
+    util.testFunction`
+        const unknownType = false as ${type};
+        return unknownType ?? "This should not be returned!";
+    `.expectToMatchJsResult();
+});
+
+test.each(["boolean | string", "number | false", "undefined | true"])(
+    "nullish-coalesing operator with union type",
+    unionType => {
+        util.testFunction`
+            const unknownType = false as ${unionType};
+            return unknownType ?? "This should not be returned!";
+        `
+            .debug()
+            .expectToMatchJsResult();
+    }
+);


### PR DESCRIPTION
Added support for nullish coalescing. We consider two cases:

lhs can be false (according to its type), or we are not sure:
```lua
-- lhs ?? rhs -->
    (function(____lhs) if ____lhs == nil then return rhs else return ____lhs end end)(lhs)
```

lhs cannot be false (according to its type):
```lua
-- lhs ?? rhs --> 
    lhs or rhs
```