### PR TITLE
added top level export parseConfigFileWithSystem

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export { version } from "./cli/information";
 export { parseCommandLine, ParsedCommandLine, updateParsedConfigFile } from "./cli/parse";
 export * from "./cli/report";
+export { parseConfigFileWithSystem } from "./cli/tsconfig";
 export * from "./CompilerOptions";
 export * from "./LuaAST";
 export { LuaLibFeature } from "./LuaLib";


### PR DESCRIPTION
`parseConfigFileWithSystem` is used in the low-level api docs example: https://typescripttolua.github.io/docs/api/overview#transpile

It looks like this export was removed during a recent refactor. If there is a different approach to this functionality, I could alternatively update the docs.