### PR TITLE
Enabled @tupleReturn on array-like types

### DIFF
--- a/src/transformation/utils/annotations.ts
+++ b/src/transformation/utils/annotations.ts
@@ -118,6 +118,10 @@ export function isTupleReturnCall(context: TransformationContext, node: ts.Node)
             return true;
         }
 
+        if (isTupleReturnType(signature.getReturnType()) && !isLuaIteratorType(context, node)) {
+            return true;
+        }
+
         // Only check function type for directive if it is declared as an interface or type alias
         const declaration = signature.getDeclaration();
         const isInterfaceOrAlias =
@@ -162,6 +166,10 @@ export function isInTupleReturnFunction(context: TransformationContext, node: ts
     }
 
     return getTypeAnnotations(functionType).has(AnnotationKind.TupleReturn);
+}
+
+export function isTupleReturnType(type: ts.Type): boolean {
+    return getTypeAnnotations(type).has(AnnotationKind.TupleReturn);
 }
 
 export function isLuaIteratorType(context: TransformationContext, node: ts.Node): boolean {

--- a/src/transformation/visitors/call.ts
+++ b/src/transformation/visitors/call.ts
@@ -2,7 +2,7 @@ import * as ts from "typescript";
 import * as lua from "../../LuaAST";
 import { transformBuiltinCallExpression } from "../builtins";
 import { FunctionVisitor, TransformationContext } from "../context";
-import { isInTupleReturnFunction, isTupleReturnCall, isVarargType } from "../utils/annotations";
+import { isInTupleReturnFunction, isTupleReturnCall, isVarargType, isTupleReturnType } from "../utils/annotations";
 import { validateAssignment } from "../utils/assignment-validation";
 import { ContextType, getDeclarationContextType } from "../utils/function-context";
 import { createImmediatelyInvokedFunctionExpression, createUnpackCall, wrapInTable } from "../utils/lua-ast";
@@ -196,7 +196,9 @@ export const transformCallExpression: FunctionVisitor<ts.CallExpression> = (node
 
     const isTupleReturn = isTupleReturnCall(context, node);
     const isTupleReturnForward =
-        node.parent && ts.isReturnStatement(node.parent) && isInTupleReturnFunction(context, node);
+        node.parent &&
+        ts.isReturnStatement(node.parent) &&
+        (isInTupleReturnFunction(context, node) || isTupleReturnType(context.checker.getTypeAtLocation(node)));
     const isInSpread = node.parent && ts.isSpreadElement(node.parent);
     const returnValueIsUsed = node.parent && !ts.isExpressionStatement(node.parent);
     const wrapResult =


### PR DESCRIPTION
This PR enables use of the `@tupleReturn` annotation on array-like types, so that functions which return a type with the annotation will be treated as if the function was annotated as such. This is basically a step towards implementing #580, and helps situations like #811.

Incidentally, this also fixes #893, as that was a general problem with casting, which I needed to work for some of the tests.

Examples:
```ts
/** @tupleReturn */
type TupleReturn<A extends unknown[]> = A & { __tupleReturn?: never };
```
*Basic Usage*
```ts
function returnTuple(): TupleReturn<string[]> {
    return ["a", "b", "c"];
}
```
*Inferred Return Type*
```ts
function returnTuple() {
    return ["a", "b", "c"] as TupleReturn<string[]>;
}
```
*Automatic Forwarding*
```ts
function forwardTuple() {
    return returnTuple();
}
const [a, b, c] = forwardTuple(); // No wrapping or unpacking
```
*Function Expression Inference*
```ts
declare function takesTupleReturnFn(cb: () => TupleReturn<string[]>): void;
takesTupleReturnFn(() => ["a", "b", "c"]); // Arrow function will be transpiled as a tupleReturn function
```
*Overloading*
```ts
declare function returnsArray(): string[];
declare function returnsTuple(): TupleReturn<string[]>;

declare function overloaded<R extends TupleReturn<unknown[]>>(cb: () => R): R;
declare function overloaded<R>(cb: () => R): R;

const [a, b, c] = overloaded(returnsArray); // a, b, c = unpack(overloaded(returnsArray))
const [d, e, f] = overloaded(returnsTuple); // d, e, f = overloaded(returnsTuple)
```
This last example is not currently possible with the function annotation version. It will be useful for typing functions such as `pcall` which take arbitrary functions call them, and return their result.
