### PR TITLE
Remove class field/accessor compatibility code

### DIFF
--- a/src/transformation/visitors/class/index.ts
+++ b/src/transformation/visitors/class/index.ts
@@ -29,7 +29,7 @@ import { isAmbientNode } from "../../utils/typescript";
 import { transformIdentifier } from "../identifier";
 import { transformPropertyName } from "../literal";
 import { createDecoratingExpression, transformDecoratorExpression } from "./decorators";
-import { isGetAccessorOverride, transformAccessorDeclarations } from "./members/accessors";
+import { transformAccessorDeclarations } from "./members/accessors";
 import { createConstructorName, transformConstructorDeclaration } from "./members/constructor";
 import {
     createPropertyDecoratingExpression,
@@ -238,15 +238,12 @@ function transformClassLikeDeclaration(
             );
 
             if (constructorResult) result.push(constructorResult);
-        } else if (
-            instanceFields.length > 0 ||
-            classDeclaration.members.some(m => isGetAccessorOverride(context, m, classDeclaration))
-        ) {
+        } else if (instanceFields.length > 0) {
             // Generate a constructor if none was defined in a class with instance fields that need initialization
             // localClassName.prototype.____constructor = function(self, ...)
             //     baseClassName.prototype.____constructor(self, ...)
             //     ...
-            const constructorBody = transformClassInstanceFields(context, classDeclaration, instanceFields);
+            const constructorBody = transformClassInstanceFields(context, instanceFields);
             const superCall = lua.createExpressionStatement(
                 lua.createCallExpression(
                     lua.createTableIndexExpression(

--- a/src/transformation/visitors/class/members/accessors.ts
+++ b/src/transformation/visitors/class/members/accessors.ts
@@ -2,10 +2,10 @@ import * as ts from "typescript";
 import * as lua from "../../../../LuaAST";
 import { AllAccessorDeclarations, TransformationContext } from "../../../context";
 import { createSelfIdentifier } from "../../../utils/lua-ast";
-import { transformLuaLibFunction, LuaLibFeature } from "../../../utils/lualib";
+import { LuaLibFeature, transformLuaLibFunction } from "../../../utils/lualib";
 import { transformFunctionBody, transformParameters } from "../../function";
 import { transformPropertyName } from "../../literal";
-import { getExtendedType, isStaticNode } from "../utils";
+import { isStaticNode } from "../utils";
 import { createPrototypeName } from "./constructor";
 
 function transformAccessor(context: TransformationContext, node: ts.AccessorDeclaration): lua.FunctionExpression {
@@ -39,69 +39,4 @@ export function transformAccessorDeclarations(
     if (!isStatic) parameters.push(lua.createBooleanLiteral(true));
     const call = transformLuaLibFunction(context, feature, undefined, ...parameters);
     return lua.createExpressionStatement(call);
-}
-
-function* classWithAncestors(
-    context: TransformationContext,
-    classDeclaration: ts.ClassLikeDeclarationBase
-): Generator<ts.ClassLikeDeclarationBase> {
-    yield classDeclaration;
-
-    const extendsType = getExtendedType(context, classDeclaration);
-    if (!extendsType) {
-        return false;
-    }
-
-    const symbol = extendsType.getSymbol();
-    if (symbol === undefined) {
-        return false;
-    }
-
-    const symbolDeclarations = symbol.getDeclarations();
-    if (symbolDeclarations === undefined) {
-        return false;
-    }
-
-    const declaration = symbolDeclarations.find(ts.isClassLike);
-    if (!declaration) {
-        return false;
-    }
-
-    yield* classWithAncestors(context, declaration);
-}
-
-export const hasMemberInClassOrAncestor = (
-    context: TransformationContext,
-    classDeclaration: ts.ClassLikeDeclarationBase,
-    callback: (m: ts.ClassElement) => boolean
-) => [...classWithAncestors(context, classDeclaration)].some(c => c.members.some(callback));
-
-function getPropertyName(propertyName: ts.PropertyName): string | number | undefined {
-    if (ts.isIdentifier(propertyName) || ts.isStringLiteral(propertyName) || ts.isNumericLiteral(propertyName)) {
-        return propertyName.text;
-    } else {
-        return undefined; // TODO: how to handle computed property names?
-    }
-}
-
-function isSamePropertyName(a: ts.PropertyName, b: ts.PropertyName): boolean {
-    const aName = getPropertyName(a);
-    const bName = getPropertyName(b);
-    return aName !== undefined && aName === bName;
-}
-
-export function isGetAccessorOverride(
-    context: TransformationContext,
-    element: ts.ClassElement,
-    classDeclaration: ts.ClassLikeDeclarationBase
-): element is ts.GetAccessorDeclaration {
-    if (!ts.isGetAccessor(element) || isStaticNode(element)) {
-        return false;
-    }
-
-    return hasMemberInClassOrAncestor(
-        context,
-        classDeclaration,
-        m => ts.isPropertyDeclaration(m) && m.initializer !== undefined && isSamePropertyName(m.name, element.name)
-    );
 }

--- a/src/transformation/visitors/class/members/constructor.ts
+++ b/src/transformation/visitors/class/members/constructor.ts
@@ -3,7 +3,7 @@ import * as lua from "../../../../LuaAST";
 import { TransformationContext } from "../../../context";
 import { createSelfIdentifier } from "../../../utils/lua-ast";
 import { popScope, pushScope, ScopeType } from "../../../utils/scope";
-import { transformFunctionBodyHeader, transformFunctionBodyContent, transformParameters } from "../../function";
+import { transformFunctionBodyContent, transformFunctionBodyHeader, transformParameters } from "../../function";
 import { transformIdentifier } from "../../identifier";
 import { transformClassInstanceFields } from "./fields";
 
@@ -43,7 +43,7 @@ export function transformConstructorDeclaration(
     // Check for field declarations in constructor
     const constructorFieldsDeclarations = statement.parameters.filter(p => p.modifiers !== undefined);
 
-    const classInstanceFields = transformClassInstanceFields(context, classDeclaration, instanceFields);
+    const classInstanceFields = transformClassInstanceFields(context, instanceFields);
 
     // If there are field initializers and the first statement is a super call,
     // move super call between default assignments and initializers


### PR DESCRIPTION
Since https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-0.html#properties-overriding-accessors-and-vice-versa-is-an-error we don't need to support it anymore. Tests were removed in #914. Reverts [`3b81007` (#774)](https://github.com/TypeScriptToLua/TypeScriptToLua/pull/774/commits/3b81007525945c1bd2abb0966230954142462e55). Closes #576.