### PR TITLE
Add test for argument passing in plugin config

### DIFF
--- a/src/CompilerOptions.ts
+++ b/src/CompilerOptions.ts
@@ -21,6 +21,7 @@ export interface TransformerImport {
 export interface LuaPluginImport {
     name: string;
     import?: string;
+    [option: string]: any;
 }
 
 export type CompilerOptions = OmitIndexSignature<ts.CompilerOptions> & {

--- a/test/transpile/plugins/arguments.ts
+++ b/test/transpile/plugins/arguments.ts
@@ -1,0 +1,28 @@
+import * as ts from "typescript";
+import * as tstl from "../../../src";
+
+interface Options {
+    name: string;
+    option: boolean;
+}
+
+// eslint-disable-next-line import/no-default-export
+export default function plugin(options: Options): tstl.Plugin {
+    return {
+        visitors: {
+            [ts.SyntaxKind.ReturnStatement]: () =>
+                tstl.createReturnStatement([
+                    tstl.createTableExpression([
+                        tstl.createTableFieldExpression(
+                            tstl.createStringLiteral(options.name),
+                            tstl.createStringLiteral("name")
+                        ),
+                        tstl.createTableFieldExpression(
+                            tstl.createBooleanLiteral(options.option),
+                            tstl.createStringLiteral("option")
+                        ),
+                    ]),
+                ]),
+        },
+    };
+}

--- a/test/transpile/plugins/plugins.spec.ts
+++ b/test/transpile/plugins/plugins.spec.ts
@@ -22,3 +22,11 @@ test("visitor using super", () => {
         .setOptions({ luaPlugins: [{ name: path.join(__dirname, "visitor-super.ts") }] })
         .expectToEqual("bar");
 });
+
+test("passing arguments", () => {
+    util.testFunction`
+        return {};
+    `
+        .setOptions({ luaPlugins: [{ name: path.join(__dirname, "arguments.ts"), option: true }] })
+        .expectToEqual({ name: path.join(__dirname, "arguments.ts"), option: true });
+});


### PR DESCRIPTION
Allow for optional arguments in LuaPluginImport, as the tsconfig file already allows for this.
Test for presence of all arguments passed into plugin factory function