### PR TITLE
Add @luaName annotation

### DIFF
--- a/src/transformation/utils/annotations.ts
+++ b/src/transformation/utils/annotations.ts
@@ -6,6 +6,7 @@ export enum AnnotationKind {
     Extension = "extension",
     MetaExtension = "metaExtension",
     CustomConstructor = "customConstructor",
+    LuaName = "luaName",
     CompileMembersOnly = "compileMembersOnly",
     NoResolution = "noResolution",
     PureAbstract = "pureAbstract",

--- a/src/transformation/visitors/call.ts
+++ b/src/transformation/visitors/call.ts
@@ -2,8 +2,9 @@ import * as ts from "typescript";
 import * as lua from "../../LuaAST";
 import { transformBuiltinCallExpression } from "../builtins";
 import { FunctionVisitor, TransformationContext } from "../context";
-import { isInTupleReturnFunction, isTupleReturnCall, isVarargType } from "../utils/annotations";
+import { AnnotationKind, getTypeAnnotations, isInTupleReturnFunction, isTupleReturnCall, isVarargType } from "../utils/annotations";
 import { validateAssignment } from "../utils/assignment-validation";
+import { annotationInvalidArgumentCount } from "../utils/diagnostics";
 import { ContextType, getDeclarationContextType } from "../utils/function-context";
 import { createImmediatelyInvokedFunctionExpression, createUnpackCall, wrapInTable } from "../utils/lua-ast";
 import { LuaLibFeature, transformLuaLibFunction } from "../utils/lualib";
@@ -114,9 +115,30 @@ export function transformContextualCallExpression(
         // table:name()
         const table = context.transformExpression(left.expression);
 
+        let luaName = left.name.text;
+
+        const type = context.checker.getTypeAtLocation(left);
+        const annotations = getTypeAnnotations(type);
+        const luaNameAnnotation = annotations.get(AnnotationKind.LuaName);
+
+        if (luaNameAnnotation) {
+            if (luaNameAnnotation.args.length == 1) {
+                luaName = luaNameAnnotation.args[0]
+            } else {
+                context.diagnostics.push(
+                    annotationInvalidArgumentCount(
+                        left,
+                        AnnotationKind.LuaName,
+                        luaNameAnnotation.args.length,
+                        1
+                    )
+                );
+            }
+        }
+
         return lua.createMethodCallExpression(
             table,
-            lua.createIdentifier(left.name.text, left.name),
+            lua.createIdentifier(luaName, left.name),
             transformedArguments,
             node
         );

--- a/src/transformation/visitors/call.ts
+++ b/src/transformation/visitors/call.ts
@@ -123,7 +123,7 @@ export function transformContextualCallExpression(
 
         if (luaNameAnnotation) {
             if (luaNameAnnotation.args.length === 1) {
-                luaName = luaNameAnnotation.args[0]
+                luaName = luaNameAnnotation.args[0];
             } else {
                 context.diagnostics.push(
                     annotationInvalidArgumentCount(

--- a/src/transformation/visitors/call.ts
+++ b/src/transformation/visitors/call.ts
@@ -122,7 +122,7 @@ export function transformContextualCallExpression(
         const luaNameAnnotation = annotations.get(AnnotationKind.LuaName);
 
         if (luaNameAnnotation) {
-            if (luaNameAnnotation.args.length == 1) {
+            if (luaNameAnnotation.args.length === 1) {
                 luaName = luaNameAnnotation.args[0]
             } else {
                 context.diagnostics.push(

--- a/src/transformation/visitors/identifier.ts
+++ b/src/transformation/visitors/identifier.ts
@@ -31,10 +31,11 @@ export const transformIdentifierExpression: FunctionVisitor<ts.Identifier> = (no
     if (symbol) {
         const exportScope = getSymbolExportScope(context, symbol);
         if (exportScope) {
-            const name = symbol.name;
-            const text = hasUnsafeIdentifierName(context, node) ? createSafeName(name) : name;
+            const originalName = symbol.name;
+            const luaName = getLuaName(context, node);
+            const text = hasUnsafeIdentifierName(context, node, true, luaName) ? createSafeName(luaName) : luaName;
             const symbolId = getIdentifierSymbolId(context, node);
-            const identifier = lua.createIdentifier(text, node, symbolId, name);
+            const identifier = lua.createIdentifier(text, node, symbolId, originalName);
             return createExportedIdentifier(context, identifier, exportScope);
         }
     }

--- a/src/transformation/visitors/identifier.ts
+++ b/src/transformation/visitors/identifier.ts
@@ -2,7 +2,7 @@ import * as ts from "typescript";
 import * as lua from "../../LuaAST";
 import { transformBuiltinIdentifierExpression } from "../builtins";
 import { FunctionVisitor, TransformationContext } from "../context";
-import { isForRangeType } from "../utils/annotations";
+import { getLuaName, isForRangeType } from "../utils/annotations";
 import { invalidForRangeCall } from "../utils/diagnostics";
 import { createExportedIdentifier, getSymbolExportScope } from "../utils/export";
 import { createSafeName, hasUnsafeIdentifierName } from "../utils/safe-names";
@@ -19,7 +19,8 @@ export function transformIdentifier(context: TransformationContext, identifier: 
         }
     }
 
-    const text = hasUnsafeIdentifierName(context, identifier) ? createSafeName(identifier.text) : identifier.text;
+    const luaName = getLuaName(context, identifier);
+    const text = hasUnsafeIdentifierName(context, identifier, true, luaName) ? createSafeName(luaName) : luaName;
 
     const symbolId = getIdentifierSymbolId(context, identifier);
     return lua.createIdentifier(text, identifier, symbolId, identifier.text);

--- a/test/unit/annotations/luaName.spec.ts
+++ b/test/unit/annotations/luaName.spec.ts
@@ -65,7 +65,7 @@ test("LuaName.Variable", () => {
 
     const tsHeader = `
         /** @luaName foo */
-        declare const bar;
+        declare const bar: string;
     `;
 
     const result = util.transpileAndExecute("return bar;", undefined, luaHeader, tsHeader);

--- a/test/unit/annotations/luaName.spec.ts
+++ b/test/unit/annotations/luaName.spec.ts
@@ -1,0 +1,102 @@
+import { annotationInvalidArgumentCount } from "../../../src/transformation/utils/diagnostics";
+import * as util from "../../util";
+
+test("LuaName.FunctionCall", () => {
+    const luaHeader = `
+        function bar(str)
+            return str
+        end
+    `;
+
+    const tsHeader = `
+        /** @luaName bar */
+        declare function foo(str: string): string
+    `;
+
+    const result = util.transpileAndExecute("return foo('hi');", undefined, luaHeader, tsHeader);
+
+    expect(result).toBe("hi");
+});
+
+test("LuaName.MethodCall", () => {
+    const luaHeader = `
+        local foo = {}
+        function foo:baz(str)
+            return str
+        end
+    `;
+
+    const tsHeader = `
+        declare namespace foo {
+            /** @luaName baz */
+            function bar(str: string): string
+        }
+    `;
+
+    const result = util.transpileAndExecute("return foo.bar('hi');", undefined, luaHeader, tsHeader);
+
+    expect(result).toBe("hi");
+});
+
+test("LuaName.Namespace", () => {
+    const luaHeader = `
+        local foo = {}
+        function foo:baz(str)
+            return str
+        end
+    `;
+
+    const tsHeader = `
+        /** @luaName foo */
+        declare namespace bar {
+            function baz(str: string): string
+        }
+    `;
+
+    const result = util.transpileAndExecute("return bar.baz('hi');", undefined, luaHeader, tsHeader);
+
+    expect(result).toBe("hi");
+});
+
+test("LuaName.Variable", () => {
+    const luaHeader = `
+        local foo = 'hi'
+    `;
+
+    const tsHeader = `
+        /** @luaName foo */
+        declare const bar;
+    `;
+
+    const result = util.transpileAndExecute("return bar;", undefined, luaHeader, tsHeader);
+
+    expect(result).toBe("hi");
+});
+
+test("LuaName.Field", () => {
+    const luaHeader = `
+        local foo = {
+            baz = 'hi'
+        }
+    `;
+
+    const tsHeader = `
+        declare const foo = {
+            /** @luaName baz */
+            bar: string
+        }
+    `;
+
+    const result = util.transpileAndExecute("return foo.bar;", undefined, luaHeader, tsHeader);
+
+    expect(result).toBe("hi");
+});
+
+test("IncorrectUsage", () => {
+    util.testFunction`
+        /** @luaName */
+        declare function foo(str: string): string
+
+        foo('hi');
+    `.expectDiagnosticsToMatchSnapshot([annotationInvalidArgumentCount.code]);
+});

--- a/test/unit/annotations/luaName.spec.ts
+++ b/test/unit/annotations/luaName.spec.ts
@@ -9,7 +9,7 @@ test("LuaName.FunctionCall", () => {
     `;
 
     const tsHeader = `
-        /** @luaName bar */
+        /** @noSelf @luaName bar */
         declare function foo(str: string): string
     `;
 


### PR DESCRIPTION
This will allow you to apply an `@luaName` annotation to things such as functions, methods, fields, namespaces, and so on, to change the transpiled name.

Example:

Lua:
```lua
local foo = {}
function foo:baz(str)
    return str
end
```

TS:
```ts
/** @luaName foo */
declare namespace bar {
    function baz(str: string): string
}

return bar.baz('hi'); // actually calls foo:baz
```

Fixes #945