### PR TITLE
Omit tostring from template literal spans if they are strings

### DIFF
--- a/src/transformation/visitors/template.ts
+++ b/src/transformation/visitors/template.ts
@@ -3,6 +3,7 @@ import * as lua from "../../LuaAST";
 import { FunctionVisitor } from "../context";
 import { ContextType, getDeclarationContextType } from "../utils/function-context";
 import { wrapInToStringForConcat } from "../utils/lua-ast";
+import { isStringType } from "../utils/typescript/types";
 import { transformArguments, transformContextualCallExpression } from "./call";
 
 // TODO: Source positions
@@ -25,7 +26,12 @@ export const transformTemplateExpression: FunctionVisitor<ts.TemplateExpression>
 
     for (const span of node.templateSpans) {
         const expression = context.transformExpression(span.expression);
-        parts.push(wrapInToStringForConcat(expression));
+        const spanType = context.checker.getTypeAtLocation(span.expression);
+        if (isStringType(context, spanType)) {
+            parts.push(expression);
+        } else {
+            parts.push(wrapInToStringForConcat(expression));
+        }
 
         const text = span.literal.text;
         if (text.length > 0) {

--- a/test/unit/templateLiterals.spec.ts
+++ b/test/unit/templateLiterals.spec.ts
@@ -60,3 +60,19 @@ test.each(["func`noSelfParameter`", "obj.func`noSelfParameter`", "obj[`func`]`no
         `.expectToMatchJsResult();
     }
 );
+
+test.each([
+    ["'any string'", "string"],
+    ["'string type'", "'string literal type'"],
+    ["'string intersection'", "string & { x: number }"],
+])("tagged template literal omit tostring for string types (%p)", (input, type) => {
+    util.testFunction`
+        function func(msg: ${type}) {
+            return \`func \${msg}\`;
+        }
+
+        return func(${input} as ${type});
+    `
+        .tap(builder => expect(builder.getMainLuaCodeChunk()).not.toContain("tostring"))
+        .expectToMatchJsResult();
+});


### PR DESCRIPTION
Closes #940

Seems like a straight forward fix

Using the existing `isStringType` to determine if the type is a string