### PR TITLE
Deprecate phantom, metaExtension, extension, pureAbstract

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "typescript-to-lua",
-            "version": "0.36.0",
+            "version": "0.36.1",
             "license": "MIT",
             "dependencies": {
                 "resolve": "^1.15.1",

--- a/src/transformation/utils/diagnostics.ts
+++ b/src/transformation/utils/diagnostics.ts
@@ -3,21 +3,32 @@ import { LuaTarget } from "../../CompilerOptions";
 import { createSerialDiagnosticFactory } from "../../utils";
 import { AnnotationKind } from "./annotations";
 
-const createDiagnosticFactory = <TArgs extends any[]>(message: string | ((...args: TArgs) => string)) =>
+type MessageProvider<TArgs extends any[]> = string | ((...args: TArgs) => string);
+
+const createDiagnosticFactory = <TArgs extends any[]>(
+    category: ts.DiagnosticCategory,
+    message: MessageProvider<TArgs>
+) =>
     createSerialDiagnosticFactory((node: ts.Node, ...args: TArgs) => ({
         file: node.getSourceFile(),
         start: node.getStart(),
         length: node.getWidth(),
         messageText: typeof message === "string" ? message : message(...args),
+        category,
     }));
 
-export const unsupportedNodeKind = createDiagnosticFactory(
+const createErrorDiagnosticFactory = <TArgs extends any[]>(message: MessageProvider<TArgs>) =>
+    createDiagnosticFactory(ts.DiagnosticCategory.Error, message);
+const createWarningDiagnosticFactory = <TArgs extends any[]>(message: MessageProvider<TArgs>) =>
+    createDiagnosticFactory(ts.DiagnosticCategory.Warning, message);
+
+export const unsupportedNodeKind = createErrorDiagnosticFactory(
     (kind: ts.SyntaxKind) => `Unsupported node kind ${ts.SyntaxKind[kind]}`
 );
 
-export const forbiddenForIn = createDiagnosticFactory("Iterating over arrays with 'for ... in' is not allowed.");
+export const forbiddenForIn = createErrorDiagnosticFactory("Iterating over arrays with 'for ... in' is not allowed.");
 
-export const unsupportedNoSelfFunctionConversion = createDiagnosticFactory((name?: string) => {
+export const unsupportedNoSelfFunctionConversion = createErrorDiagnosticFactory((name?: string) => {
     const nameReference = name ? ` '${name}'` : "";
     return (
         `Unable to convert function with a 'this' parameter to function${nameReference} with no 'this'. ` +
@@ -25,7 +36,7 @@ export const unsupportedNoSelfFunctionConversion = createDiagnosticFactory((name
     );
 });
 
-export const unsupportedSelfFunctionConversion = createDiagnosticFactory((name?: string) => {
+export const unsupportedSelfFunctionConversion = createErrorDiagnosticFactory((name?: string) => {
     const nameReference = name ? ` '${name}'` : "";
     return (
         `Unable to convert function with no 'this' parameter to function${nameReference} with 'this'. ` +
@@ -33,7 +44,7 @@ export const unsupportedSelfFunctionConversion = createDiagnosticFactory((name?:
     );
 });
 
-export const unsupportedOverloadAssignment = createDiagnosticFactory((name?: string) => {
+export const unsupportedOverloadAssignment = createErrorDiagnosticFactory((name?: string) => {
     const nameReference = name ? ` to '${name}'` : "";
     return (
         `Unsupported assignment of function with different overloaded types for 'this'${nameReference}. ` +
@@ -41,88 +52,97 @@ export const unsupportedOverloadAssignment = createDiagnosticFactory((name?: str
     );
 });
 
-export const decoratorInvalidContext = createDiagnosticFactory("Decorator function cannot have 'this: void'.");
+export const decoratorInvalidContext = createErrorDiagnosticFactory("Decorator function cannot have 'this: void'.");
 
-export const annotationInvalidArgumentCount = createDiagnosticFactory(
+export const annotationInvalidArgumentCount = createErrorDiagnosticFactory(
     (kind: AnnotationKind, got: number, expected: number) => `'@${kind}' expects ${expected} arguments, but got ${got}.`
 );
 
-export const extensionCannotConstruct = createDiagnosticFactory(
+export const extensionCannotConstruct = createErrorDiagnosticFactory(
     "Cannot construct classes with '@extension' or '@metaExtension' annotation."
 );
 
-export const extensionCannotExtend = createDiagnosticFactory(
+export const extensionCannotExtend = createErrorDiagnosticFactory(
     "Cannot extend classes with '@extension' or '@metaExtension' annotation."
 );
 
-export const extensionCannotExport = createDiagnosticFactory(
+export const extensionCannotExport = createErrorDiagnosticFactory(
     "Cannot export classes with '@extension' or '@metaExtension' annotation."
 );
 
-export const extensionInvalidInstanceOf = createDiagnosticFactory(
+export const extensionInvalidInstanceOf = createErrorDiagnosticFactory(
     "Cannot use instanceof on classes with '@extension' or '@metaExtension' annotation."
 );
 
-export const extensionAndMetaExtensionConflict = createDiagnosticFactory(
+export const extensionAndMetaExtensionConflict = createErrorDiagnosticFactory(
     "Cannot use both '@extension' and '@metaExtension' annotations on the same class."
 );
 
-export const metaExtensionMissingExtends = createDiagnosticFactory(
+export const metaExtensionMissingExtends = createErrorDiagnosticFactory(
     "'@metaExtension' annotation requires the extension of the metatable class."
 );
 
-export const invalidForRangeCall = createDiagnosticFactory((message: string) => `Invalid @forRange call: ${message}.`);
+export const invalidForRangeCall = createErrorDiagnosticFactory(
+    (message: string) => `Invalid @forRange call: ${message}.`
+);
 
-export const luaTableMustBeAmbient = createDiagnosticFactory(
+export const luaTableMustBeAmbient = createErrorDiagnosticFactory(
     "Classes with the '@luaTable' annotation must be ambient."
 );
 
-export const luaTableCannotBeExtended = createDiagnosticFactory(
+export const luaTableCannotBeExtended = createErrorDiagnosticFactory(
     "Cannot extend classes with the '@luaTable' annotation."
 );
 
-export const luaTableInvalidInstanceOf = createDiagnosticFactory(
+export const luaTableInvalidInstanceOf = createErrorDiagnosticFactory(
     "The instanceof operator cannot be used with a '@luaTable' class."
 );
 
-export const luaTableCannotBeAccessedDynamically = createDiagnosticFactory("@luaTable cannot be accessed dynamically.");
+export const luaTableCannotBeAccessedDynamically = createErrorDiagnosticFactory(
+    "@luaTable cannot be accessed dynamically."
+);
 
-export const luaTableForbiddenUsage = createDiagnosticFactory(
+export const luaTableForbiddenUsage = createErrorDiagnosticFactory(
     (description: string) => `Invalid @luaTable usage: ${description}.`
 );
 
-export const luaIteratorForbiddenUsage = createDiagnosticFactory(
+export const luaIteratorForbiddenUsage = createErrorDiagnosticFactory(
     "Unsupported use of lua iterator with '@tupleReturn' annotation in for...of statement. " +
         "You must use a destructuring statement to catch results from a lua iterator with " +
         "the '@tupleReturn' annotation."
 );
 
-export const unsupportedAccessorInObjectLiteral = createDiagnosticFactory(
+export const unsupportedAccessorInObjectLiteral = createErrorDiagnosticFactory(
     "Accessors in object literal are not supported."
 );
 
-export const unsupportedRightShiftOperator = createDiagnosticFactory(
+export const unsupportedRightShiftOperator = createErrorDiagnosticFactory(
     "Right shift operator is not supported for target Lua 5.3. Use `>>>` instead."
 );
 
 const getLuaTargetName = (version: LuaTarget) => (version === LuaTarget.LuaJIT ? "LuaJIT" : `Lua ${version}`);
-export const unsupportedForTarget = createDiagnosticFactory(
+export const unsupportedForTarget = createErrorDiagnosticFactory(
     (functionality: string, version: Exclude<LuaTarget, LuaTarget.Universal>) =>
         `${functionality} is/are not supported for target ${getLuaTargetName(version)}.`
 );
 
-export const unsupportedProperty = createDiagnosticFactory(
+export const unsupportedProperty = createErrorDiagnosticFactory(
     (parentName: string, property: string) => `${parentName}.${property} is unsupported.`
 );
 
-export const invalidAmbientIdentifierName = createDiagnosticFactory(
+export const invalidAmbientIdentifierName = createErrorDiagnosticFactory(
     (text: string) => `Invalid ambient identifier name '${text}'. Ambient identifiers must be valid lua identifiers.`
 );
 
-export const unresolvableRequirePath = createDiagnosticFactory(
+export const unresolvableRequirePath = createErrorDiagnosticFactory(
     (path: string) => `Cannot create require path. Module '${path}' does not exist within --rootDir.`
 );
 
-export const unsupportedVarDeclaration = createDiagnosticFactory(
+export const unsupportedVarDeclaration = createErrorDiagnosticFactory(
     "`var` declarations are not supported. Use `let` or `const` instead."
+);
+
+export const annotationDeprecated = createWarningDiagnosticFactory(
+    (kind: AnnotationKind) =>
+        `'@${kind}' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile.`
 );

--- a/src/transformation/utils/diagnostics.ts
+++ b/src/transformation/utils/diagnostics.ts
@@ -145,5 +145,5 @@ export const unsupportedVarDeclaration = createErrorDiagnosticFactory(
 export const annotationDeprecated = createWarningDiagnosticFactory(
     (kind: AnnotationKind) =>
         `'@${kind}' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. ` +
-        `See https://typescripttolua.github.io/docs/advanced/compiler-annotations#${kind} for more information.`
+        `See https://typescripttolua.github.io/docs/advanced/compiler-annotations#${kind.toLowerCase()} for more information.`
 );

--- a/src/transformation/utils/diagnostics.ts
+++ b/src/transformation/utils/diagnostics.ts
@@ -144,5 +144,6 @@ export const unsupportedVarDeclaration = createErrorDiagnosticFactory(
 
 export const annotationDeprecated = createWarningDiagnosticFactory(
     (kind: AnnotationKind) =>
-        `'@${kind}' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile.`
+        `'@${kind}' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. ` +
+        `See https://typescripttolua.github.io/docs/advanced/compiler-annotations#${kind} for more information.`
 );

--- a/src/transformation/visitors/class/index.ts
+++ b/src/transformation/visitors/class/index.ts
@@ -4,6 +4,7 @@ import { getOrUpdate } from "../../../utils";
 import { FunctionVisitor, TransformationContext } from "../../context";
 import { AnnotationKind, getTypeAnnotations } from "../../utils/annotations";
 import {
+    annotationDeprecated,
     extensionAndMetaExtensionConflict,
     extensionCannotExport,
     extensionCannotExtend,
@@ -93,6 +94,13 @@ function transformClassLikeDeclaration(
     const extensionDirective = annotations.get(AnnotationKind.Extension);
     const isExtension = extensionDirective !== undefined;
     const isMetaExtension = annotations.has(AnnotationKind.MetaExtension);
+
+    if (isExtension) {
+        context.diagnostics.push(annotationDeprecated(classDeclaration, AnnotationKind.Extension));
+    }
+    if (isMetaExtension) {
+        context.diagnostics.push(annotationDeprecated(classDeclaration, AnnotationKind.MetaExtension));
+    }
 
     if (isExtension && isMetaExtension) {
         context.diagnostics.push(extensionAndMetaExtensionConflict(classDeclaration));

--- a/src/transformation/visitors/class/utils.ts
+++ b/src/transformation/visitors/class/utils.ts
@@ -1,6 +1,7 @@
 import * as ts from "typescript";
 import { TransformationContext } from "../../context";
 import { AnnotationKind, getTypeAnnotations } from "../../utils/annotations";
+import { annotationDeprecated } from "../../utils/diagnostics";
 
 export function isStaticNode(node: ts.Node): boolean {
     return (node.modifiers ?? []).some(m => m.kind === ts.SyntaxKind.StaticKeyword);
@@ -21,6 +22,10 @@ export function getExtendedNode(
     const annotations = getTypeAnnotations(superType);
     if (!annotations.has(AnnotationKind.PureAbstract)) {
         return extendsClause.types[0];
+    }
+
+    if (annotations.has(AnnotationKind.PureAbstract)) {
+        context.diagnostics.push(annotationDeprecated(extendsClause, AnnotationKind.PureAbstract));
     }
 }
 

--- a/src/transformation/visitors/namespace.ts
+++ b/src/transformation/visitors/namespace.ts
@@ -2,6 +2,7 @@ import * as ts from "typescript";
 import * as lua from "../../LuaAST";
 import { FunctionVisitor, TransformationContext } from "../context";
 import { AnnotationKind, getTypeAnnotations } from "../utils/annotations";
+import { annotationDeprecated } from "../utils/diagnostics";
 import { addExportToIdentifier, createExportedIdentifier, getIdentifierExportScope } from "../utils/export";
 import {
     createHoistableVariableDeclarationStatement,
@@ -53,6 +54,7 @@ export const transformModuleDeclaration: FunctionVisitor<ts.ModuleDeclaration> =
     const annotations = getTypeAnnotations(context.checker.getTypeAtLocation(node));
     // If phantom namespace elide the declaration and return the body
     if (annotations.has(AnnotationKind.Phantom) && node.body && ts.isModuleBlock(node.body)) {
+        context.diagnostics.push(annotationDeprecated(node, AnnotationKind.Phantom));
         return context.transformStatements(node.body.statements);
     }
 

--- a/test/legacy-utils.ts
+++ b/test/legacy-utils.ts
@@ -13,7 +13,9 @@ export function transpileString(
     const { diagnostics, file } = transpileStringResult(str, options);
     expect(file.lua).toBeDefined();
 
-    const errors = ignoreDiagnostics ? [] : diagnostics.filter(d => d.source === "typescript-to-lua");
+    const errors = diagnostics.filter(
+        d => (!ignoreDiagnostics || d.source === "typescript-to-lua") && d.category === ts.DiagnosticCategory.Error
+    );
     expect(errors).not.toHaveDiagnostics();
 
     return file.lua!.trim();

--- a/test/legacy-utils.ts
+++ b/test/legacy-utils.ts
@@ -13,7 +13,7 @@ export function transpileString(
     const { diagnostics, file } = transpileStringResult(str, options);
     expect(file.lua).toBeDefined();
 
-    const errors = diagnostics.filter(d => !ignoreDiagnostics || d.source === "typescript-to-lua");
+    const errors = ignoreDiagnostics ? [] : diagnostics.filter(d => d.source === "typescript-to-lua");
     expect(errors).not.toHaveDiagnostics();
 
     return file.lua!.trim();
@@ -86,14 +86,15 @@ export function transpileAndExecute(
     tsStr: string,
     compilerOptions?: tstl.CompilerOptions,
     luaHeader?: string,
-    tsHeader?: string
+    tsHeader?: string,
+    ignoreDiagnostics = false
 ): any {
     const wrappedTsString = `${tsHeader ?? ""}
         declare function JSONStringify(this: void, p: any): string;
         function __runTest(this: void): any {${tsStr}}`;
 
     const lua = `${luaHeader ?? ""}
-        ${transpileString(wrappedTsString, compilerOptions, false)}
+        ${transpileString(wrappedTsString, compilerOptions, ignoreDiagnostics)}
         return __runTest();`;
 
     return executeLua(lua);

--- a/test/translation/transformation.spec.ts
+++ b/test/translation/transformation.spec.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as tstl from "../../src";
+import { annotationDeprecated } from "../../src/transformation/utils/diagnostics";
 import * as util from "../util";
 
 const fixturesPath = path.join(__dirname, "./transformation");
@@ -13,6 +14,7 @@ const fixtures = fs
 test.each(fixtures)("Transformation (%s)", (_name, content) => {
     util.testModule(content)
         .setOptions({ luaLibImport: tstl.LuaLibImportKind.Require })
+        .ignoreDiagnostics([annotationDeprecated.code])
         .disableSemanticCheck()
         .expectLuaToMatchSnapshot();
 });

--- a/test/unit/annotations/__snapshots__/deprecated.spec.ts.snap
+++ b/test/unit/annotations/__snapshots__/deprecated.spec.ts.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`extension deprecation: code 1`] = `""`;
+
+exports[`extension deprecation: code 2`] = `"local __meta__A = debug.getregistry().A"`;
+
+exports[`extension deprecation: diagnostics 1`] = `"main.ts(4,9): warning TSTL: '@extension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile."`;
+
+exports[`extension deprecation: diagnostics 2`] = `"main.ts(4,9): warning TSTL: '@metaExtension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile."`;
+
+exports[`phantom deprecation: code 1`] = `
+"function nsMember(self)
+end"
+`;
+
+exports[`phantom deprecation: diagnostics 1`] = `"main.ts(3,9): warning TSTL: '@phantom' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile."`;
+
+exports[`pureAbstract deprecation: code 1`] = `
+"require(\\"lualib_bundle\\");
+ClassB = __TS__Class()
+ClassB.name = \\"ClassB\\"
+function ClassB.prototype.____constructor(self)
+end"
+`;
+
+exports[`pureAbstract deprecation: diagnostics 1`] = `"main.ts(4,22): warning TSTL: '@pureAbstract' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile."`;

--- a/test/unit/annotations/__snapshots__/deprecated.spec.ts.snap
+++ b/test/unit/annotations/__snapshots__/deprecated.spec.ts.snap
@@ -4,16 +4,16 @@ exports[`extension deprecation: code 1`] = `""`;
 
 exports[`extension deprecation: code 2`] = `"local __meta__A = debug.getregistry().A"`;
 
-exports[`extension deprecation: diagnostics 1`] = `"main.ts(4,9): warning TSTL: '@extension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile."`;
+exports[`extension deprecation: diagnostics 1`] = `"main.ts(4,9): warning TSTL: '@extension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. See https://typescripttolua.github.io/docs/advanced/compiler-annotations#extension for more information."`;
 
-exports[`extension deprecation: diagnostics 2`] = `"main.ts(4,9): warning TSTL: '@metaExtension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile."`;
+exports[`extension deprecation: diagnostics 2`] = `"main.ts(4,9): warning TSTL: '@metaExtension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. See https://typescripttolua.github.io/docs/advanced/compiler-annotations#metaExtension for more information."`;
 
 exports[`phantom deprecation: code 1`] = `
 "function nsMember(self)
 end"
 `;
 
-exports[`phantom deprecation: diagnostics 1`] = `"main.ts(3,9): warning TSTL: '@phantom' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile."`;
+exports[`phantom deprecation: diagnostics 1`] = `"main.ts(3,9): warning TSTL: '@phantom' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. See https://typescripttolua.github.io/docs/advanced/compiler-annotations#phantom for more information."`;
 
 exports[`pureAbstract deprecation: code 1`] = `
 "require(\\"lualib_bundle\\");
@@ -23,4 +23,4 @@ function ClassB.prototype.____constructor(self)
 end"
 `;
 
-exports[`pureAbstract deprecation: diagnostics 1`] = `"main.ts(4,22): warning TSTL: '@pureAbstract' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile."`;
+exports[`pureAbstract deprecation: diagnostics 1`] = `"main.ts(4,22): warning TSTL: '@pureAbstract' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. See https://typescripttolua.github.io/docs/advanced/compiler-annotations#pureAbstract for more information."`;

--- a/test/unit/annotations/__snapshots__/deprecated.spec.ts.snap
+++ b/test/unit/annotations/__snapshots__/deprecated.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`extension deprecation: code 2`] = `"local __meta__A = debug.getregistry
 
 exports[`extension deprecation: diagnostics 1`] = `"main.ts(4,9): warning TSTL: '@extension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. See https://typescripttolua.github.io/docs/advanced/compiler-annotations#extension for more information."`;
 
-exports[`extension deprecation: diagnostics 2`] = `"main.ts(4,9): warning TSTL: '@metaExtension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. See https://typescripttolua.github.io/docs/advanced/compiler-annotations#metaExtension for more information."`;
+exports[`extension deprecation: diagnostics 2`] = `"main.ts(4,9): warning TSTL: '@metaExtension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. See https://typescripttolua.github.io/docs/advanced/compiler-annotations#metaextension for more information."`;
 
 exports[`phantom deprecation: code 1`] = `
 "function nsMember(self)
@@ -23,4 +23,4 @@ function ClassB.prototype.____constructor(self)
 end"
 `;
 
-exports[`pureAbstract deprecation: diagnostics 1`] = `"main.ts(4,22): warning TSTL: '@pureAbstract' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. See https://typescripttolua.github.io/docs/advanced/compiler-annotations#pureAbstract for more information."`;
+exports[`pureAbstract deprecation: diagnostics 1`] = `"main.ts(4,22): warning TSTL: '@pureAbstract' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. See https://typescripttolua.github.io/docs/advanced/compiler-annotations#pureabstract for more information."`;

--- a/test/unit/annotations/__snapshots__/extension.spec.ts.snap
+++ b/test/unit/annotations/__snapshots__/extension.spec.ts.snap
@@ -5,7 +5,10 @@ exports[`Class construct extension ("extension"): code 1`] = `
 b = __TS__New(B)"
 `;
 
-exports[`Class construct extension ("extension"): diagnostics 1`] = `"main.ts(5,19): error TSTL: Cannot construct classes with '@extension' or '@metaExtension' annotation."`;
+exports[`Class construct extension ("extension"): diagnostics 1`] = `
+"main.ts(4,9): warning TSTL: '@extension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile.
+main.ts(5,19): error TSTL: Cannot construct classes with '@extension' or '@metaExtension' annotation."
+`;
 
 exports[`Class construct extension ("metaExtension"): code 1`] = `
 "require(\\"lualib_bundle\\");
@@ -13,7 +16,10 @@ local __meta__A = debug.getregistry().A
 b = __TS__New(B)"
 `;
 
-exports[`Class construct extension ("metaExtension"): diagnostics 1`] = `"main.ts(5,19): error TSTL: Cannot construct classes with '@extension' or '@metaExtension' annotation."`;
+exports[`Class construct extension ("metaExtension"): diagnostics 1`] = `
+"main.ts(4,9): warning TSTL: '@metaExtension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile.
+main.ts(5,19): error TSTL: Cannot construct classes with '@extension' or '@metaExtension' annotation."
+`;
 
 exports[`Class extends extension ("extension"): code 1`] = `
 "require(\\"lualib_bundle\\");
@@ -22,7 +28,10 @@ C.name = \\"C\\"
 __TS__ClassExtends(C, B)"
 `;
 
-exports[`Class extends extension ("extension"): diagnostics 1`] = `"main.ts(5,9): error TSTL: Cannot extend classes with '@extension' or '@metaExtension' annotation."`;
+exports[`Class extends extension ("extension"): diagnostics 1`] = `
+"main.ts(4,9): warning TSTL: '@extension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile.
+main.ts(5,9): error TSTL: Cannot extend classes with '@extension' or '@metaExtension' annotation."
+`;
 
 exports[`Class extends extension ("metaExtension"): code 1`] = `
 "require(\\"lualib_bundle\\");
@@ -32,14 +41,20 @@ C.name = \\"C\\"
 __TS__ClassExtends(C, B)"
 `;
 
-exports[`Class extends extension ("metaExtension"): diagnostics 1`] = `"main.ts(5,9): error TSTL: Cannot extend classes with '@extension' or '@metaExtension' annotation."`;
+exports[`Class extends extension ("metaExtension"): diagnostics 1`] = `
+"main.ts(4,9): warning TSTL: '@metaExtension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile.
+main.ts(5,9): error TSTL: Cannot extend classes with '@extension' or '@metaExtension' annotation."
+`;
 
 exports[`instanceof extension ("extension"): code 1`] = `
 "require(\\"lualib_bundle\\");
 result = __TS__InstanceOf(foo, B)"
 `;
 
-exports[`instanceof extension ("extension"): diagnostics 1`] = `"main.ts(6,24): error TSTL: Cannot use instanceof on classes with '@extension' or '@metaExtension' annotation."`;
+exports[`instanceof extension ("extension"): diagnostics 1`] = `
+"main.ts(4,9): warning TSTL: '@extension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile.
+main.ts(6,24): error TSTL: Cannot use instanceof on classes with '@extension' or '@metaExtension' annotation."
+`;
 
 exports[`instanceof extension ("metaExtension"): code 1`] = `
 "require(\\"lualib_bundle\\");
@@ -47,4 +62,7 @@ local __meta__A = debug.getregistry().A
 result = __TS__InstanceOf(foo, B)"
 `;
 
-exports[`instanceof extension ("metaExtension"): diagnostics 1`] = `"main.ts(6,24): error TSTL: Cannot use instanceof on classes with '@extension' or '@metaExtension' annotation."`;
+exports[`instanceof extension ("metaExtension"): diagnostics 1`] = `
+"main.ts(4,9): warning TSTL: '@metaExtension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile.
+main.ts(6,24): error TSTL: Cannot use instanceof on classes with '@extension' or '@metaExtension' annotation."
+`;

--- a/test/unit/annotations/__snapshots__/extension.spec.ts.snap
+++ b/test/unit/annotations/__snapshots__/extension.spec.ts.snap
@@ -17,7 +17,7 @@ b = __TS__New(B)"
 `;
 
 exports[`Class construct extension ("metaExtension"): diagnostics 1`] = `
-"main.ts(4,9): warning TSTL: '@metaExtension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. See https://typescripttolua.github.io/docs/advanced/compiler-annotations#metaExtension for more information.
+"main.ts(4,9): warning TSTL: '@metaExtension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. See https://typescripttolua.github.io/docs/advanced/compiler-annotations#metaextension for more information.
 main.ts(5,19): error TSTL: Cannot construct classes with '@extension' or '@metaExtension' annotation."
 `;
 
@@ -42,7 +42,7 @@ __TS__ClassExtends(C, B)"
 `;
 
 exports[`Class extends extension ("metaExtension"): diagnostics 1`] = `
-"main.ts(4,9): warning TSTL: '@metaExtension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. See https://typescripttolua.github.io/docs/advanced/compiler-annotations#metaExtension for more information.
+"main.ts(4,9): warning TSTL: '@metaExtension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. See https://typescripttolua.github.io/docs/advanced/compiler-annotations#metaextension for more information.
 main.ts(5,9): error TSTL: Cannot extend classes with '@extension' or '@metaExtension' annotation."
 `;
 
@@ -63,6 +63,6 @@ result = __TS__InstanceOf(foo, B)"
 `;
 
 exports[`instanceof extension ("metaExtension"): diagnostics 1`] = `
-"main.ts(4,9): warning TSTL: '@metaExtension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. See https://typescripttolua.github.io/docs/advanced/compiler-annotations#metaExtension for more information.
+"main.ts(4,9): warning TSTL: '@metaExtension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. See https://typescripttolua.github.io/docs/advanced/compiler-annotations#metaextension for more information.
 main.ts(6,24): error TSTL: Cannot use instanceof on classes with '@extension' or '@metaExtension' annotation."
 `;

--- a/test/unit/annotations/__snapshots__/extension.spec.ts.snap
+++ b/test/unit/annotations/__snapshots__/extension.spec.ts.snap
@@ -6,7 +6,7 @@ b = __TS__New(B)"
 `;
 
 exports[`Class construct extension ("extension"): diagnostics 1`] = `
-"main.ts(4,9): warning TSTL: '@extension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile.
+"main.ts(4,9): warning TSTL: '@extension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. See https://typescripttolua.github.io/docs/advanced/compiler-annotations#extension for more information.
 main.ts(5,19): error TSTL: Cannot construct classes with '@extension' or '@metaExtension' annotation."
 `;
 
@@ -17,7 +17,7 @@ b = __TS__New(B)"
 `;
 
 exports[`Class construct extension ("metaExtension"): diagnostics 1`] = `
-"main.ts(4,9): warning TSTL: '@metaExtension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile.
+"main.ts(4,9): warning TSTL: '@metaExtension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. See https://typescripttolua.github.io/docs/advanced/compiler-annotations#metaExtension for more information.
 main.ts(5,19): error TSTL: Cannot construct classes with '@extension' or '@metaExtension' annotation."
 `;
 
@@ -29,7 +29,7 @@ __TS__ClassExtends(C, B)"
 `;
 
 exports[`Class extends extension ("extension"): diagnostics 1`] = `
-"main.ts(4,9): warning TSTL: '@extension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile.
+"main.ts(4,9): warning TSTL: '@extension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. See https://typescripttolua.github.io/docs/advanced/compiler-annotations#extension for more information.
 main.ts(5,9): error TSTL: Cannot extend classes with '@extension' or '@metaExtension' annotation."
 `;
 
@@ -42,7 +42,7 @@ __TS__ClassExtends(C, B)"
 `;
 
 exports[`Class extends extension ("metaExtension"): diagnostics 1`] = `
-"main.ts(4,9): warning TSTL: '@metaExtension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile.
+"main.ts(4,9): warning TSTL: '@metaExtension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. See https://typescripttolua.github.io/docs/advanced/compiler-annotations#metaExtension for more information.
 main.ts(5,9): error TSTL: Cannot extend classes with '@extension' or '@metaExtension' annotation."
 `;
 
@@ -52,7 +52,7 @@ result = __TS__InstanceOf(foo, B)"
 `;
 
 exports[`instanceof extension ("extension"): diagnostics 1`] = `
-"main.ts(4,9): warning TSTL: '@extension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile.
+"main.ts(4,9): warning TSTL: '@extension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. See https://typescripttolua.github.io/docs/advanced/compiler-annotations#extension for more information.
 main.ts(6,24): error TSTL: Cannot use instanceof on classes with '@extension' or '@metaExtension' annotation."
 `;
 
@@ -63,6 +63,6 @@ result = __TS__InstanceOf(foo, B)"
 `;
 
 exports[`instanceof extension ("metaExtension"): diagnostics 1`] = `
-"main.ts(4,9): warning TSTL: '@metaExtension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile.
+"main.ts(4,9): warning TSTL: '@metaExtension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. See https://typescripttolua.github.io/docs/advanced/compiler-annotations#metaExtension for more information.
 main.ts(6,24): error TSTL: Cannot use instanceof on classes with '@extension' or '@metaExtension' annotation."
 `;

--- a/test/unit/annotations/__snapshots__/metaExtension.spec.ts.snap
+++ b/test/unit/annotations/__snapshots__/metaExtension.spec.ts.snap
@@ -7,7 +7,7 @@ e = __TS__New(Ext)"
 `;
 
 exports[`DontAllowInstantiation: diagnostics 1`] = `
-"main.ts(4,9): warning TSTL: '@metaExtension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. See https://typescripttolua.github.io/docs/advanced/compiler-annotations#metaExtension for more information.
+"main.ts(4,9): warning TSTL: '@metaExtension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. See https://typescripttolua.github.io/docs/advanced/compiler-annotations#metaextension for more information.
 main.ts(5,19): error TSTL: Cannot construct classes with '@extension' or '@metaExtension' annotation."
 `;
 
@@ -19,5 +19,5 @@ end"
 
 exports[`IncorrectUsage: diagnostics 1`] = `
 "main.ts(3,9): error TSTL: '@metaExtension' annotation requires the extension of the metatable class.
-main.ts(3,9): warning TSTL: '@metaExtension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. See https://typescripttolua.github.io/docs/advanced/compiler-annotations#metaExtension for more information."
+main.ts(3,9): warning TSTL: '@metaExtension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. See https://typescripttolua.github.io/docs/advanced/compiler-annotations#metaextension for more information."
 `;

--- a/test/unit/annotations/__snapshots__/metaExtension.spec.ts.snap
+++ b/test/unit/annotations/__snapshots__/metaExtension.spec.ts.snap
@@ -7,7 +7,7 @@ e = __TS__New(Ext)"
 `;
 
 exports[`DontAllowInstantiation: diagnostics 1`] = `
-"main.ts(4,9): warning TSTL: '@metaExtension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile.
+"main.ts(4,9): warning TSTL: '@metaExtension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. See https://typescripttolua.github.io/docs/advanced/compiler-annotations#metaExtension for more information.
 main.ts(5,19): error TSTL: Cannot construct classes with '@extension' or '@metaExtension' annotation."
 `;
 
@@ -19,5 +19,5 @@ end"
 
 exports[`IncorrectUsage: diagnostics 1`] = `
 "main.ts(3,9): error TSTL: '@metaExtension' annotation requires the extension of the metatable class.
-main.ts(3,9): warning TSTL: '@metaExtension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile."
+main.ts(3,9): warning TSTL: '@metaExtension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. See https://typescripttolua.github.io/docs/advanced/compiler-annotations#metaExtension for more information."
 `;

--- a/test/unit/annotations/__snapshots__/metaExtension.spec.ts.snap
+++ b/test/unit/annotations/__snapshots__/metaExtension.spec.ts.snap
@@ -6,7 +6,10 @@ local __meta___LOADED = debug.getregistry()._LOADED
 e = __TS__New(Ext)"
 `;
 
-exports[`DontAllowInstantiation: diagnostics 1`] = `"main.ts(5,19): error TSTL: Cannot construct classes with '@extension' or '@metaExtension' annotation."`;
+exports[`DontAllowInstantiation: diagnostics 1`] = `
+"main.ts(4,9): warning TSTL: '@metaExtension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile.
+main.ts(5,19): error TSTL: Cannot construct classes with '@extension' or '@metaExtension' annotation."
+`;
 
 exports[`IncorrectUsage: code 1`] = `
 "function LoadedExt.test(self)
@@ -14,4 +17,7 @@ exports[`IncorrectUsage: code 1`] = `
 end"
 `;
 
-exports[`IncorrectUsage: diagnostics 1`] = `"main.ts(3,9): error TSTL: '@metaExtension' annotation requires the extension of the metatable class."`;
+exports[`IncorrectUsage: diagnostics 1`] = `
+"main.ts(3,9): error TSTL: '@metaExtension' annotation requires the extension of the metatable class.
+main.ts(3,9): warning TSTL: '@metaExtension' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile."
+`;

--- a/test/unit/annotations/deprecated.spec.ts
+++ b/test/unit/annotations/deprecated.spec.ts
@@ -1,0 +1,27 @@
+import { annotationDeprecated } from "../../../src/transformation/utils/diagnostics";
+import * as util from "../../util";
+
+test.each(["extension", "metaExtension"])("extension deprecation", extensionType => {
+    util.testModule`
+        declare class A {}
+        /** @${extensionType} **/
+        class B extends A {}
+    `.expectDiagnosticsToMatchSnapshot([annotationDeprecated.code]);
+});
+
+test("phantom deprecation", () => {
+    util.testModule`
+        /** @phantom **/
+        namespace A {
+            function nsMember() {}
+        }
+    `.expectDiagnosticsToMatchSnapshot([annotationDeprecated.code]);
+});
+
+test("pureAbstract deprecation", () => {
+    util.testModule`
+        /** @pureAbstract */
+        declare class ClassA {}
+        class ClassB extends ClassA {}    
+    `.expectDiagnosticsToMatchSnapshot([annotationDeprecated.code]);
+});

--- a/test/unit/annotations/extension.spec.ts
+++ b/test/unit/annotations/extension.spec.ts
@@ -1,4 +1,5 @@
 import {
+    annotationDeprecated,
     extensionCannotConstruct,
     extensionCannotExtend,
     extensionInvalidInstanceOf,
@@ -11,7 +12,7 @@ test.each(["extension", "metaExtension"])("Class extends extension (%p)", extens
         /** @${extensionType} **/
         class B extends A {}
         class C extends B {}
-    `.expectDiagnosticsToMatchSnapshot([extensionCannotExtend.code]);
+    `.expectDiagnosticsToMatchSnapshot([annotationDeprecated.code, extensionCannotExtend.code]);
 });
 
 test.each(["extension", "metaExtension"])("Class construct extension (%p)", extensionType => {
@@ -20,7 +21,7 @@ test.each(["extension", "metaExtension"])("Class construct extension (%p)", exte
         /** @${extensionType} **/
         class B extends A {}
         const b = new B();
-    `.expectDiagnosticsToMatchSnapshot([extensionCannotConstruct.code]);
+    `.expectDiagnosticsToMatchSnapshot([annotationDeprecated.code, extensionCannotConstruct.code]);
 });
 
 test.each(["extension", "metaExtension"])("instanceof extension (%p)", extensionType => {
@@ -30,5 +31,5 @@ test.each(["extension", "metaExtension"])("instanceof extension (%p)", extension
         class B extends A {}
         declare const foo: any;
         const result = foo instanceof B;
-    `.expectDiagnosticsToMatchSnapshot([extensionInvalidInstanceOf.code]);
+    `.expectDiagnosticsToMatchSnapshot([annotationDeprecated.code, extensionInvalidInstanceOf.code]);
 });

--- a/test/unit/annotations/metaExtension.spec.ts
+++ b/test/unit/annotations/metaExtension.spec.ts
@@ -1,4 +1,8 @@
-import { extensionCannotConstruct, metaExtensionMissingExtends } from "../../../src/transformation/utils/diagnostics";
+import {
+    annotationDeprecated,
+    extensionCannotConstruct,
+    metaExtensionMissingExtends,
+} from "../../../src/transformation/utils/diagnostics";
 import * as util from "../../util";
 
 test("MetaExtension", () => {
@@ -19,7 +23,8 @@ test("MetaExtension", () => {
         'return debug.getregistry()["_LOADED"].test();',
         undefined,
         undefined,
-        tsHeader
+        tsHeader,
+        true
     );
 
     expect(result).toBe(5);
@@ -33,7 +38,7 @@ test("IncorrectUsage", () => {
                 return 5;
             }
         }
-    `.expectDiagnosticsToMatchSnapshot([metaExtensionMissingExtends.code]);
+    `.expectDiagnosticsToMatchSnapshot([metaExtensionMissingExtends.code, annotationDeprecated.code]);
 });
 
 test("DontAllowInstantiation", () => {
@@ -42,5 +47,5 @@ test("DontAllowInstantiation", () => {
         /** @metaExtension */
         class Ext extends _LOADED {}
         const e = new Ext();
-    `.expectDiagnosticsToMatchSnapshot([extensionCannotConstruct.code]);
+    `.expectDiagnosticsToMatchSnapshot([annotationDeprecated.code, extensionCannotConstruct.code]);
 });

--- a/test/util.ts
+++ b/test/util.ts
@@ -298,7 +298,9 @@ export abstract class TestBuilder {
 
     private getLuaDiagnostics(): ts.Diagnostic[] {
         const { diagnostics } = this.getLuaResult();
-        return diagnostics.filter(d => this.semanticCheck || d.source === "typescript-to-lua");
+        return diagnostics.filter(
+            d => (this.semanticCheck || d.source === "typescript-to-lua") && !this.ignoredDiagnostics.includes(d.code)
+        );
     }
 
     // Actions
@@ -311,6 +313,12 @@ export abstract class TestBuilder {
     }
 
     private diagnosticsChecked = false;
+    private ignoredDiagnostics: number[] = [];
+
+    public ignoreDiagnostics(ignored: number[]): this {
+        this.ignoredDiagnostics.push(...ignored);
+        return this;
+    }
 
     public expectToHaveDiagnostics(expected?: number[]): this {
         if (this.diagnosticsChecked) return this;


### PR DESCRIPTION
I tried to keep the deprecation warnings seperate from existing code/tests, so they can be easily removed once we delete the the deprecated annotations.

Fixes #652