### PR TITLE
Allow numeric access to MultiReturn

### DIFF
--- a/src/transformation/utils/diagnostics.ts
+++ b/src/transformation/utils/diagnostics.ts
@@ -164,6 +164,10 @@ export const invalidMultiTypeArrayLiteralElementInitializer = createErrorDiagnos
     "This array literal pattern cannot have initializers."
 );
 
+export const invalidMultiReturnAccess = createErrorDiagnosticFactory(
+    "The MultiReturn type can only be accessed via an element access expression of a numeric type."
+);
+
 export const unsupportedMultiFunctionAssignment = createErrorDiagnosticFactory(
     "Omitted expressions and BindingElements are expected here."
 );

--- a/test/unit/language-extensions/__snapshots__/multi.spec.ts.snap
+++ b/test/unit/language-extensions/__snapshots__/multi.spec.ts.snap
@@ -1,5 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`disallow MultiReturn non-numeric access: code 1`] = `
+"local ____exports = {}
+function ____exports.__main(self)
+    local function multi(self, ...)
+        local args = {...}
+        return table.unpack(args)
+    end
+    return select(
+        \\"forEach\\",
+        multi(nil)
+    )
+end
+return ____exports"
+`;
+
+exports[`disallow MultiReturn non-numeric access: code 2`] = `
+"local ____exports = {}
+function ____exports.__main(self)
+    local function multi(self, ...)
+        local args = {...}
+        return table.unpack(args)
+    end
+    return multi(nil).forEach
+end
+return ____exports"
+`;
+
+exports[`disallow MultiReturn non-numeric access: diagnostics 1`] = `"main.ts(7,16): error TSTL: The MultiReturn type can only be accessed via an element access expression of a numeric type."`;
+
+exports[`disallow MultiReturn non-numeric access: diagnostics 2`] = `"main.ts(7,16): error TSTL: The MultiReturn type can only be accessed via an element access expression of a numeric type."`;
+
 exports[`invalid $multi call ($multi()): code 1`] = `"____(_G)"`;
 
 exports[`invalid $multi call ($multi()): diagnostics 1`] = `"main.ts(2,9): error TSTL: The $multi function must be called in an expression that is returned."`;

--- a/test/unit/language-extensions/multi.spec.ts
+++ b/test/unit/language-extensions/multi.spec.ts
@@ -5,6 +5,7 @@ import {
     invalidMultiFunctionUse,
     invalidMultiTypeToNonArrayBindingPattern,
     invalidMultiTypeArrayBindingPatternElementInitializer,
+    invalidMultiReturnAccess,
 } from "../../../src/transformation/utils/diagnostics";
 
 const multiProjectOptions: tstl.CompilerOptions = {
@@ -125,4 +126,23 @@ test("allow $multi call in ArrowFunction body", () => {
     `
         .setOptions(multiProjectOptions)
         .expectToEqual(1);
+});
+
+test.each(["0", "i"])("allow MultiReturn numeric access", expression => {
+    util.testFunction`
+        ${multiFunction}
+        const i = 0;
+        return multi(1)[${expression}];
+    `
+        .setOptions(multiProjectOptions)
+        .expectToEqual(1);
+});
+
+test.each(["multi()['forEach']", "multi().forEach"])("disallow MultiReturn non-numeric access", expression => {
+    util.testFunction`
+        ${multiFunction}
+        return ${expression};
+    `
+        .setOptions(multiProjectOptions)
+        .expectDiagnosticsToMatchSnapshot([invalidMultiReturnAccess.code]);
 });


### PR DESCRIPTION
Resolves #960

```ts
function result() {
  return $multi(1, 2, 3);
}

const first = result()[0];
```

transforms to

```lua
function result() ... end

local first = select(
  1, -- uses +1 rule
  result()
)
```

But diagnostics will be generated if anything else about the type is attempted to be accessed

```ts
result()["forEach"] // not allowed to access via non-numeric type
result().forEach // not allowed to access via property access expression
```