### PR TITLE
Multi-Return update

### DIFF
--- a/language-extensions/index.d.ts
+++ b/language-extensions/index.d.ts
@@ -1,5 +1,19 @@
-declare function $multi<T extends any[]>(...values: T): MultiReturn<T>;
-declare type MultiReturn<T extends any[]> = T & { readonly " __multiBrand": unique symbol };
+/**
+ * Returns multiple values from a function, by wrapping them in a LuaMultiReturn tuple.
+ * For more information see: https://typescripttolua.github.io/docs/advanced/language-extensions
+ *
+ * @param T A tuple type with each element type representing a return value's type.
+ * @param values Return values.
+ */
+declare function $multi<T extends any[]>(...values: T): LuaMultiReturn<T>;
+
+/**
+ * Represents multiple return values as a tuple.
+ * For more information see: https://typescripttolua.github.io/docs/advanced/language-extensions
+ *
+ * @param T A tuple type with each element type representing a return value's type.
+ */
+declare type LuaMultiReturn<T extends any[]> = T & { readonly __luaMultiReturnBrand: unique symbol };
 
 /**
  * Calls to functions with this type are translated to `left + right`.

--- a/src/lualib/StringIncludes.ts
+++ b/src/lualib/StringIncludes.ts
@@ -5,5 +5,6 @@ function __TS__StringIncludes(this: string, searchString: string, position?: num
     } else {
         position += 1;
     }
-    return string.find(this, searchString, position, true) !== undefined;
+    const [index] = string.find(this, searchString, position, true);
+    return index !== undefined;
 }

--- a/src/lualib/declarations/string.d.ts
+++ b/src/lualib/declarations/string.d.ts
@@ -19,5 +19,5 @@ declare namespace string {
         pattern: string,
         start?: number,
         plainflag?: boolean
-    ): MultiReturn<[number, number]> | undefined;
+    ): LuaMultiReturn<[number, number]> | undefined;
 }

--- a/src/lualib/declarations/string.d.ts
+++ b/src/lualib/declarations/string.d.ts
@@ -19,5 +19,5 @@ declare namespace string {
         pattern: string,
         start?: number,
         plainflag?: boolean
-    ): LuaMultiReturn<[number, number]> | undefined;
+    ): LuaMultiReturn<[number, number] | [undefined]>;
 }

--- a/src/transformation/utils/diagnostics.ts
+++ b/src/transformation/utils/diagnostics.ts
@@ -165,7 +165,7 @@ export const invalidMultiTypeArrayLiteralElementInitializer = createErrorDiagnos
 );
 
 export const invalidMultiReturnAccess = createErrorDiagnosticFactory(
-    "The MultiReturn type can only be accessed via an element access expression of a numeric type."
+    "The LuaMultiReturn type can only be accessed via an element access expression of a numeric type."
 );
 
 export const unsupportedMultiFunctionAssignment = createErrorDiagnosticFactory(

--- a/src/transformation/utils/diagnostics.ts
+++ b/src/transformation/utils/diagnostics.ts
@@ -143,11 +143,11 @@ export const unsupportedVarDeclaration = createErrorDiagnosticFactory(
 );
 
 export const invalidMultiFunctionUse = createErrorDiagnosticFactory(
-    "The $multi function must be called in an expression that is returned."
+    "The $multi function must be called in a return statement."
 );
 
 export const invalidMultiFunctionReturnType = createErrorDiagnosticFactory(
-    "The $multi function can only be used to return a LuaMultiReturn type."
+    "The $multi function cannot be cast to a non-LuaMultiReturn type."
 );
 
 export const invalidMultiTypeToNonArrayLiteral = createErrorDiagnosticFactory("Expected an array literal.");

--- a/src/transformation/utils/diagnostics.ts
+++ b/src/transformation/utils/diagnostics.ts
@@ -146,30 +146,14 @@ export const invalidMultiFunctionUse = createErrorDiagnosticFactory(
     "The $multi function must be called in an expression that is returned."
 );
 
-export const invalidMultiTypeToNonArrayBindingPattern = createErrorDiagnosticFactory(
-    "Expected an array destructuring pattern."
-);
-
 export const invalidMultiTypeToNonArrayLiteral = createErrorDiagnosticFactory("Expected an array literal.");
 
 export const invalidMultiTypeToEmptyPatternOrArrayLiteral = createErrorDiagnosticFactory(
     "There must be one or more elements specified here."
 );
 
-export const invalidMultiTypeArrayBindingPatternElementInitializer = createErrorDiagnosticFactory(
-    "This array binding pattern cannot have initializers."
-);
-
-export const invalidMultiTypeArrayLiteralElementInitializer = createErrorDiagnosticFactory(
-    "This array literal pattern cannot have initializers."
-);
-
 export const invalidMultiReturnAccess = createErrorDiagnosticFactory(
     "The LuaMultiReturn type can only be accessed via an element access expression of a numeric type."
-);
-
-export const unsupportedMultiFunctionAssignment = createErrorDiagnosticFactory(
-    "Omitted expressions and BindingElements are expected here."
 );
 
 export const invalidOperatorMappingUse = createErrorDiagnosticFactory(

--- a/src/transformation/utils/diagnostics.ts
+++ b/src/transformation/utils/diagnostics.ts
@@ -146,6 +146,10 @@ export const invalidMultiFunctionUse = createErrorDiagnosticFactory(
     "The $multi function must be called in an expression that is returned."
 );
 
+export const invalidMultiFunctionReturnType = createErrorDiagnosticFactory(
+    "The $multi function can only be used to return a LuaMultiReturn type."
+);
+
 export const invalidMultiTypeToNonArrayLiteral = createErrorDiagnosticFactory("Expected an array literal.");
 
 export const invalidMultiTypeToEmptyPatternOrArrayLiteral = createErrorDiagnosticFactory(

--- a/src/transformation/utils/language-extensions.ts
+++ b/src/transformation/utils/language-extensions.ts
@@ -43,7 +43,7 @@ export enum ExtensionKind {
 }
 
 const typeNameToExtensionKind: { [name: string]: ExtensionKind } = {
-    MultiReturn: ExtensionKind.MultiType,
+    LuaMultiReturn: ExtensionKind.MultiType,
     LuaAddition: ExtensionKind.AdditionOperatorType,
     LuaAdditionMethod: ExtensionKind.AdditionOperatorMethodType,
     LuaSubtraction: ExtensionKind.SubtractionOperatorType,

--- a/src/transformation/visitors/binary-expression/assignments.ts
+++ b/src/transformation/visitors/binary-expression/assignments.ts
@@ -92,7 +92,7 @@ export function transformAssignmentExpression(
         const rootIdentifier = lua.createAnonymousIdentifier(expression.left);
 
         let right = context.transformExpression(expression.right);
-        if (isTupleReturnCall(context, expression.right)) {
+        if (isTupleReturnCall(context, expression.right) || isMultiReturnCall(context, expression.right)) {
             right = wrapInTable(right);
         }
 

--- a/src/transformation/visitors/binary-expression/assignments.ts
+++ b/src/transformation/visitors/binary-expression/assignments.ts
@@ -11,6 +11,7 @@ import { isArrayType, isDestructuringAssignment } from "../../utils/typescript";
 import { transformElementAccessArgument } from "../access";
 import { transformLuaTablePropertyAccessInAssignment } from "../lua-table";
 import { isArrayLength, transformDestructuringAssignment } from "./destructuring-assignments";
+import { isMultiReturnCall } from "../language-extensions/multi";
 
 export function transformAssignmentLeftHandSideExpression(
     context: TransformationContext,
@@ -184,7 +185,10 @@ export function transformAssignmentStatement(
             const rightType = context.checker.getTypeAtLocation(expression.right);
             let right = context.transformExpression(expression.right);
 
-            if (!isTupleReturnCall(context, expression.right) && isArrayType(context, rightType)) {
+            if (
+                !(isTupleReturnCall(context, expression.right) || isMultiReturnCall(context, expression.right)) &&
+                isArrayType(context, rightType)
+            ) {
                 right = createUnpackCall(context, right, expression.right);
             }
 
@@ -194,7 +198,7 @@ export function transformAssignmentStatement(
         }
 
         let right = context.transformExpression(expression.right);
-        if (isTupleReturnCall(context, expression.right)) {
+        if (isTupleReturnCall(context, expression.right) || isMultiReturnCall(context, expression.right)) {
             right = wrapInTable(right);
         }
 

--- a/src/transformation/visitors/call.ts
+++ b/src/transformation/visitors/call.ts
@@ -11,7 +11,7 @@ import { isValidLuaIdentifier } from "../utils/safe-names";
 import { isArrayType, isExpressionWithEvaluationEffect, isInDestructingAssignment } from "../utils/typescript";
 import { transformElementAccessArgument } from "./access";
 import { transformLuaTableCallExpression } from "./lua-table";
-import { multiReturnCallShouldBeWrapped, returnsMultiType } from "./language-extensions/multi";
+import { shouldMultiReturnCallBeWrapped, returnsMultiType } from "./language-extensions/multi";
 import { isOperatorMapping, transformOperatorMappingExpression } from "./language-extensions/operators";
 
 export type PropertyCallExpression = ts.CallExpression & { expression: ts.PropertyAccessExpression };
@@ -203,7 +203,7 @@ export const transformCallExpression: FunctionVisitor<ts.CallExpression> = (node
     const returnValueIsUsed = node.parent && !ts.isExpressionStatement(node.parent);
     const wrapTupleReturn =
         isTupleReturn && !isTupleReturnForward && !isInDestructingAssignment(node) && !isInSpread && returnValueIsUsed;
-    const wrapResult = wrapTupleReturn || multiReturnCallShouldBeWrapped(context, node);
+    const wrapResult = wrapTupleReturn || shouldMultiReturnCallBeWrapped(context, node);
 
     const builtinResult = transformBuiltinCallExpression(context, node);
     if (builtinResult) {

--- a/src/transformation/visitors/call.ts
+++ b/src/transformation/visitors/call.ts
@@ -11,7 +11,7 @@ import { isValidLuaIdentifier } from "../utils/safe-names";
 import { isArrayType, isExpressionWithEvaluationEffect, isInDestructingAssignment } from "../utils/typescript";
 import { transformElementAccessArgument } from "./access";
 import { transformLuaTableCallExpression } from "./lua-table";
-import { returnsMultiType } from "./language-extensions/multi";
+import { multiReturnCallShouldBeWrapped, returnsMultiType } from "./language-extensions/multi";
 import { isOperatorMapping, transformOperatorMappingExpression } from "./language-extensions/operators";
 
 export type PropertyCallExpression = ts.CallExpression & { expression: ts.PropertyAccessExpression };
@@ -201,8 +201,9 @@ export const transformCallExpression: FunctionVisitor<ts.CallExpression> = (node
         node.parent && ts.isReturnStatement(node.parent) && isInTupleReturnFunction(context, node);
     const isInSpread = node.parent && ts.isSpreadElement(node.parent);
     const returnValueIsUsed = node.parent && !ts.isExpressionStatement(node.parent);
-    const wrapResult =
+    const wrapTupleReturn =
         isTupleReturn && !isTupleReturnForward && !isInDestructingAssignment(node) && !isInSpread && returnValueIsUsed;
+    const wrapResult = wrapTupleReturn || multiReturnCallShouldBeWrapped(context, node);
 
     const builtinResult = transformBuiltinCallExpression(context, node);
     if (builtinResult) {

--- a/src/transformation/visitors/errors.ts
+++ b/src/transformation/visitors/errors.ts
@@ -6,6 +6,7 @@ import { createUnpackCall } from "../utils/lua-ast";
 import { findScope, ScopeType } from "../utils/scope";
 import { transformScopeBlock } from "./block";
 import { transformIdentifier } from "./identifier";
+import { isInMultiReturnFunction } from "./language-extensions/multi";
 
 export const transformTryStatement: FunctionVisitor<ts.TryStatement> = (statement, context) => {
     const [tryBlock, tryScope] = transformScopeBlock(context, statement.tryBlock, ScopeType.Try);
@@ -88,7 +89,7 @@ export const transformTryStatement: FunctionVisitor<ts.TryStatement> = (statemen
             returnValues.push(lua.createBooleanLiteral(true));
         }
 
-        if (isInTupleReturnFunction(context, statement)) {
+        if (isInTupleReturnFunction(context, statement) || isInMultiReturnFunction(statement)) {
             returnValues.push(createUnpackCall(context, lua.cloneIdentifier(returnValueIdentifier)));
         } else {
             returnValues.push(lua.cloneIdentifier(returnValueIdentifier));

--- a/src/transformation/visitors/errors.ts
+++ b/src/transformation/visitors/errors.ts
@@ -89,7 +89,7 @@ export const transformTryStatement: FunctionVisitor<ts.TryStatement> = (statemen
             returnValues.push(lua.createBooleanLiteral(true));
         }
 
-        if (isInTupleReturnFunction(context, statement) || isInMultiReturnFunction(statement)) {
+        if (isInTupleReturnFunction(context, statement) || isInMultiReturnFunction(context, statement)) {
             returnValues.push(createUnpackCall(context, lua.cloneIdentifier(returnValueIdentifier)));
         } else {
             returnValues.push(lua.cloneIdentifier(returnValueIdentifier));

--- a/src/transformation/visitors/expression-statement.ts
+++ b/src/transformation/visitors/expression-statement.ts
@@ -4,18 +4,8 @@ import { FunctionVisitor } from "../context";
 import { transformBinaryExpressionStatement } from "./binary-expression";
 import { transformLuaTableExpressionStatement } from "./lua-table";
 import { transformUnaryExpressionStatement } from "./unary-expression";
-import { returnsMultiType, transformMultiDestructuringAssignmentStatement } from "./language-extensions/multi";
 
 export const transformExpressionStatement: FunctionVisitor<ts.ExpressionStatement> = (node, context) => {
-    if (
-        ts.isBinaryExpression(node.expression) &&
-        node.expression.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
-        ts.isCallExpression(node.expression.right) &&
-        returnsMultiType(context, node.expression.right)
-    ) {
-        return transformMultiDestructuringAssignmentStatement(context, node);
-    }
-
     const luaTableResult = transformLuaTableExpressionStatement(context, node);
     if (luaTableResult) {
         return luaTableResult;

--- a/src/transformation/visitors/function.ts
+++ b/src/transformation/visitors/function.ts
@@ -15,7 +15,6 @@ import {
 import { LuaLibFeature, transformLuaLibFunction } from "../utils/lualib";
 import { peekScope, performHoisting, popScope, pushScope, Scope, ScopeType } from "../utils/scope";
 import { transformIdentifier } from "./identifier";
-import { isMultiFunction, transformMultiCallExpressionToReturnStatement } from "./language-extensions/multi";
 import { transformExpressionBodyToReturnStatement } from "./return";
 import { transformBindingPattern } from "./variable-declaration";
 
@@ -56,10 +55,6 @@ function isRestParameterReferenced(context: TransformationContext, identifier: l
 
 export function transformFunctionBodyContent(context: TransformationContext, body: ts.ConciseBody): lua.Statement[] {
     if (!ts.isBlock(body)) {
-        if (ts.isCallExpression(body) && isMultiFunction(context, body)) {
-            return [transformMultiCallExpressionToReturnStatement(context, body)];
-        }
-
         const returnStatement = transformExpressionBodyToReturnStatement(context, body);
         return [returnStatement];
     }

--- a/src/transformation/visitors/language-extensions/multi.ts
+++ b/src/transformation/visitors/language-extensions/multi.ts
@@ -11,11 +11,7 @@ const isMultiTypeDeclaration = (declaration: ts.Declaration): boolean =>
     extensions.getExtensionKind(declaration) === extensions.ExtensionKind.MultiType;
 
 export function isMultiReturnType(type: ts.Type): boolean {
-    return (
-        (type.symbol?.declarations?.some(isMultiTypeDeclaration) ||
-            type.aliasSymbol?.declarations?.some(isMultiTypeDeclaration)) ??
-        false
-    );
+    return type.aliasSymbol?.declarations?.some(isMultiTypeDeclaration) ?? false;
 }
 
 export function isMultiFunction(context: TransformationContext, expression: ts.CallExpression): boolean {

--- a/src/transformation/visitors/language-extensions/multi.ts
+++ b/src/transformation/visitors/language-extensions/multi.ts
@@ -14,7 +14,7 @@ export function isMultiReturnType(type: ts.Type): boolean {
     return type.aliasSymbol?.declarations?.some(isMultiTypeDeclaration) ?? false;
 }
 
-export function isMultiFunction(context: TransformationContext, expression: ts.CallExpression): boolean {
+export function isMultiFunctionCall(context: TransformationContext, expression: ts.CallExpression): boolean {
     const type = context.checker.getTypeAtLocation(expression.expression);
     return type.symbol?.declarations?.some(isMultiFunctionDeclaration) ?? false;
 }

--- a/src/transformation/visitors/language-extensions/multi.ts
+++ b/src/transformation/visitors/language-extensions/multi.ts
@@ -10,6 +10,14 @@ const isMultiFunctionDeclaration = (declaration: ts.Declaration): boolean =>
 const isMultiTypeDeclaration = (declaration: ts.Declaration): boolean =>
     extensions.getExtensionKind(declaration) === extensions.ExtensionKind.MultiType;
 
+export function isMultiReturnType(type: ts.Type): boolean {
+    return (
+        (type.symbol?.declarations?.some(isMultiTypeDeclaration) ||
+            type.aliasSymbol?.declarations?.some(isMultiTypeDeclaration)) ??
+        false
+    );
+}
+
 export function isMultiFunction(context: TransformationContext, expression: ts.CallExpression): boolean {
     const type = context.checker.getTypeAtLocation(expression.expression);
     return type.symbol?.declarations?.some(isMultiFunctionDeclaration) ?? false;
@@ -17,7 +25,8 @@ export function isMultiFunction(context: TransformationContext, expression: ts.C
 
 export function returnsMultiType(context: TransformationContext, node: ts.CallExpression): boolean {
     const signature = context.checker.getResolvedSignature(node);
-    return signature?.getReturnType().aliasSymbol?.declarations?.some(isMultiTypeDeclaration) ?? false;
+    const type = signature?.getReturnType();
+    return type ? isMultiReturnType(type) : false;
 }
 
 export function isMultiReturnCall(context: TransformationContext, expression: ts.Expression) {
@@ -35,7 +44,8 @@ export function isInMultiReturnFunction(context: TransformationContext, node: ts
         return false;
     }
     const signature = context.checker.getSignatureFromDeclaration(declaration);
-    return signature?.getReturnType().aliasSymbol?.declarations?.some(isMultiTypeDeclaration) ?? false;
+    const type = signature?.getReturnType();
+    return type ? isMultiReturnType(type) : false;
 }
 
 export function multiReturnCallShouldBeWrapped(context: TransformationContext, node: ts.CallExpression) {

--- a/src/transformation/visitors/language-extensions/multi.ts
+++ b/src/transformation/visitors/language-extensions/multi.ts
@@ -1,22 +1,10 @@
 import * as ts from "typescript";
-import * as lua from "../../../LuaAST";
 import * as extensions from "../../utils/language-extensions";
 import { TransformationContext } from "../../context";
-import { transformAssignmentLeftHandSideExpression } from "../binary-expression/assignments";
-import { transformIdentifier } from "../identifier";
-import { transformArguments } from "../call";
-import { getDependenciesOfSymbol, createExportedIdentifier } from "../../utils/export";
-import { createLocalOrExportedOrGlobalDeclaration } from "../../utils/lua-ast";
 import {
-    invalidMultiTypeArrayBindingPatternElementInitializer,
-    invalidMultiTypeArrayLiteralElementInitializer,
-    invalidMultiTypeToEmptyPatternOrArrayLiteral,
-    invalidMultiTypeToNonArrayBindingPattern,
-    invalidMultiTypeToNonArrayLiteral,
-    unsupportedMultiFunctionAssignment,
     invalidMultiFunctionUse,
 } from "../../utils/diagnostics";
-import { assert } from "../../../utils";
+import { findFirstNodeAbove } from "../../utils/typescript";
 
 const isMultiFunctionDeclaration = (declaration: ts.Declaration): boolean =>
     extensions.getExtensionKind(declaration) === extensions.ExtensionKind.MultiFunction;
@@ -39,131 +27,42 @@ export function isMultiFunctionNode(context: TransformationContext, node: ts.Nod
     return type.symbol?.declarations?.some(isMultiFunctionDeclaration) ?? false;
 }
 
-export function transformMultiCallExpressionToReturnStatement(
-    context: TransformationContext,
-    expression: ts.Expression
-): lua.Statement {
-    assert(ts.isCallExpression(expression));
-
-    const expressions = transformArguments(context, expression.arguments);
-    return lua.createReturnStatement(expressions, expression);
+export function isInMultiReturnFunction(node: ts.Node) {
+    const declaration = findFirstNodeAbove(node, ts.isFunctionDeclaration)
+    return declaration ? isMultiFunctionDeclaration(declaration) : false;
 }
 
-export function transformMultiReturnStatement(
-    context: TransformationContext,
-    statement: ts.ReturnStatement
-): lua.Statement {
-    assert(statement.expression);
-
-    return transformMultiCallExpressionToReturnStatement(context, statement.expression);
-}
-
-function transformMultiFunctionArguments(
-    context: TransformationContext,
-    expression: ts.CallExpression
-): lua.Expression[] | lua.Expression {
-    if (!isMultiFunction(context, expression)) {
-        return context.transformExpression(expression);
+export function multiReturnCallShouldBeWrapped(context: TransformationContext, node: ts.CallExpression) {
+    if (!returnsMultiType(context, node)) {
+        return false;
     }
 
-    if (expression.arguments.length === 0) {
-        return lua.createNilLiteral(expression);
+    // Variable declaration with destructuring
+    if (ts.isVariableDeclaration(node.parent) && ts.isArrayBindingPattern(node.parent.name)) {
+        return false;
     }
 
-    return expression.arguments.map(e => context.transformExpression(e));
-}
-
-export function transformMultiVariableDeclaration(
-    context: TransformationContext,
-    declaration: ts.VariableDeclaration
-): lua.Statement[] {
-    assert(declaration.initializer);
-    assert(ts.isCallExpression(declaration.initializer));
-
-    if (!ts.isArrayBindingPattern(declaration.name)) {
-        context.diagnostics.push(invalidMultiTypeToNonArrayBindingPattern(declaration.name));
-        return [];
+    // Variable assignment with destructuring
+    if (ts.isBinaryExpression(node.parent) && node.parent.operatorToken.kind === ts.SyntaxKind.EqualsToken && ts.isArrayLiteralExpression(node.parent.left)) {
+        return false;
     }
 
-    if (declaration.name.elements.length < 1) {
-        context.diagnostics.push(invalidMultiTypeToEmptyPatternOrArrayLiteral(declaration.name));
-        return [];
+    // Spread operator
+    if (ts.isSpreadElement(node.parent)) {
+        return false;
     }
 
-    if (declaration.name.elements.some(e => ts.isBindingElement(e) && e.initializer)) {
-        context.diagnostics.push(invalidMultiTypeArrayBindingPatternElementInitializer(declaration.name));
-        return [];
+    // Stand-alone expression
+    if (ts.isExpressionStatement(node.parent)) {
+        return false;
     }
 
-    if (isMultiFunction(context, declaration.initializer)) {
-        context.diagnostics.push(invalidMultiFunctionUse(declaration.initializer));
-        return [];
+    // Forwarded multi-return call
+    if (ts.isReturnStatement(node.parent) && isInMultiReturnFunction(node.parent)) {
+        return false;
     }
 
-    const leftIdentifiers: lua.Identifier[] = [];
-
-    for (const element of declaration.name.elements) {
-        if (ts.isBindingElement(element)) {
-            if (ts.isIdentifier(element.name)) {
-                leftIdentifiers.push(transformIdentifier(context, element.name));
-            } else {
-                context.diagnostics.push(unsupportedMultiFunctionAssignment(element));
-            }
-        } else if (ts.isOmittedExpression(element)) {
-            leftIdentifiers.push(lua.createAnonymousIdentifier(element));
-        }
-    }
-
-    const rightExpressions = transformMultiFunctionArguments(context, declaration.initializer);
-    return createLocalOrExportedOrGlobalDeclaration(context, leftIdentifiers, rightExpressions, declaration);
-}
-
-export function transformMultiDestructuringAssignmentStatement(
-    context: TransformationContext,
-    statement: ts.ExpressionStatement
-): lua.Statement[] | undefined {
-    assert(ts.isBinaryExpression(statement.expression));
-    assert(ts.isCallExpression(statement.expression.right));
-
-    if (!ts.isArrayLiteralExpression(statement.expression.left)) {
-        context.diagnostics.push(invalidMultiTypeToNonArrayLiteral(statement.expression.left));
-        return [];
-    }
-
-    if (statement.expression.left.elements.some(ts.isBinaryExpression)) {
-        context.diagnostics.push(invalidMultiTypeArrayLiteralElementInitializer(statement.expression.left));
-        return [];
-    }
-
-    if (statement.expression.left.elements.length < 1) {
-        context.diagnostics.push(invalidMultiTypeToEmptyPatternOrArrayLiteral(statement.expression.left));
-        return [];
-    }
-
-    if (isMultiFunction(context, statement.expression.right)) {
-        context.diagnostics.push(invalidMultiFunctionUse(statement.expression.right));
-        return [];
-    }
-
-    const transformLeft = (expression: ts.Expression): lua.AssignmentLeftHandSideExpression =>
-        ts.isOmittedExpression(expression)
-            ? lua.createAnonymousIdentifier(expression)
-            : transformAssignmentLeftHandSideExpression(context, expression);
-
-    const leftIdentifiers = statement.expression.left.elements.map(transformLeft);
-
-    const rightExpressions = transformMultiFunctionArguments(context, statement.expression.right);
-
-    const trailingStatements = statement.expression.left.elements.flatMap(expression => {
-        const symbol = context.checker.getSymbolAtLocation(expression);
-        const dependentSymbols = symbol ? getDependenciesOfSymbol(context, symbol) : [];
-        return dependentSymbols.map(symbol => {
-            const identifierToAssign = createExportedIdentifier(context, lua.createIdentifier(symbol.name));
-            return lua.createAssignmentStatement(identifierToAssign, transformLeft(expression));
-        });
-    });
-
-    return [lua.createAssignmentStatement(leftIdentifiers, rightExpressions, statement), ...trailingStatements];
+    return true;
 }
 
 export function findMultiAssignmentViolations(

--- a/src/transformation/visitors/language-extensions/multi.ts
+++ b/src/transformation/visitors/language-extensions/multi.ts
@@ -44,7 +44,7 @@ export function isInMultiReturnFunction(context: TransformationContext, node: ts
     return type ? isMultiReturnType(type) : false;
 }
 
-export function multiReturnCallShouldBeWrapped(context: TransformationContext, node: ts.CallExpression) {
+export function shouldMultiReturnCallBeWrapped(context: TransformationContext, node: ts.CallExpression) {
     if (!returnsMultiType(context, node)) {
         return false;
     }

--- a/src/transformation/visitors/return.ts
+++ b/src/transformation/visitors/return.ts
@@ -9,7 +9,7 @@ import { isArrayType } from "../utils/typescript";
 import { transformArguments } from "./call";
 import {
     returnsMultiType,
-    multiReturnCallShouldBeWrapped,
+    shouldMultiReturnCallBeWrapped,
     isMultiFunctionCall,
     isMultiReturnType,
 } from "./language-extensions/multi";
@@ -37,7 +37,7 @@ function transformExpressionsInReturn(
         }
 
         // Force-wrap LuaMultiReturn when returning inside try/catch
-        if (insideTryCatch && returnsMultiType(context, node) && !multiReturnCallShouldBeWrapped(context, node)) {
+        if (insideTryCatch && returnsMultiType(context, node) && !shouldMultiReturnCallBeWrapped(context, node)) {
             return [wrapInTable(context.transformExpression(node))];
         }
     }

--- a/src/transformation/visitors/return.ts
+++ b/src/transformation/visitors/return.ts
@@ -10,7 +10,7 @@ import { transformArguments } from "./call";
 import {
     returnsMultiType,
     multiReturnCallShouldBeWrapped,
-    isMultiFunction,
+    isMultiFunctionCall,
     isMultiReturnType,
 } from "./language-extensions/multi";
 import { invalidMultiFunctionReturnType } from "../utils/diagnostics";
@@ -22,7 +22,7 @@ function transformExpressionsInReturn(
 ): lua.Expression[] {
     if (ts.isCallExpression(node)) {
         // $multi(...)
-        if (isMultiFunction(context, node)) {
+        if (isMultiFunctionCall(context, node)) {
             // Don't allow $multi to be implicitly cast to something other than LuaMultiReturn
             const type = context.checker.getContextualType(node);
             if (type && !isMultiReturnType(type)) {

--- a/src/transformation/visitors/variable-declaration.ts
+++ b/src/transformation/visitors/variable-declaration.ts
@@ -10,7 +10,6 @@ import { createLocalOrExportedOrGlobalDeclaration, createUnpackCall } from "../u
 import { LuaLibFeature, transformLuaLibFunction } from "../utils/lualib";
 import { transformIdentifier } from "./identifier";
 import { transformPropertyName } from "./literal";
-import { returnsMultiType, transformMultiVariableDeclaration } from "./language-extensions/multi";
 
 export function transformArrayBindingElement(
     context: TransformationContext,
@@ -230,14 +229,6 @@ export function transformVariableDeclaration(
     context: TransformationContext,
     statement: ts.VariableDeclaration
 ): lua.Statement[] {
-    if (
-        statement.initializer &&
-        ts.isCallExpression(statement.initializer) &&
-        returnsMultiType(context, statement.initializer)
-    ) {
-        return transformMultiVariableDeclaration(context, statement);
-    }
-
     if (statement.initializer && statement.type) {
         const initializerType = context.checker.getTypeAtLocation(statement.initializer);
         const varType = context.checker.getTypeFromTypeNode(statement.type);

--- a/src/transformation/visitors/variable-declaration.ts
+++ b/src/transformation/visitors/variable-declaration.ts
@@ -9,6 +9,7 @@ import { addExportToIdentifier } from "../utils/export";
 import { createLocalOrExportedOrGlobalDeclaration, createUnpackCall } from "../utils/lua-ast";
 import { LuaLibFeature, transformLuaLibFunction } from "../utils/lualib";
 import { transformIdentifier } from "./identifier";
+import { isMultiReturnCall } from "./language-extensions/multi";
 import { transformPropertyName } from "./literal";
 
 export function transformArrayBindingElement(
@@ -172,8 +173,8 @@ export function transformBindingVariableDeclaration(
             : lua.createAnonymousIdentifier();
 
     if (initializer) {
-        if (isTupleReturnCall(context, initializer)) {
-            // Don't unpack @tupleReturn annotated functions
+        if (isTupleReturnCall(context, initializer) || isMultiReturnCall(context, initializer)) {
+            // Don't unpack @tupleReturn or LuaMultiReturn functions
             statements.push(
                 ...createLocalOrExportedOrGlobalDeclaration(
                     context,

--- a/test/unit/language-extensions/__snapshots__/multi.spec.ts.snap
+++ b/test/unit/language-extensions/__snapshots__/multi.spec.ts.snap
@@ -22,7 +22,9 @@ function ____exports.__main(self)
         local args = {...}
         return table.unpack(args)
     end
-    return multi(nil).forEach
+    return ({
+        multi(nil)
+    }).forEach
 end
 return ____exports"
 `;
@@ -42,7 +44,9 @@ exports[`invalid $multi call ($multi): diagnostics 1`] = `"main.ts(2,9): error T
 exports[`invalid $multi call (([a] = $multi(1)) => {}): code 1`] = `
 "local function ____(____, ____bindingPattern0)
     if ____bindingPattern0 == nil then
-        ____bindingPattern0 = ____(_G, 1)
+        ____bindingPattern0 = {
+            ____(_G, 1)
+        }
     end
     local a = ____bindingPattern0[1]
 end"
@@ -54,17 +58,30 @@ exports[`invalid $multi call (({ $multi });): code 1`] = `"local ____ = nil"`;
 
 exports[`invalid $multi call (({ $multi });): diagnostics 1`] = `"main.ts(2,12): error TSTL: The $multi function must be called in an expression that is returned."`;
 
-exports[`invalid $multi call (const [a = 0] = $multi()): code 1`] = `""`;
+exports[`invalid $multi call (const [a = 0] = $multi()): code 1`] = `
+"a = ____(_G)
+if a == nil then
+    a = 0
+end"
+`;
 
-exports[`invalid $multi call (const [a = 0] = $multi()): diagnostics 1`] = `"main.ts(2,15): error TSTL: This array binding pattern cannot have initializers."`;
+exports[`invalid $multi call (const [a = 0] = $multi()): diagnostics 1`] = `"main.ts(2,25): error TSTL: The $multi function must be called in an expression that is returned."`;
 
-exports[`invalid $multi call (const {} = $multi();): code 1`] = `""`;
+exports[`invalid $multi call (const {} = $multi();): code 1`] = `
+"local ____ = {
+    ____(_G)
+}"
+`;
 
-exports[`invalid $multi call (const {} = $multi();): diagnostics 1`] = `"main.ts(2,15): error TSTL: Expected an array destructuring pattern."`;
+exports[`invalid $multi call (const {} = $multi();): diagnostics 1`] = `"main.ts(2,20): error TSTL: The $multi function must be called in an expression that is returned."`;
 
-exports[`invalid $multi call (const a = $multi();): code 1`] = `""`;
+exports[`invalid $multi call (const a = $multi();): code 1`] = `
+"a = {
+    ____(_G)
+}"
+`;
 
-exports[`invalid $multi call (const a = $multi();): diagnostics 1`] = `"main.ts(2,15): error TSTL: Expected an array destructuring pattern."`;
+exports[`invalid $multi call (const a = $multi();): diagnostics 1`] = `"main.ts(2,19): error TSTL: The $multi function must be called in an expression that is returned."`;
 
 exports[`invalid direct $multi function use (const [a] = $multi()): code 1`] = `
 "local ____exports = {}
@@ -72,6 +89,7 @@ local function multi(self, ...)
     local args = {...}
     return table.unpack(args)
 end
+local a = ____(nil)
 ____exports.a = a
 return ____exports"
 `;
@@ -84,6 +102,7 @@ local function multi(self, ...)
     local args = {...}
     return table.unpack(args)
 end
+local a = ____(nil, 1)
 ____exports.a = a
 return ____exports"
 `;
@@ -97,6 +116,7 @@ local function multi(self, ...)
     return table.unpack(args)
 end
 local _ = nil
+local a = ____(nil, 1)
 ____exports.a = a
 return ____exports"
 `;
@@ -110,6 +130,10 @@ local function multi(self, ...)
     return table.unpack(args)
 end
 local ar = {1}
+local a = ____(
+    nil,
+    table.unpack(ar)
+)
 ____exports.a = a
 return ____exports"
 `;
@@ -123,6 +147,11 @@ local function multi(self, ...)
     return table.unpack(args)
 end
 local a
+local ____ = {
+    ____(nil)
+}
+a = ____[1]
+____exports.a = a
 ____exports.a = a
 return ____exports"
 `;
@@ -137,6 +166,11 @@ local function multi(self, ...)
 end
 local a
 do
+    local ____ = {
+        ____(nil, 1, 2)
+    }
+    a = ____[1]
+    ____exports.a = a
     while false do
         local ____ = 1
     end
@@ -155,6 +189,7 @@ local function multi(self, ...)
 end
 local a
 do
+    local a = ____(nil, 1, 2)
     while false do
         local ____ = 1
     end

--- a/test/unit/language-extensions/__snapshots__/multi.spec.ts.snap
+++ b/test/unit/language-extensions/__snapshots__/multi.spec.ts.snap
@@ -83,6 +83,46 @@ exports[`invalid $multi call (const a = $multi();): code 1`] = `
 
 exports[`invalid $multi call (const a = $multi();): diagnostics 1`] = `"main.ts(2,19): error TSTL: The $multi function must be called in an expression that is returned."`;
 
+exports[`invalid $multi implicit cast: code 1`] = `
+"function badMulti(self)
+    return \\"foo\\", 42
+end"
+`;
+
+exports[`invalid $multi implicit cast: diagnostics 1`] = `"main.ts(3,20): error TSTL: The $multi function can only be used to return a LuaMultiReturn type."`;
+
+exports[`invalid direct $multi function use (const [a = 1] = $multi()): code 1`] = `
+"local ____exports = {}
+local function multi(self, ...)
+    local args = {...}
+    return table.unpack(args)
+end
+local a = ____(nil)
+if a == nil then
+    a = 1
+end
+____exports.a = a
+return ____exports"
+`;
+
+exports[`invalid direct $multi function use (const [a = 1] = $multi()): diagnostics 1`] = `"main.ts(7,25): error TSTL: The $multi function must be called in an expression that is returned."`;
+
+exports[`invalid direct $multi function use (const [a = 1] = $multi(2)): code 1`] = `
+"local ____exports = {}
+local function multi(self, ...)
+    local args = {...}
+    return table.unpack(args)
+end
+local a = ____(nil, 2)
+if a == nil then
+    a = 1
+end
+____exports.a = a
+return ____exports"
+`;
+
+exports[`invalid direct $multi function use (const [a = 1] = $multi(2)): diagnostics 1`] = `"main.ts(7,25): error TSTL: The $multi function must be called in an expression that is returned."`;
+
 exports[`invalid direct $multi function use (const [a] = $multi()): code 1`] = `
 "local ____exports = {}
 local function multi(self, ...)

--- a/test/unit/language-extensions/__snapshots__/multi.spec.ts.snap
+++ b/test/unit/language-extensions/__snapshots__/multi.spec.ts.snap
@@ -239,3 +239,27 @@ return ____exports"
 `;
 
 exports[`invalid direct $multi function use (let a; for (const [a] = $multi(1, 2); false; 1) {}): diagnostics 1`] = `"main.ts(7,33): error TSTL: The $multi function must be called in an expression that is returned."`;
+
+exports[`invalid direct $multi function use (let a; if ([a] = $multi(1)) { ++a; }): code 1`] = `
+"local ____exports = {}
+local function multi(self, ...)
+    local args = {...}
+    return table.unpack(args)
+end
+local a
+if (function()
+    local ____ = {
+        ____(nil, 1)
+    }
+    a = ____[1]
+    ____exports.a = a
+    return ____
+end)() then
+    a = a + 1
+    ____exports.a = a
+end
+____exports.a = a
+return ____exports"
+`;
+
+exports[`invalid direct $multi function use (let a; if ([a] = $multi(1)) { ++a; }): diagnostics 1`] = `"main.ts(7,26): error TSTL: The $multi function must be called in an expression that is returned."`;

--- a/test/unit/language-extensions/__snapshots__/multi.spec.ts.snap
+++ b/test/unit/language-extensions/__snapshots__/multi.spec.ts.snap
@@ -35,11 +35,11 @@ exports[`disallow LuaMultiReturn non-numeric access: diagnostics 2`] = `"main.ts
 
 exports[`invalid $multi call ($multi()): code 1`] = `"____(_G)"`;
 
-exports[`invalid $multi call ($multi()): diagnostics 1`] = `"main.ts(2,9): error TSTL: The $multi function must be called in an expression that is returned."`;
+exports[`invalid $multi call ($multi()): diagnostics 1`] = `"main.ts(2,9): error TSTL: The $multi function must be called in a return statement."`;
 
 exports[`invalid $multi call ($multi): code 1`] = `"local ____ = ____"`;
 
-exports[`invalid $multi call ($multi): diagnostics 1`] = `"main.ts(2,9): error TSTL: The $multi function must be called in an expression that is returned."`;
+exports[`invalid $multi call ($multi): diagnostics 1`] = `"main.ts(2,9): error TSTL: The $multi function must be called in a return statement."`;
 
 exports[`invalid $multi call (([a] = $multi(1)) => {}): code 1`] = `
 "local function ____(____, ____bindingPattern0)
@@ -52,11 +52,11 @@ exports[`invalid $multi call (([a] = $multi(1)) => {}): code 1`] = `
 end"
 `;
 
-exports[`invalid $multi call (([a] = $multi(1)) => {}): diagnostics 1`] = `"main.ts(2,16): error TSTL: The $multi function must be called in an expression that is returned."`;
+exports[`invalid $multi call (([a] = $multi(1)) => {}): diagnostics 1`] = `"main.ts(2,16): error TSTL: The $multi function must be called in a return statement."`;
 
 exports[`invalid $multi call (({ $multi });): code 1`] = `"local ____ = nil"`;
 
-exports[`invalid $multi call (({ $multi });): diagnostics 1`] = `"main.ts(2,12): error TSTL: The $multi function must be called in an expression that is returned."`;
+exports[`invalid $multi call (({ $multi });): diagnostics 1`] = `"main.ts(2,12): error TSTL: The $multi function must be called in a return statement."`;
 
 exports[`invalid $multi call (const [a = 0] = $multi()): code 1`] = `
 "a = ____(_G)
@@ -65,7 +65,7 @@ if a == nil then
 end"
 `;
 
-exports[`invalid $multi call (const [a = 0] = $multi()): diagnostics 1`] = `"main.ts(2,25): error TSTL: The $multi function must be called in an expression that is returned."`;
+exports[`invalid $multi call (const [a = 0] = $multi()): diagnostics 1`] = `"main.ts(2,25): error TSTL: The $multi function must be called in a return statement."`;
 
 exports[`invalid $multi call (const {} = $multi();): code 1`] = `
 "local ____ = {
@@ -73,7 +73,7 @@ exports[`invalid $multi call (const {} = $multi();): code 1`] = `
 }"
 `;
 
-exports[`invalid $multi call (const {} = $multi();): diagnostics 1`] = `"main.ts(2,20): error TSTL: The $multi function must be called in an expression that is returned."`;
+exports[`invalid $multi call (const {} = $multi();): diagnostics 1`] = `"main.ts(2,20): error TSTL: The $multi function must be called in a return statement."`;
 
 exports[`invalid $multi call (const a = $multi();): code 1`] = `
 "a = {
@@ -81,7 +81,7 @@ exports[`invalid $multi call (const a = $multi();): code 1`] = `
 }"
 `;
 
-exports[`invalid $multi call (const a = $multi();): diagnostics 1`] = `"main.ts(2,19): error TSTL: The $multi function must be called in an expression that is returned."`;
+exports[`invalid $multi call (const a = $multi();): diagnostics 1`] = `"main.ts(2,19): error TSTL: The $multi function must be called in a return statement."`;
 
 exports[`invalid $multi implicit cast: code 1`] = `
 "function badMulti(self)
@@ -89,7 +89,7 @@ exports[`invalid $multi implicit cast: code 1`] = `
 end"
 `;
 
-exports[`invalid $multi implicit cast: diagnostics 1`] = `"main.ts(3,20): error TSTL: The $multi function can only be used to return a LuaMultiReturn type."`;
+exports[`invalid $multi implicit cast: diagnostics 1`] = `"main.ts(3,20): error TSTL: The $multi function cannot be cast to a non-LuaMultiReturn type."`;
 
 exports[`invalid direct $multi function use (const [a = 1] = $multi()): code 1`] = `
 "local ____exports = {}
@@ -105,7 +105,7 @@ ____exports.a = a
 return ____exports"
 `;
 
-exports[`invalid direct $multi function use (const [a = 1] = $multi()): diagnostics 1`] = `"main.ts(7,25): error TSTL: The $multi function must be called in an expression that is returned."`;
+exports[`invalid direct $multi function use (const [a = 1] = $multi()): diagnostics 1`] = `"main.ts(7,25): error TSTL: The $multi function must be called in a return statement."`;
 
 exports[`invalid direct $multi function use (const [a = 1] = $multi(2)): code 1`] = `
 "local ____exports = {}
@@ -121,7 +121,7 @@ ____exports.a = a
 return ____exports"
 `;
 
-exports[`invalid direct $multi function use (const [a = 1] = $multi(2)): diagnostics 1`] = `"main.ts(7,25): error TSTL: The $multi function must be called in an expression that is returned."`;
+exports[`invalid direct $multi function use (const [a = 1] = $multi(2)): diagnostics 1`] = `"main.ts(7,25): error TSTL: The $multi function must be called in a return statement."`;
 
 exports[`invalid direct $multi function use (const [a] = $multi()): code 1`] = `
 "local ____exports = {}
@@ -134,7 +134,7 @@ ____exports.a = a
 return ____exports"
 `;
 
-exports[`invalid direct $multi function use (const [a] = $multi()): diagnostics 1`] = `"main.ts(7,21): error TSTL: The $multi function must be called in an expression that is returned."`;
+exports[`invalid direct $multi function use (const [a] = $multi()): diagnostics 1`] = `"main.ts(7,21): error TSTL: The $multi function must be called in a return statement."`;
 
 exports[`invalid direct $multi function use (const [a] = $multi(1)): code 1`] = `
 "local ____exports = {}
@@ -147,7 +147,7 @@ ____exports.a = a
 return ____exports"
 `;
 
-exports[`invalid direct $multi function use (const [a] = $multi(1)): diagnostics 1`] = `"main.ts(7,21): error TSTL: The $multi function must be called in an expression that is returned."`;
+exports[`invalid direct $multi function use (const [a] = $multi(1)): diagnostics 1`] = `"main.ts(7,21): error TSTL: The $multi function must be called in a return statement."`;
 
 exports[`invalid direct $multi function use (const _ = null, [a] = $multi(1)): code 1`] = `
 "local ____exports = {}
@@ -161,7 +161,7 @@ ____exports.a = a
 return ____exports"
 `;
 
-exports[`invalid direct $multi function use (const _ = null, [a] = $multi(1)): diagnostics 1`] = `"main.ts(7,31): error TSTL: The $multi function must be called in an expression that is returned."`;
+exports[`invalid direct $multi function use (const _ = null, [a] = $multi(1)): diagnostics 1`] = `"main.ts(7,31): error TSTL: The $multi function must be called in a return statement."`;
 
 exports[`invalid direct $multi function use (const ar = [1]; const [a] = $multi(...ar)): code 1`] = `
 "local ____exports = {}
@@ -178,7 +178,7 @@ ____exports.a = a
 return ____exports"
 `;
 
-exports[`invalid direct $multi function use (const ar = [1]; const [a] = $multi(...ar)): diagnostics 1`] = `"main.ts(7,37): error TSTL: The $multi function must be called in an expression that is returned."`;
+exports[`invalid direct $multi function use (const ar = [1]; const [a] = $multi(...ar)): diagnostics 1`] = `"main.ts(7,37): error TSTL: The $multi function must be called in a return statement."`;
 
 exports[`invalid direct $multi function use (let a; [a] = $multi()): code 1`] = `
 "local ____exports = {}
@@ -196,7 +196,7 @@ ____exports.a = a
 return ____exports"
 `;
 
-exports[`invalid direct $multi function use (let a; [a] = $multi()): diagnostics 1`] = `"main.ts(7,22): error TSTL: The $multi function must be called in an expression that is returned."`;
+exports[`invalid direct $multi function use (let a; [a] = $multi()): diagnostics 1`] = `"main.ts(7,22): error TSTL: The $multi function must be called in a return statement."`;
 
 exports[`invalid direct $multi function use (let a; for ([a] = $multi(1, 2); false; 1) {}): code 1`] = `
 "local ____exports = {}
@@ -219,7 +219,7 @@ ____exports.a = a
 return ____exports"
 `;
 
-exports[`invalid direct $multi function use (let a; for ([a] = $multi(1, 2); false; 1) {}): diagnostics 1`] = `"main.ts(7,27): error TSTL: The $multi function must be called in an expression that is returned."`;
+exports[`invalid direct $multi function use (let a; for ([a] = $multi(1, 2); false; 1) {}): diagnostics 1`] = `"main.ts(7,27): error TSTL: The $multi function must be called in a return statement."`;
 
 exports[`invalid direct $multi function use (let a; for (const [a] = $multi(1, 2); false; 1) {}): code 1`] = `
 "local ____exports = {}
@@ -238,7 +238,7 @@ ____exports.a = a
 return ____exports"
 `;
 
-exports[`invalid direct $multi function use (let a; for (const [a] = $multi(1, 2); false; 1) {}): diagnostics 1`] = `"main.ts(7,33): error TSTL: The $multi function must be called in an expression that is returned."`;
+exports[`invalid direct $multi function use (let a; for (const [a] = $multi(1, 2); false; 1) {}): diagnostics 1`] = `"main.ts(7,33): error TSTL: The $multi function must be called in a return statement."`;
 
 exports[`invalid direct $multi function use (let a; if ([a] = $multi(1)) { ++a; }): code 1`] = `
 "local ____exports = {}
@@ -262,4 +262,4 @@ ____exports.a = a
 return ____exports"
 `;
 
-exports[`invalid direct $multi function use (let a; if ([a] = $multi(1)) { ++a; }): diagnostics 1`] = `"main.ts(7,26): error TSTL: The $multi function must be called in an expression that is returned."`;
+exports[`invalid direct $multi function use (let a; if ([a] = $multi(1)) { ++a; }): diagnostics 1`] = `"main.ts(7,26): error TSTL: The $multi function must be called in a return statement."`;

--- a/test/unit/language-extensions/__snapshots__/multi.spec.ts.snap
+++ b/test/unit/language-extensions/__snapshots__/multi.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`disallow MultiReturn non-numeric access: code 1`] = `
+exports[`disallow LuaMultiReturn non-numeric access: code 1`] = `
 "local ____exports = {}
 function ____exports.__main(self)
     local function multi(self, ...)
@@ -15,7 +15,7 @@ end
 return ____exports"
 `;
 
-exports[`disallow MultiReturn non-numeric access: code 2`] = `
+exports[`disallow LuaMultiReturn non-numeric access: code 2`] = `
 "local ____exports = {}
 function ____exports.__main(self)
     local function multi(self, ...)
@@ -27,9 +27,9 @@ end
 return ____exports"
 `;
 
-exports[`disallow MultiReturn non-numeric access: diagnostics 1`] = `"main.ts(7,16): error TSTL: The MultiReturn type can only be accessed via an element access expression of a numeric type."`;
+exports[`disallow LuaMultiReturn non-numeric access: diagnostics 1`] = `"main.ts(7,16): error TSTL: The LuaMultiReturn type can only be accessed via an element access expression of a numeric type."`;
 
-exports[`disallow MultiReturn non-numeric access: diagnostics 2`] = `"main.ts(7,16): error TSTL: The MultiReturn type can only be accessed via an element access expression of a numeric type."`;
+exports[`disallow LuaMultiReturn non-numeric access: diagnostics 2`] = `"main.ts(7,16): error TSTL: The LuaMultiReturn type can only be accessed via an element access expression of a numeric type."`;
 
 exports[`invalid $multi call ($multi()): code 1`] = `"____(_G)"`;
 

--- a/test/unit/language-extensions/multi.spec.ts
+++ b/test/unit/language-extensions/multi.spec.ts
@@ -14,7 +14,7 @@ const multiProjectOptions: tstl.CompilerOptions = {
 
 test("multi example use case", () => {
     util.testModule`
-        function multiReturn(): MultiReturn<[string, number]> {
+        function multiReturn(): LuaMultiReturn<[string, number]> {
             return $multi("foo", 5);
         }
 
@@ -128,7 +128,7 @@ test("allow $multi call in ArrowFunction body", () => {
         .expectToEqual(1);
 });
 
-test.each(["0", "i"])("allow MultiReturn numeric access", expression => {
+test.each(["0", "i"])("allow LuaMultiReturn numeric access", expression => {
     util.testFunction`
         ${multiFunction}
         const i = 0;
@@ -138,7 +138,7 @@ test.each(["0", "i"])("allow MultiReturn numeric access", expression => {
         .expectToEqual(1);
 });
 
-test.each(["multi()['forEach']", "multi().forEach"])("disallow MultiReturn non-numeric access", expression => {
+test.each(["multi()['forEach']", "multi().forEach"])("disallow LuaMultiReturn non-numeric access", expression => {
     util.testFunction`
         ${multiFunction}
         return ${expression};

--- a/test/unit/language-extensions/multi.spec.ts
+++ b/test/unit/language-extensions/multi.spec.ts
@@ -52,6 +52,7 @@ const createCasesThatCall = (name: string): Array<[string, any]> => [
     [`const _ = null, [a] = ${name}(1)`, 1],
     [`let a; for (const [a] = ${name}(1, 2); false; 1) {}`, undefined],
     [`let a; for ([a] = ${name}(1, 2); false; 1) {}`, 1],
+    [`let a; if ([a] = ${name}(1)) { ++a; }`, 2],
 ];
 
 test.each<[string, any]>(createCasesThatCall("$multi"))("invalid direct $multi function use (%s)", statement => {

--- a/test/unit/language-extensions/multi.spec.ts
+++ b/test/unit/language-extensions/multi.spec.ts
@@ -190,3 +190,67 @@ test.each([
         .setOptions(multiProjectOptions)
         .expectToEqual(result);
 });
+
+test("return $multi from try", () => {
+    util.testFunction`
+        function multiTest() {
+            try {
+                return $multi(1, 2);
+            } catch {
+            }
+        }
+        const [_, a] = multiTest();
+        return a;
+    `
+        .setOptions(multiProjectOptions)
+        .expectToEqual(2);
+});
+
+test("return $multi from catch", () => {
+    util.testFunction`
+        function multiTest() {
+            try {
+                throw "error";
+            } catch {
+                return $multi(1, 2);
+            }
+        }
+        const [_, a] = multiTest();
+        return a;
+    `
+        .setOptions(multiProjectOptions)
+        .expectToEqual(2);
+});
+
+test("return LuaMultiReturn from try", () => {
+    util.testFunction`
+        ${multiFunction}
+        function multiTest() {
+            try {
+                return multi(1, 2);
+            } catch {
+            }
+        }
+        const [_, a] = multiTest();
+        return a;
+    `
+        .setOptions(multiProjectOptions)
+        .expectToEqual(2);
+});
+
+test("return LuaMultiReturn from catch", () => {
+    util.testFunction`
+        ${multiFunction}
+        function multiTest() {
+            try {
+                throw "error";
+            } catch {
+                return multi(1, 2);
+            }
+        }
+        const [_, a] = multiTest();
+        return a;
+    `
+        .setOptions(multiProjectOptions)
+        .expectToEqual(2);
+});

--- a/test/unit/language-extensions/multi.spec.ts
+++ b/test/unit/language-extensions/multi.spec.ts
@@ -1,12 +1,7 @@
 import * as path from "path";
 import * as util from "../../util";
 import * as tstl from "../../../src";
-import {
-    invalidMultiFunctionUse,
-    invalidMultiTypeToNonArrayBindingPattern,
-    invalidMultiTypeArrayBindingPatternElementInitializer,
-    invalidMultiReturnAccess,
-} from "../../../src/transformation/utils/diagnostics";
+import { invalidMultiFunctionUse, invalidMultiReturnAccess } from "../../../src/transformation/utils/diagnostics";
 
 const multiProjectOptions: tstl.CompilerOptions = {
     types: [path.resolve(__dirname, "../../../language-extensions")],
@@ -82,10 +77,10 @@ test.each<[string, number[]]>([
     ["$multi", [invalidMultiFunctionUse.code]],
     ["$multi()", [invalidMultiFunctionUse.code]],
     ["({ $multi });", [invalidMultiFunctionUse.code]],
-    ["const a = $multi();", [invalidMultiTypeToNonArrayBindingPattern.code]],
-    ["const {} = $multi();", [invalidMultiTypeToNonArrayBindingPattern.code]],
+    ["const a = $multi();", [invalidMultiFunctionUse.code]],
+    ["const {} = $multi();", [invalidMultiFunctionUse.code]],
     ["([a] = $multi(1)) => {}", [invalidMultiFunctionUse.code]],
-    ["const [a = 0] = $multi()", [invalidMultiTypeArrayBindingPatternElementInitializer.code]],
+    ["const [a = 0] = $multi()", [invalidMultiFunctionUse.code]],
 ])("invalid $multi call (%s)", (statement, diagnostics) => {
     util.testModule`
         ${statement}
@@ -128,7 +123,7 @@ test("allow $multi call in ArrowFunction body", () => {
         .expectToEqual(1);
 });
 
-test.each(["0", "i"])("allow LuaMultiReturn numeric access", expression => {
+test.each(["0", "i"])("allow LuaMultiReturn numeric access (%s)", expression => {
     util.testFunction`
         ${multiFunction}
         const i = 0;


### PR DESCRIPTION
This turned into a somewhat major refactor on the multi-return stuff, as I ran into more unhandled cases along the way.

Here's the main things this PR does:
- Rename `MultiReturn` to `LuaMultiReturn` for consistency with other lib extensions
- Added doc comments to multi-return stuff in lib extension declarations
- Fixed #968 
- Enabled support for assigning multi-return values without destructuring, by wrapping call in a table
- Fixed broken code generation with assignment expressions and try/catch blocks
- Added a diagnostic for cases where `$multi` could be implicitly cast to something else (such as when the function explicitly defines a non-multireturn return type)
