### PR TITLE
Fix destructuring assignment of multiReturn (closes #995)

### DIFF
--- a/test/unit/language-extensions/__snapshots__/multi.spec.ts.snap
+++ b/test/unit/language-extensions/__snapshots__/multi.spec.ts.snap
@@ -69,7 +69,9 @@ exports[`invalid $multi call (const [a = 0] = $multi()): diagnostics 1`] = `"mai
 
 exports[`invalid $multi call (const {} = $multi();): code 1`] = `
 "local ____ = {
-    ____(_G)
+    {
+        ____(_G)
+    }
 }"
 `;
 

--- a/test/unit/language-extensions/multi.spec.ts
+++ b/test/unit/language-extensions/multi.spec.ts
@@ -24,6 +24,19 @@ test("multi example use case", () => {
         .expectToEqual({ a: "foo", b: 5 });
 });
 
+test("multi #995", () => {
+    util.testModule`
+        function multiReturn(): LuaMultiReturn<[number, number, number]> {
+            return $multi(1, 2, 3);
+        }
+
+        const [a, ...b] = multiReturn();
+        export {a, b};
+    `
+        .setOptions(multiProjectOptions)
+        .expectToEqual({ a: 1, b: [2, 3] });
+});
+
 test.each<[string, any]>([
     ["$multi()", undefined],
     ["$multi(true)", true],

--- a/test/unit/language-extensions/multi.spec.ts
+++ b/test/unit/language-extensions/multi.spec.ts
@@ -24,7 +24,8 @@ test("multi example use case", () => {
         .expectToEqual({ a: "foo", b: 5 });
 });
 
-test("multi #995", () => {
+// https://github.com/TypeScriptToLua/TypeScriptToLua/issues/995
+test("Destructuring assignment of LuaMultiReturn", () => {
     util.testModule`
         function multiReturn(): LuaMultiReturn<[number, number, number]> {
             return $multi(1, 2, 3);
@@ -35,6 +36,16 @@ test("multi #995", () => {
     `
         .setOptions(multiProjectOptions)
         .expectToEqual({ a: 1, b: [2, 3] });
+    util.testModule`
+        function multiReturn(): LuaMultiReturn<[number, number, number]> {
+            return;
+        }
+
+        const [a, ...b] = multiReturn();
+        export {a, b};
+    `
+        .setOptions(multiProjectOptions)
+        .expectToEqual({ b: [] });
 });
 
 test.each<[string, any]>([

--- a/test/unit/language-extensions/multi.spec.ts
+++ b/test/unit/language-extensions/multi.spec.ts
@@ -36,6 +36,9 @@ test("Destructuring assignment of LuaMultiReturn", () => {
     `
         .setOptions(multiProjectOptions)
         .expectToEqual({ a: 1, b: [2, 3] });
+});
+
+test("Destructuring assignment of LuaMultiReturn returning nil", () => {
     util.testModule`
         function multiReturn(): LuaMultiReturn<[number, number, number]> {
             return;
@@ -45,7 +48,7 @@ test("Destructuring assignment of LuaMultiReturn", () => {
         export {a, b};
     `
         .setOptions(multiProjectOptions)
-        .expectToEqual({ b: [] });
+        .expectToEqual({ a: undefined, b: [] });
 });
 
 test.each<[string, any]>([


### PR DESCRIPTION
Fixed the issue. Turns out we were dealing with this problem on normal assignments, so something like this works:
```js
let a, b;
[a, ...b] = string.find("a", "b");
```
This is handled here: https://github.com/TypeScriptToLua/TypeScriptToLua/blob/master/src/transformation/visitors/binary-expression/assignments.ts#L94-L97

Maybe this is an indicative that this needs some refactoring, as that code should be common. However, I just fixed the issue locally, and added a test showing it is now working.

The only other change is a snapshot of a test that's supposed to fail, so that shouldn't be a problem I believe.

`npm test` works.