### PR TITLE
Add actual multi version tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
                 "jest": "^26.0.1",
                 "jest-circus": "^25.1.0",
                 "lua-types": "^2.8.0",
-                "lua-wasm-bindings": "^0.1.4",
+                "lua-wasm-bindings": "^0.2.1",
                 "prettier": "^2.0.5",
                 "ts-jest": "^26.3.0",
                 "ts-node": "^8.6.2"
@@ -8795,9 +8795,9 @@
             "dev": true
         },
         "node_modules/lua-wasm-bindings": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/lua-wasm-bindings/-/lua-wasm-bindings-0.1.4.tgz",
-            "integrity": "sha512-Hos8hbdj7YJCOyiPN1ApsFMLZylyoaGA6J5J40zzGGRz+bcz8Ui7ocI3iwOLJJC1lEBbNA8wchV9i+PyRq2SYg==",
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/lua-wasm-bindings/-/lua-wasm-bindings-0.2.1.tgz",
+            "integrity": "sha512-8oig7XmwI/Tq/hSpuBZbjyBXrw3vngUSvQ5kV3/9mGaHfJrQVd993j1HVy6CN/griuPrKsLtSEbpn8Hu79dYhg==",
             "dev": true
         },
         "node_modules/make-dir": {
@@ -18828,9 +18828,9 @@
             "dev": true
         },
         "lua-wasm-bindings": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/lua-wasm-bindings/-/lua-wasm-bindings-0.1.4.tgz",
-            "integrity": "sha512-Hos8hbdj7YJCOyiPN1ApsFMLZylyoaGA6J5J40zzGGRz+bcz8Ui7ocI3iwOLJJC1lEBbNA8wchV9i+PyRq2SYg==",
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/lua-wasm-bindings/-/lua-wasm-bindings-0.2.1.tgz",
+            "integrity": "sha512-8oig7XmwI/Tq/hSpuBZbjyBXrw3vngUSvQ5kV3/9mGaHfJrQVd993j1HVy6CN/griuPrKsLtSEbpn8Hu79dYhg==",
             "dev": true
         },
         "make-dir": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "jest": "^26.0.1",
         "jest-circus": "^25.1.0",
         "lua-types": "^2.8.0",
-        "lua-wasm-bindings": "^0.1.4",
+        "lua-wasm-bindings": "^0.2.1",
         "prettier": "^2.0.5",
         "ts-jest": "^26.3.0",
         "ts-node": "^8.6.2"

--- a/test/unit/builtins/math.spec.ts
+++ b/test/unit/builtins/math.spec.ts
@@ -37,6 +37,11 @@ util.testEachVersion("Math.atan2", () => util.testExpression`Math.atan2(4, 5)`, 
     [tstl.LuaTarget.Lua54]: builder => builder.tap(expectMathAtan2),
 });
 
-test("Math.atan2(4, 5)", () => {
-    util.testExpression`Math.atan2(4, 5)`.expectToMatchJsResult();
+util.testEachVersion("Math.atan2(4, 5)", () => util.testExpression`Math.atan2(4, 5)`, {
+    [tstl.LuaTarget.Universal]: builder => builder.expectToMatchJsResult(),
+    [tstl.LuaTarget.LuaJIT]: false,
+    [tstl.LuaTarget.Lua51]: builder => builder.expectToMatchJsResult(),
+    [tstl.LuaTarget.Lua52]: builder => builder.expectToMatchJsResult(),
+    [tstl.LuaTarget.Lua53]: builder => builder.expectToMatchJsResult(),
+    [tstl.LuaTarget.Lua54]: builder => builder.expectToMatchJsResult(),
 });

--- a/test/unit/conditionals.spec.ts
+++ b/test/unit/conditionals.spec.ts
@@ -368,9 +368,6 @@ test.each([
     { input: "true ? false : true", options: { luaTarget: tstl.LuaTarget.Lua51 } },
     { input: "false ? false : true", options: { luaTarget: tstl.LuaTarget.Lua51 } },
     { input: "true ? undefined : true", options: { luaTarget: tstl.LuaTarget.Lua51 } },
-    { input: "true ? false : true", options: { luaTarget: tstl.LuaTarget.LuaJIT } },
-    { input: "false ? false : true", options: { luaTarget: tstl.LuaTarget.LuaJIT } },
-    { input: "true ? undefined : true", options: { luaTarget: tstl.LuaTarget.LuaJIT } },
 ])("Ternary operator (%p)", ({ input, options }) => {
     util.testFunction`
         const literalValue = "literal";

--- a/test/unit/loops.spec.ts
+++ b/test/unit/loops.spec.ts
@@ -2,15 +2,6 @@ import * as tstl from "../../src";
 import { forbiddenForIn, unsupportedForTarget } from "../../src/transformation/utils/diagnostics";
 import * as util from "../util";
 
-const multiVersionContinueExpects = {
-    [tstl.LuaTarget.Universal]: (builder: util.TestBuilder) => builder.expectToHaveDiagnostics(),
-    [tstl.LuaTarget.Lua51]: (builder: util.TestBuilder) => builder.expectToHaveDiagnostics(),
-    [tstl.LuaTarget.Lua52]: (builder: util.TestBuilder) => builder.expectToMatchJsResult(),
-    [tstl.LuaTarget.Lua53]: (builder: util.TestBuilder) => builder.expectToMatchJsResult(),
-    [tstl.LuaTarget.Lua54]: (builder: util.TestBuilder) => builder.expectToMatchJsResult(),
-    [tstl.LuaTarget.LuaJIT]: false,
-};
-
 test("while", () => {
     util.testFunction`
         let arrTest = [0, 1, 2, 3];
@@ -23,9 +14,8 @@ test("while", () => {
     `.expectToMatchJsResult();
 });
 
-util.testEachVersion(
-    "while with continue",
-    () => util.testFunction`
+test("while with continue", () => {
+    util.testFunction`
         let arrTest = [0, 1, 2, 3, 4];
         let i = 0;
         while (i < arrTest.length) {
@@ -46,13 +36,11 @@ util.testEachVersion(
             i++;
         }
         return arrTest;
-    `,
-    multiVersionContinueExpects
-);
+    `.expectToMatchJsResult();
+});
 
-util.testEachVersion(
-    "dowhile with continue",
-    () => util.testFunction`
+test("dowhile with continue", () => {
+    util.testFunction`
         let arrTest = [0, 1, 2, 3, 4];
         let i = 0;
         do {
@@ -73,9 +61,8 @@ util.testEachVersion(
             i++;
         } while (i < arrTest.length)
         return arrTest;
-    `,
-    multiVersionContinueExpects
-);
+    `.expectToMatchJsResult();
+});
 
 test("for", () => {
     util.testFunction`
@@ -98,27 +85,24 @@ test("for with expression", () => {
     `.expectToMatchJsResult();
 });
 
-util.testEachVersion(
-    "for with continue",
-    () =>
-        util.testFunction`
-            let arrTest = [0, 1, 2, 3, 4];
-            for (let i = 0; i < arrTest.length; i++) {
-                if (i % 2 == 0) {
+test("for with continue", () => {
+    util.testFunction`
+        let arrTest = [0, 1, 2, 3, 4];
+        for (let i = 0; i < arrTest.length; i++) {
+            if (i % 2 == 0) {
+                continue;
+            }
+
+            for (let j = 0; j < 2; j++) {
+                if (j == 1) {
                     continue;
                 }
-
-                for (let j = 0; j < 2; j++) {
-                    if (j == 1) {
-                        continue;
-                    }
-                    arrTest[i] = j;
-                }
+                arrTest[i] = j;
             }
-            return arrTest;
-    `,
-    multiVersionContinueExpects
-);
+        }
+        return arrTest;
+    `.expectToMatchJsResult();
+});
 
 test("forMirror", () => {
     util.testFunction`
@@ -233,9 +217,7 @@ test("forin[Array]", () => {
 });
 
 test.each([{ inp: { a: 0, b: 1, c: 2, d: 3, e: 4 } }])("forin with continue (%p)", ({ inp }) => {
-    util.testEachVersion(
-        expect.getState().currentTestName,
-        () => util.testFunctionTemplate`
+    util.testFunctionTemplate`
             let obj = ${inp};
             for (let i in obj) {
                 if (obj[i] % 2 == 0) {
@@ -245,9 +227,7 @@ test.each([{ inp: { a: 0, b: 1, c: 2, d: 3, e: 4 } }])("forin with continue (%p)
                 obj[i] = 0;
             }
             return obj;
-        `,
-        multiVersionContinueExpects
-    );
+        `.expectToMatchJsResult();
 });
 
 test.each([{ inp: [0, 1, 2] }])("forof (%p)", ({ inp }) => {
@@ -318,30 +298,27 @@ test("forof destructing with existing variables", () => {
     `.expectToMatchJsResult();
 });
 
-util.testEachVersion(
-    "forof with continue",
-    () =>
-        util.testFunction`
-            let testArr = [0, 1, 2, 3, 4];
-            let a = 0;
-            for (let i of testArr) {
-                if (i % 2 == 0) {
-                    a++;
+test("forof with continue", () => {
+    util.testFunction`
+        let testArr = [0, 1, 2, 3, 4];
+        let a = 0;
+        for (let i of testArr) {
+            if (i % 2 == 0) {
+                a++;
+                continue;
+            }
+
+            for (let j of [0, 1]) {
+                if (j == 1) {
                     continue;
                 }
-
-                for (let j of [0, 1]) {
-                    if (j == 1) {
-                        continue;
-                    }
-                    testArr[a] = j;
-                }
-                a++;
+                testArr[a] = j;
             }
-            return testArr;
-    `,
-    multiVersionContinueExpects
-);
+            a++;
+        }
+        return testArr;
+    `.expectToMatchJsResult();
+});
 
 test("forof with iterator", () => {
     util.testFunction`

--- a/test/unit/spread.spec.ts
+++ b/test/unit/spread.spec.ts
@@ -76,8 +76,8 @@ describe("in function call", () => {
             [tstl.LuaTarget.Universal]: builder => builder.tap(expectLualibUnpack),
             [tstl.LuaTarget.LuaJIT]: builder => builder.tap(expectUnpack),
             [tstl.LuaTarget.Lua51]: builder => builder.tap(expectUnpack),
-            [tstl.LuaTarget.Lua52]: builder => builder.tap(expectTableUnpack),
-            [tstl.LuaTarget.Lua53]: builder => builder.tap(expectTableUnpack),
+            [tstl.LuaTarget.Lua52]: builder => builder.tap(expectTableUnpack).expectToMatchJsResult(),
+            [tstl.LuaTarget.Lua53]: builder => builder.tap(expectTableUnpack).expectToMatchJsResult(),
             [tstl.LuaTarget.Lua54]: builder => builder.tap(expectTableUnpack).expectToMatchJsResult(),
         }
     );
@@ -87,9 +87,9 @@ describe("in array literal", () => {
     util.testEachVersion(undefined, () => util.testExpression`[...[0, 1, 2]]`, {
         [tstl.LuaTarget.Universal]: builder => builder.tap(expectLualibUnpack),
         [tstl.LuaTarget.LuaJIT]: builder => builder.tap(expectUnpack),
-        [tstl.LuaTarget.Lua51]: builder => builder.tap(expectUnpack),
-        [tstl.LuaTarget.Lua52]: builder => builder.tap(expectTableUnpack),
-        [tstl.LuaTarget.Lua53]: builder => builder.tap(expectTableUnpack),
+        [tstl.LuaTarget.Lua51]: builder => builder.tap(expectUnpack).expectToMatchJsResult(),
+        [tstl.LuaTarget.Lua52]: builder => builder.tap(expectTableUnpack).expectToMatchJsResult(),
+        [tstl.LuaTarget.Lua53]: builder => builder.tap(expectTableUnpack).expectToMatchJsResult(),
         [tstl.LuaTarget.Lua54]: builder => builder.tap(expectTableUnpack).expectToMatchJsResult(),
     });
 

--- a/test/unit/spread.spec.ts
+++ b/test/unit/spread.spec.ts
@@ -73,9 +73,9 @@ describe("in function call", () => {
             return foo(...array);
         `,
         {
-            [tstl.LuaTarget.Universal]: builder => builder.tap(expectLualibUnpack),
+            [tstl.LuaTarget.Universal]: builder => builder.tap(expectLualibUnpack).expectToMatchJsResult(),
             [tstl.LuaTarget.LuaJIT]: builder => builder.tap(expectUnpack),
-            [tstl.LuaTarget.Lua51]: builder => builder.tap(expectUnpack),
+            [tstl.LuaTarget.Lua51]: builder => builder.tap(expectUnpack).expectToMatchJsResult(),
             [tstl.LuaTarget.Lua52]: builder => builder.tap(expectTableUnpack).expectToMatchJsResult(),
             [tstl.LuaTarget.Lua53]: builder => builder.tap(expectTableUnpack).expectToMatchJsResult(),
             [tstl.LuaTarget.Lua54]: builder => builder.tap(expectTableUnpack).expectToMatchJsResult(),
@@ -85,7 +85,7 @@ describe("in function call", () => {
 
 describe("in array literal", () => {
     util.testEachVersion(undefined, () => util.testExpression`[...[0, 1, 2]]`, {
-        [tstl.LuaTarget.Universal]: builder => builder.tap(expectLualibUnpack),
+        [tstl.LuaTarget.Universal]: builder => builder.tap(expectLualibUnpack).expectToMatchJsResult(),
         [tstl.LuaTarget.LuaJIT]: builder => builder.tap(expectUnpack),
         [tstl.LuaTarget.Lua51]: builder => builder.tap(expectUnpack).expectToMatchJsResult(),
         [tstl.LuaTarget.Lua52]: builder => builder.tap(expectTableUnpack).expectToMatchJsResult(),

--- a/test/util.ts
+++ b/test/util.ts
@@ -29,6 +29,9 @@ function getLuaBindingsForVersion(target: tstl.LuaTarget): { lauxlib: LauxLib; l
         const { lauxlib, lua, lualib } = require("lua-wasm-bindings/dist/lua.53");
         return { lauxlib, lua, lualib };
     }
+    if (target === tstl.LuaTarget.LuaJIT) {
+        throw Error("Can't use executeLua() or expectToMatchJsResult() wit LuaJIT as target!");
+    }
 
     const { lauxlib, lua, lualib } = require("lua-wasm-bindings/dist/lua.54");
     return { lauxlib, lua, lualib };

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,7 +1,6 @@
 /* eslint-disable jest/no-standalone-expect */
 import * as nativeAssert from "assert";
-import { lauxlib, lua, lualib } from "lua-wasm-bindings/dist/lua.54";
-import { LUA_OK } from "lua-wasm-bindings/dist/lua";
+import { LauxLib, Lua, LuaLib, LUA_OK } from "lua-wasm-bindings/dist/lua";
 import * as fs from "fs";
 import { stringify } from "javascript-stringify";
 import * as path from "path";
@@ -16,6 +15,24 @@ const luaLib = fs.readFileSync(path.resolve(__dirname, "../dist/lualib/lualib_bu
 
 // Using `test` directly makes eslint-plugin-jest consider this file as a test
 const defineTest = test;
+
+function getLuaBindingsForVersion(target: tstl.LuaTarget): { lauxlib: LauxLib; lua: Lua; lualib: LuaLib } {
+    if (target === tstl.LuaTarget.Lua51) {
+        const { lauxlib, lua, lualib } = require("lua-wasm-bindings/dist/lua.51");
+        return { lauxlib, lua, lualib };
+    }
+    if (target === tstl.LuaTarget.Lua52) {
+        const { lauxlib, lua, lualib } = require("lua-wasm-bindings/dist/lua.52");
+        return { lauxlib, lua, lualib };
+    }
+    if (target === tstl.LuaTarget.Lua53) {
+        const { lauxlib, lua, lualib } = require("lua-wasm-bindings/dist/lua.53");
+        return { lauxlib, lua, lualib };
+    }
+
+    const { lauxlib, lua, lualib } = require("lua-wasm-bindings/dist/lua.54");
+    return { lauxlib, lua, lualib };
+}
 
 export function assert(value: any, message?: string | Error): asserts value {
     nativeAssert(value, message);
@@ -338,6 +355,8 @@ export abstract class TestBuilder {
     private executeLua(): any {
         // Main file
         const mainFile = this.getMainLuaCodeChunk();
+
+        const { lauxlib, lua, lualib } = getLuaBindingsForVersion(this.options.luaTarget ?? tstl.LuaTarget.Lua54);
 
         const L = lauxlib.luaL_newstate();
         lualib.luaL_openlibs(L);


### PR DESCRIPTION
Tests now select the appropriate Lua runtime based on luaTarget option
This works for all supported Lua versions except JIT