### PR TITLE
Bump lua-wasm-bindings version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
                 "jest": "^26.0.1",
                 "jest-circus": "^25.1.0",
                 "lua-types": "^2.8.0",
-                "lua-wasm-bindings": "^0.2.1",
+                "lua-wasm-bindings": "^0.2.2",
                 "prettier": "^2.0.5",
                 "ts-jest": "^26.3.0",
                 "ts-node": "^8.6.2"
@@ -8795,9 +8795,9 @@
             "dev": true
         },
         "node_modules/lua-wasm-bindings": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/lua-wasm-bindings/-/lua-wasm-bindings-0.2.1.tgz",
-            "integrity": "sha512-8oig7XmwI/Tq/hSpuBZbjyBXrw3vngUSvQ5kV3/9mGaHfJrQVd993j1HVy6CN/griuPrKsLtSEbpn8Hu79dYhg==",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/lua-wasm-bindings/-/lua-wasm-bindings-0.2.2.tgz",
+            "integrity": "sha512-Z2v3An8jEvYbhUJ/gYxNd65ZBbaRyPMmUaleDoOhzJSIGrMgjURvy1EtHtgRGTzdtpmKtHA+YYKDrSZBE9g/ig==",
             "dev": true
         },
         "node_modules/make-dir": {
@@ -18828,9 +18828,9 @@
             "dev": true
         },
         "lua-wasm-bindings": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/lua-wasm-bindings/-/lua-wasm-bindings-0.2.1.tgz",
-            "integrity": "sha512-8oig7XmwI/Tq/hSpuBZbjyBXrw3vngUSvQ5kV3/9mGaHfJrQVd993j1HVy6CN/griuPrKsLtSEbpn8Hu79dYhg==",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/lua-wasm-bindings/-/lua-wasm-bindings-0.2.2.tgz",
+            "integrity": "sha512-Z2v3An8jEvYbhUJ/gYxNd65ZBbaRyPMmUaleDoOhzJSIGrMgjURvy1EtHtgRGTzdtpmKtHA+YYKDrSZBE9g/ig==",
             "dev": true
         },
         "make-dir": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "jest": "^26.0.1",
         "jest-circus": "^25.1.0",
         "lua-types": "^2.8.0",
-        "lua-wasm-bindings": "^0.2.1",
+        "lua-wasm-bindings": "^0.2.2",
         "prettier": "^2.0.5",
         "ts-jest": "^26.3.0",
         "ts-node": "^8.6.2"


### PR DESCRIPTION
Fixed an issue were errors would be printed for 5.1 tests even though the tests passed.