### PR TITLE
Use ts.getParseTreeNode before getSourceFile to handle transformer output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1460,6 +1460,7 @@
                 "jest-resolve": "^26.0.1",
                 "jest-util": "^26.0.1",
                 "jest-worker": "^26.0.0",
+                "node-notifier": "^7.0.0",
                 "slash": "^3.0.0",
                 "source-map": "^0.6.0",
                 "string-length": "^4.0.1",
@@ -3567,7 +3568,8 @@
                 "esprima": "^4.0.1",
                 "estraverse": "^4.2.0",
                 "esutils": "^2.0.2",
-                "optionator": "^0.8.1"
+                "optionator": "^0.8.1",
+                "source-map": "~0.6.1"
             },
             "bin": {
                 "escodegen": "bin/escodegen.js",
@@ -6206,6 +6208,7 @@
                 "@types/graceful-fs": "^4.1.2",
                 "anymatch": "^3.0.3",
                 "fb-watchman": "^2.0.0",
+                "fsevents": "^2.1.2",
                 "graceful-fs": "^4.2.4",
                 "jest-serializer": "^26.0.0",
                 "jest-util": "^26.0.1",
@@ -8762,9 +8765,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.15",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "dev": true
         },
         "node_modules/lodash.memoize": {
@@ -11549,9 +11552,9 @@
             "dev": true
         },
         "node_modules/y18n": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-            "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+            "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
             "dev": true
         },
         "node_modules/yargs": {
@@ -18795,9 +18798,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.15",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "dev": true
         },
         "lodash.memoize": {
@@ -21039,9 +21042,9 @@
             "dev": true
         },
         "y18n": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-            "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+            "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
             "dev": true
         },
         "yargs": {

--- a/src/LuaAST.ts
+++ b/src/LuaAST.ts
@@ -174,10 +174,12 @@ export function setNodeOriginal<T extends Node>(node: T | undefined, tsOriginal:
 }
 
 function getSourcePosition(sourceNode: ts.Node): TextRange | undefined {
-    if (sourceNode.getSourceFile() !== undefined && sourceNode.pos >= 0) {
+    const parseTreeNode = ts.getParseTreeNode(sourceNode) ?? sourceNode;
+    const sourceFile = parseTreeNode.getSourceFile();
+    if (sourceFile !== undefined && parseTreeNode.pos >= 0) {
         const { line, character } = ts.getLineAndCharacterOfPosition(
-            sourceNode.getSourceFile(),
-            sourceNode.pos + sourceNode.getLeadingTriviaWidth()
+            sourceFile,
+            parseTreeNode.pos + parseTreeNode.getLeadingTriviaWidth()
         );
 
         return { line, column: character };

--- a/src/transformation/utils/typescript/index.ts
+++ b/src/transformation/utils/typescript/index.ts
@@ -32,7 +32,8 @@ export function getFirstDeclarationInFile(symbol: ts.Symbol, sourceFile: ts.Sour
 }
 
 function isStandardLibraryDeclaration(context: TransformationContext, declaration: ts.Declaration): boolean {
-    const sourceFile = declaration.getSourceFile();
+    const parseTreeNode = ts.getParseTreeNode(declaration) ?? declaration;
+    const sourceFile = parseTreeNode.getSourceFile();
     if (!sourceFile) {
         return false;
     }


### PR DESCRIPTION
AST Nodes transformed with a TS transformer did not set the parent of the new or updated node, causing getSourceFile() to return undefined. `ts.getParseTreeNode` will try to look up the original node if no parent is available. If no 'original' node was found, it returns the node itself or undefined.

I also ran a npm audit fix.