### PR TITLE
Fixed typo in language extensions

### DIFF
--- a/language-extensions/index.d.ts
+++ b/language-extensions/index.d.ts
@@ -487,7 +487,7 @@ declare type LuaTableSet<TTable extends AnyTable, TKey extends AnyNotNil, TValue
  * @param TKey The type of the key to use to access the table.
  * @param TValue The type of the value to assign to the table.
  */
-declare type LuaTableSetMethod<TKey extends AnyNonNil, TValue> = ((key: TKey, value: TValue) => void) &
+declare type LuaTableSetMethod<TKey extends AnyNotNil, TValue> = ((key: TKey, value: TValue) => void) &
     LuaExtension<"__luaTableSetMethodBrand">;
 
 /**

--- a/package.json
+++ b/package.json
@@ -25,12 +25,13 @@
     "scripts": {
         "build": "tsc && npm run build-lualib",
         "build-lualib": "node build-lualib.js",
-        "pretest": "npm run lint && npm run build-lualib",
+        "pretest": "npm run lint && npm run check:language-extensions && npm run build-lualib",
         "test": "jest",
         "lint": "npm run lint:eslint && npm run lint:prettier",
         "lint:prettier": "prettier --check . || (echo 'Run `npm run fix:prettier` to fix it.' && exit 1)",
         "lint:eslint": "eslint . --ext .js,.ts",
         "fix:prettier": "prettier --write .",
+        "check:language-extensions": "tsc language-extensions/index.d.ts",
         "preversion": "npm run build && npm test",
         "postversion": "git push && git push --tags"
     },


### PR DESCRIPTION
Not caught because we did not yet check this file with tsc. Added a test step that does so, so it doesn't happen again.