### PR TITLE
Bundle librarymode error & tstlverbose CLI flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "jest-circus": "^25.1.0",
                 "lua-types": "^2.8.0",
                 "lua-wasm-bindings": "^0.2.2",
-                "prettier": "^2.0.5",
+                "prettier": "^2.3.2",
                 "ts-jest": "^26.3.0",
                 "ts-node": "^8.6.2"
             },
@@ -9554,9 +9554,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
-            "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+            "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
             "dev": true,
             "bin": {
                 "prettier": "bin-prettier.js"
@@ -19259,9 +19259,9 @@
             "dev": true
         },
         "prettier": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
-            "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+            "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
             "dev": true
         },
         "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "jest-circus": "^25.1.0",
         "lua-types": "^2.8.0",
         "lua-wasm-bindings": "^0.2.2",
-        "prettier": "^2.0.5",
+        "prettier": "^2.3.2",
         "ts-jest": "^26.3.0",
         "ts-node": "^8.6.2"
     }

--- a/src/CompilerOptions.ts
+++ b/src/CompilerOptions.ts
@@ -1,13 +1,9 @@
 import * as ts from "typescript";
 import * as diagnosticFactories from "./transpilation/diagnostics";
 
-type KnownKeys<T> = { [K in keyof T]: string extends K ? never : number extends K ? never : K } extends {
-    [K in keyof T]: infer U;
-}
-    ? U
-    : never;
-
-type OmitIndexSignature<T extends Record<any, any>> = Pick<T, KnownKeys<T>>;
+type OmitIndexSignature<T> = {
+    [K in keyof T as string extends K ? never : number extends K ? never : K]: T[K];
+};
 
 export interface TransformerImport {
     transform: string;
@@ -35,6 +31,7 @@ export type CompilerOptions = OmitIndexSignature<ts.CompilerOptions> & {
     sourceMapTraceback?: boolean;
     luaPlugins?: LuaPluginImport[];
     plugins?: Array<ts.PluginImport | TransformerImport>;
+    tstlVerbose?: boolean;
     [option: string]: any;
 };
 

--- a/src/CompilerOptions.ts
+++ b/src/CompilerOptions.ts
@@ -73,5 +73,9 @@ export function validateOptions(options: CompilerOptions): ts.Diagnostic[] {
         diagnostics.push(diagnosticFactories.usingLuaBundleWithInlineMightGenerateDuplicateCode());
     }
 
+    if (options.luaBundle && options.buildMode === BuildMode.Library) {
+        diagnostics.push(diagnosticFactories.cannotBundleLibrary());
+    }
+
     return diagnostics;
 }

--- a/src/cli/parse.ts
+++ b/src/cli/parse.ts
@@ -73,6 +73,11 @@ export const optionDeclarations: CommandLineOption[] = [
         description: "List of TypeScriptToLua plugins.",
         type: "object",
     },
+    {
+        name: "tstlVerbose",
+        description: "Provide verbose output useful for diagnosing problems.",
+        type: "boolean",
+    },
 ];
 
 export function updateParsedConfigFile(parsedConfigFile: ts.ParsedCommandLine): ParsedCommandLine {

--- a/src/transformation/context/context.ts
+++ b/src/transformation/context/context.ts
@@ -27,8 +27,7 @@ export interface DiagnosticsProducingTypeChecker extends ts.TypeChecker {
 
 export class TransformationContext {
     public readonly diagnostics: ts.Diagnostic[] = [];
-    public readonly checker: DiagnosticsProducingTypeChecker = (this
-        .program as any).getDiagnosticsProducingTypeChecker();
+    public readonly checker: DiagnosticsProducingTypeChecker = this.program.getDiagnosticsProducingTypeChecker();
     public readonly resolver: EmitResolver;
 
     public readonly options: CompilerOptions = this.program.getCompilerOptions();

--- a/src/transpilation/diagnostics.ts
+++ b/src/transpilation/diagnostics.ts
@@ -48,3 +48,8 @@ export const usingLuaBundleWithInlineMightGenerateDuplicateCode = createSerialDi
         "Using 'luaBundle' with 'luaLibImport: \"inline\"' might generate duplicate code. " +
         "It is recommended to use 'luaLibImport: \"require\"'.",
 }));
+
+export const cannotBundleLibrary = createDiagnosticFactory(
+    () =>
+        'Cannot bundle probjects with"buildmode": "library". Projects including the library can still bundle (which will include external library files).'
+);

--- a/src/typescript-internal.d.ts
+++ b/src/typescript-internal.d.ts
@@ -1,3 +1,5 @@
+import { DiagnosticsProducingTypeChecker } from "./transformation/context";
+
 export {};
 
 declare module "typescript" {
@@ -14,6 +16,7 @@ declare module "typescript" {
 
     interface Program {
         getCommonSourceDirectory(): string;
+        getDiagnosticsProducingTypeChecker(): DiagnosticsProducingTypeChecker;
     }
 
     interface CompilerOptions {

--- a/test/cli/parse.spec.ts
+++ b/test/cli/parse.spec.ts
@@ -104,6 +104,8 @@ describe("command line", () => {
             ["noHeader", "true", { noHeader: true }],
             ["sourceMapTraceback", "false", { sourceMapTraceback: false }],
             ["sourceMapTraceback", "true", { sourceMapTraceback: true }],
+            ["tstlVerbose", "true", { tstlVerbose: true }],
+            ["tstlVerbose", "false", { tstlVerbose: false }],
 
             ["buildMode", "default", { buildMode: tstl.BuildMode.Default }],
             ["buildMode", "library", { buildMode: tstl.BuildMode.Library }],

--- a/test/transpile/__snapshots__/project.spec.ts.snap
+++ b/test/transpile/__snapshots__/project.spec.ts.snap
@@ -1,5 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`should give verbose output 1`] = `
+Array [
+  "Parsing project settings",
+  "Successfully loaded 0 plugins",
+  "Transforming <cwd>/test/transpile/project/otherFile.ts",
+  "Printing <cwd>/test/transpile/project/otherFile.ts",
+  "Transforming <cwd>/test/transpile/project/index.ts",
+  "Printing <cwd>/test/transpile/project/index.ts",
+  "Constructing emit plan",
+  "Resolving dependencies for <cwd>/test/transpile/project/otherFile.ts",
+  "Resolving dependencies for <cwd>/test/transpile/project/index.ts",
+  "Resolving \\"./otherFile\\" from <cwd>/test/transpile/project",
+  "Resolved ./otherFile to <cwd>/test/transpile/project/otherFile.ts",
+  "Emitting output",
+  "Emitting <cwd>/test/transpile/project/otherFile.lua",
+  "Emitting <cwd>/test/transpile/project/index.lua",
+  "Emit finished!",
+]
+`;
+
 exports[`should transpile 1`] = `
 Array [
   Object {

--- a/test/transpile/module-resolution.spec.ts
+++ b/test/transpile/module-resolution.spec.ts
@@ -230,25 +230,6 @@ describe("module resolution in library mode", () => {
             expect(file.lua).not.toContain('require("lua_modules');
         }
     });
-
-    test("bundle works in library mode because no external dependencies", () => {
-        const projectPath = path.resolve(__dirname, "module-resolution", "project-with-lua-sources");
-        const mainFile = path.join(projectPath, "main.ts");
-
-        const { transpiledFiles } = util
-            .testProject(path.join(projectPath, "tsconfig.json"))
-            .setMainFileName(path.join(projectPath, "main.ts"))
-            .setOptions({ buildMode: tstl.BuildMode.Library, luaBundle: "bundle.lua", luaBundleEntry: mainFile })
-            .expectToEqual({
-                funcFromLuaFile: "lua file in subdir",
-                funcFromSubDirLuaFile: "lua file in subdir",
-            })
-            .getLuaResult();
-
-        for (const file of transpiledFiles) {
-            expect(file.lua).not.toContain('require("lua_modules');
-        }
-    });
 });
 
 describe("module resolution project with dependencies built by tstl library mode", () => {

--- a/test/transpile/project.spec.ts
+++ b/test/transpile/project.spec.ts
@@ -1,4 +1,5 @@
 import * as path from "path";
+import { normalizeSlashes } from "../../src/utils";
 import * as util from "../util";
 
 test("should transpile", () => {
@@ -12,4 +13,23 @@ test("should transpile", () => {
     expect(
         transpiledFiles.map(f => ({ filePath: path.relative(projectDir, f.outPath), lua: f.lua }))
     ).toMatchSnapshot();
+});
+
+test("should give verbose output", () => {
+    // Capture console logs
+    const consoleLogs: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: any[]) => {
+        consoleLogs.push(args.map(a => a.toString().replace(normalizeSlashes(process.cwd()), "<cwd>")).join(","));
+    };
+
+    const projectDir = path.join(__dirname, "project");
+    util.testProject(path.join(projectDir, "tsconfig.json"))
+        .setMainFileName(path.join(projectDir, "index.ts"))
+        .setOptions({ tstlVerbose: true })
+        .expectToHaveNoDiagnostics();
+
+    console.log = originalLog;
+
+    expect(consoleLogs).toMatchSnapshot();
 });

--- a/test/transpile/transformers/fixtures.ts
+++ b/test/transpile/transformers/fixtures.ts
@@ -6,22 +6,25 @@ import { visitAndReplace } from "./utils";
 export const program = (program: ts.Program, options: { value: any }): ts.TransformerFactory<ts.SourceFile> =>
     checker(program.getTypeChecker(), options);
 
-export const config = ({ value }: { value: any }): ts.TransformerFactory<ts.SourceFile> => context => file =>
-    visitAndReplace(context, file, node => {
-        if (!ts.isReturnStatement(node)) return;
-        return ts.factory.updateReturnStatement(node, value ? ts.factory.createTrue() : ts.factory.createFalse());
-    });
+export const config =
+    ({ value }: { value: any }): ts.TransformerFactory<ts.SourceFile> =>
+    context =>
+    file =>
+        visitAndReplace(context, file, node => {
+            if (!ts.isReturnStatement(node)) return;
+            return ts.factory.updateReturnStatement(node, value ? ts.factory.createTrue() : ts.factory.createFalse());
+        });
 
-export const checker = (
-    checker: ts.TypeChecker,
-    { value }: { value: any }
-): ts.TransformerFactory<ts.SourceFile> => context => file =>
-    visitAndReplace(context, file, node => {
-        if (!ts.isReturnStatement(node) || !node.expression) return;
-        const type = checker.getTypeAtLocation(node.expression);
-        if ((type.flags & ts.TypeFlags.BooleanLiteral) === 0) return;
-        return ts.factory.updateReturnStatement(node, value ? ts.factory.createTrue() : ts.factory.createFalse());
-    });
+export const checker =
+    (checker: ts.TypeChecker, { value }: { value: any }): ts.TransformerFactory<ts.SourceFile> =>
+    context =>
+    file =>
+        visitAndReplace(context, file, node => {
+            if (!ts.isReturnStatement(node) || !node.expression) return;
+            const type = checker.getTypeAtLocation(node.expression);
+            if ((type.flags & ts.TypeFlags.BooleanLiteral) === 0) return;
+            return ts.factory.updateReturnStatement(node, value ? ts.factory.createTrue() : ts.factory.createFalse());
+        });
 
 export const raw: ts.TransformerFactory<ts.SourceFile> = context => file =>
     visitAndReplace(context, file, node => {
@@ -29,12 +32,13 @@ export const raw: ts.TransformerFactory<ts.SourceFile> = context => file =>
         return ts.factory.updateReturnStatement(node, ts.factory.createTrue());
     });
 
-export const compilerOptions = (
-    options: tstl.CompilerOptions
-): ts.TransformerFactory<ts.SourceFile> => context => file => {
-    assert(options.plugins?.length === 1);
-    return visitAndReplace(context, file, node => {
-        if (!ts.isReturnStatement(node)) return;
-        return ts.factory.updateReturnStatement(node, ts.factory.createTrue());
-    });
-};
+export const compilerOptions =
+    (options: tstl.CompilerOptions): ts.TransformerFactory<ts.SourceFile> =>
+    context =>
+    file => {
+        assert(options.plugins?.length === 1);
+        return visitAndReplace(context, file, node => {
+            if (!ts.isReturnStatement(node)) return;
+            return ts.factory.updateReturnStatement(node, ts.factory.createTrue());
+        });
+    };

--- a/test/unit/__snapshots__/bundle.spec.ts.snap
+++ b/test/unit/__snapshots__/bundle.spec.ts.snap
@@ -2,6 +2,8 @@
 
 exports[`LuaLibImportKind.Inline generates a warning: diagnostics 1`] = `"warning TSTL: Using 'luaBundle' with 'luaLibImport: \\"inline\\"' might generate duplicate code. It is recommended to use 'luaLibImport: \\"require\\"'."`;
 
+exports[`bundling not allowed for buildmode library: diagnostics 1`] = `"error TSTL: Cannot bundle probjects with\\"buildmode\\": \\"library\\". Projects including the library can still bundle (which will include external library files)."`;
+
 exports[`luaEntry doesn't exist: diagnostics 1`] = `"error TSTL: Could not find bundle entry point 'entry.ts'. It should be a file in the project."`;
 
 exports[`no entry point: diagnostics 1`] = `"error TSTL: 'luaBundleEntry' is required when 'luaBundle' is enabled."`;

--- a/test/unit/bundle.spec.ts
+++ b/test/unit/bundle.spec.ts
@@ -1,4 +1,4 @@
-import { LuaLibImportKind } from "../../src";
+import { BuildMode, LuaLibImportKind } from "../../src";
 import * as diagnosticFactories from "../../src/transpilation/diagnostics";
 import * as util from "../util";
 
@@ -119,4 +119,10 @@ test("luaEntry doesn't exist", () => {
     util.testBundle``
         .setEntryPoint("entry.ts")
         .expectDiagnosticsToMatchSnapshot([diagnosticFactories.couldNotFindBundleEntryPoint.code], true);
+});
+
+test("bundling not allowed for buildmode library", () => {
+    util.testBundle``
+        .setOptions({ buildMode: BuildMode.Library })
+        .expectDiagnosticsToMatchSnapshot([diagnosticFactories.cannotBundleLibrary.code], true);
 });

--- a/test/unit/modules/resolution.spec.ts
+++ b/test/unit/modules/resolution.spec.ts
@@ -3,10 +3,12 @@ import { couldNotResolveRequire } from "../../../src/transpilation/diagnostics";
 import * as util from "../../util";
 
 const requireRegex = /require\("(.*?)"\)/;
-const expectToRequire = (expected: string): util.TapCallback => builder => {
-    const [, requiredPath] = builder.getMainLuaCodeChunk().match(requireRegex) ?? [];
-    expect(requiredPath).toBe(expected);
-};
+const expectToRequire =
+    (expected: string): util.TapCallback =>
+    builder => {
+        const [, requiredPath] = builder.getMainLuaCodeChunk().match(requireRegex) ?? [];
+        expect(requiredPath).toBe(expected);
+    };
 
 test.each([
     {

--- a/test/util.ts
+++ b/test/util.ts
@@ -239,8 +239,9 @@ export abstract class TestBuilder {
     @memoize
     public getMainJsCodeChunk(): string {
         const { transpiledFiles } = this.getJsResult();
-        const code = transpiledFiles.find(({ sourceFiles }) => sourceFiles.some(f => f.fileName === this.mainFileName))
-            ?.js;
+        const code = transpiledFiles.find(({ sourceFiles }) =>
+            sourceFiles.some(f => f.fileName === this.mainFileName)
+        )?.js;
         assert(code !== undefined);
 
         const header = this.jsHeader ? `${this.jsHeader.trimRight()}\n` : "";
@@ -557,25 +558,24 @@ class ProjectTestBuilder extends ModuleTestBuilder {
     }
 }
 
-const createTestBuilderFactory = <T extends TestBuilder>(
-    builder: new (_tsCode: string) => T,
-    serializeSubstitutions: boolean
-) => (...args: [string] | [TemplateStringsArray, ...any[]]): T => {
-    let tsCode: string;
-    if (typeof args[0] === "string") {
-        expect(serializeSubstitutions).toBe(false);
-        tsCode = args[0];
-    } else {
-        let [raw, ...substitutions] = args;
-        if (serializeSubstitutions) {
-            substitutions = substitutions.map(s => formatCode(s));
+const createTestBuilderFactory =
+    <T extends TestBuilder>(builder: new (_tsCode: string) => T, serializeSubstitutions: boolean) =>
+    (...args: [string] | [TemplateStringsArray, ...any[]]): T => {
+        let tsCode: string;
+        if (typeof args[0] === "string") {
+            expect(serializeSubstitutions).toBe(false);
+            tsCode = args[0];
+        } else {
+            let [raw, ...substitutions] = args;
+            if (serializeSubstitutions) {
+                substitutions = substitutions.map(s => formatCode(s));
+            }
+
+            tsCode = String.raw(Object.assign([], { raw }), ...substitutions);
         }
 
-        tsCode = String.raw(Object.assign([], { raw }), ...substitutions);
-    }
-
-    return new builder(tsCode);
-};
+        return new builder(tsCode);
+    };
 
 export const testBundle = createTestBuilderFactory(BundleTestBuilder, false);
 export const testModule = createTestBuilderFactory(ModuleTestBuilder, false);


### PR DESCRIPTION
No longer allows bundling files with buildmode: library.

Also added tstlVerbose option with some extra information to hopefully help diagnose problems.