### PR TITLE
Fix crash when trying to assign to an optional chain

### DIFF
--- a/src/transformation/utils/diagnostics.ts
+++ b/src/transformation/utils/diagnostics.ts
@@ -143,3 +143,7 @@ export const annotationDeprecated = createWarningDiagnosticFactory(
         `'@${kind}' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. ` +
         `See https://typescripttolua.github.io/docs/advanced/compiler-annotations#${kind.toLowerCase()} for more information.`
 );
+
+export const notAllowedOptionalAssignment = createErrorDiagnosticFactory(
+    "The left-hand side of an assignment expression may not be an optional property access."
+);

--- a/src/transformation/visitors/binary-expression/assignments.ts
+++ b/src/transformation/visitors/binary-expression/assignments.ts
@@ -16,6 +16,7 @@ import {
     ImmediatelyInvokedFunctionParameters,
     transformToImmediatelyInvokedFunctionExpression,
 } from "../../utils/transform";
+import { notAllowedOptionalAssignment } from "../../utils/diagnostics";
 
 export function transformAssignmentLeftHandSideExpression(
     context: TransformationContext,
@@ -36,6 +37,11 @@ export function transformAssignment(
     right: lua.Expression,
     parent?: ts.Expression
 ): lua.Statement[] {
+    if (ts.isOptionalChain(lhs)) {
+        context.diagnostics.push(notAllowedOptionalAssignment(lhs));
+        return [];
+    }
+
     if (isArrayLength(context, lhs)) {
         const arrayLengthAssignment = lua.createExpressionStatement(
             transformLuaLibFunction(

--- a/test/unit/optionalChaining.spec.ts
+++ b/test/unit/optionalChaining.spec.ts
@@ -1,3 +1,4 @@
+import { notAllowedOptionalAssignment } from "../../src/transformation/utils/diagnostics";
 import * as util from "../util";
 
 test.each(["null", "undefined", '{ foo: "foo" }'])("optional chaining (%p)", value => {
@@ -95,6 +96,15 @@ test("no side effects", () => {
         const result = getFoo()?.foo ?? getBar()?.bar;
         return { result, barCalls };
     `.expectToMatchJsResult();
+});
+
+// Test for https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1044
+test("does not crash when incorrectly used in assignment (#1044)", () => {
+    const { diagnostics } = util.testFunction`
+        foo?.bar = "foo";
+    `.getLuaResult();
+
+    expect(diagnostics.find(d => d.code === notAllowedOptionalAssignment.code)).toBeDefined();
 });
 
 describe("optional chaining function calls", () => {


### PR DESCRIPTION
Fixes #1044 Crash is the result of an optional assignment left-hand-side to be transformed to a lualib CallExpression, but we only allow identifiers or table index expressions as assignment left-hand side.

If trying to assign to an optional left-hand-side, exit out of transformAssignment early with a diagnostic. TypeScript also already throws a diagnostic here, but it felt wrong to just silently ignore code.