### PR TITLE
fixed vararg optimization logic

### DIFF
--- a/src/transformation/utils/scope.ts
+++ b/src/transformation/utils/scope.ts
@@ -92,9 +92,9 @@ export function popScope(context: TransformationContext): Scope {
     return scope;
 }
 
-function isDeclaredInScope(symbol: ts.Symbol, scopeNode: ts.Node) {
+function isHoistableFunctionDeclaredInScope(symbol: ts.Symbol, scopeNode: ts.Node) {
     return symbol?.declarations?.some(
-        d => findFirstNodeAbove(d, (n): n is ts.Node => n === scopeNode) && !ts.isParameter(d.parent)
+        d => ts.isFunctionDeclaration(d) && findFirstNodeAbove(d, (n): n is ts.Node => n === scopeNode)
     );
 }
 
@@ -109,7 +109,7 @@ export function hasReferencedUndefinedLocalFunction(context: TransformationConte
         if (
             !scope.functionDefinitions?.has(symbolId) &&
             type.getCallSignatures().length > 0 &&
-            isDeclaredInScope(type.symbol, scope.node)
+            isHoistableFunctionDeclaredInScope(type.symbol, scope.node)
         ) {
             return true;
         }

--- a/test/unit/__snapshots__/spread.spec.ts.snap
+++ b/test/unit/__snapshots__/spread.spec.ts.snap
@@ -81,6 +81,24 @@ end
 return ____exports"
 `;
 
+exports[`vararg spread optimization curry with indirect type 1`] = `
+"local ____exports = {}
+function ____exports.__main(self)
+    local function test(self, obj, ...)
+        local fn = obj.fn
+        return fn(nil, ...)
+    end
+    return test(
+        nil,
+        {
+            fn = function(____, arg) return arg end
+        },
+        \\"foobar\\"
+    )
+end
+return ____exports"
+`;
+
 exports[`vararg spread optimization finally clause 1`] = `
 "local ____exports = {}
 function ____exports.__main(self)
@@ -101,6 +119,21 @@ function ____exports.__main(self)
         end
     end
     return test(nil, \\"a\\", \\"b\\", \\"c\\")
+end
+return ____exports"
+`;
+
+exports[`vararg spread optimization function type declared inside scope 1`] = `
+"local ____exports = {}
+function ____exports.__main(self)
+    local function test(self, ...)
+        local function fn(____, ...)
+            local args = {...}
+            return args[1]
+        end
+        return fn(nil, ...)
+    end
+    test(nil, \\"foobar\\")
 end
 return ____exports"
 `;

--- a/test/unit/spread.spec.ts
+++ b/test/unit/spread.spec.ts
@@ -241,6 +241,30 @@ describe("vararg spread optimization", () => {
             .expectLuaToMatchSnapshot()
             .expectToMatchJsResult();
     });
+
+    test("curry with indirect type", () => {
+        util.testFunction`
+            function test<A extends any[]>(obj: {fn: (...args: A) => void}, ...args: A) {
+                const fn = obj.fn;
+                return fn(...args);
+            }
+            return test({fn: (arg: string) => arg}, "foobar");
+        `
+            .expectLuaToMatchSnapshot()
+            .expectToMatchJsResult();
+    });
+
+    test("function type declared inside scope", () => {
+        util.testFunction`
+            function test<A extends any[]>(...args: A) {
+                const fn: (...args: A) => A[0] = (...args) => args[0];
+                return fn(...args);
+            }
+            test("foobar");
+        `
+            .expectLuaToMatchSnapshot()
+            .expectToMatchJsResult();
+    });
 });
 
 describe("vararg spread de-optimization", () => {


### PR DESCRIPTION
The core flaw in how this was working is that any function types defined inside the scope would be flagged as "hoistable" and trigger deoptimization. But this would include things like parameters or local variable types.

I've changed this logic to explicitly only include actual hoistable functions (ex. `function foo() {}`) which seems to address all cases properly now. We should keep our eye out for other edge cases here, though.

Closes #1047 
