### PR TITLE
Module resolution fixes

### DIFF
--- a/src/transpilation/resolve.ts
+++ b/src/transpilation/resolve.ts
@@ -170,12 +170,22 @@ function resolveDependency(
         path.join(resolvedPath, "index.ts"), // Index ts file,
         resolvedPath + ".tsx", // tsx file
         path.join(resolvedPath, "index.tsx"), // tsx index
-        resolvedPath + ".lua", // lua file in sources
-        path.join(resolvedPath, "index.lua"), // lua index file in sources
     ];
 
     for (const possibleFile of possibleProjectFiles) {
         if (isProjectFile(possibleFile, program)) {
+            return possibleFile;
+        }
+    }
+
+    // Check if this is a lua file in the project sources
+    const possibleLuaProjectFiles = [
+        resolvedPath + ".lua", // lua file in sources
+        path.join(resolvedPath, "index.lua"), // lua index file in sources
+    ];
+
+    for (const possibleFile of possibleLuaProjectFiles) {
+        if (emitHost.fileExists(possibleFile)) {
             return possibleFile;
         }
     }

--- a/src/transpilation/resolve.ts
+++ b/src/transpilation/resolve.ts
@@ -170,6 +170,8 @@ function resolveDependency(
         path.join(resolvedPath, "index.ts"), // Index ts file,
         resolvedPath + ".tsx", // tsx file
         path.join(resolvedPath, "index.tsx"), // tsx index
+        resolvedPath + ".lua", // lua file in sources
+        path.join(resolvedPath, "index.lua") // lua index file in sources
     ];
 
     for (const possibleFile of possibleProjectFiles) {

--- a/src/transpilation/resolve.ts
+++ b/src/transpilation/resolve.ts
@@ -37,7 +37,11 @@ export function resolveDependencies(program: ts.Program, files: ProcessedFile[],
         diagnostics.push(...resolutionResult.diagnostics);
     }
 
-    return { resolvedFiles: outFiles, diagnostics };
+    return { resolvedFiles: deduplicateResolvedFiles(outFiles), diagnostics };
+}
+
+function deduplicateResolvedFiles(files: ProcessedFile[]): ProcessedFile[] {
+    return [...new Map(files.map(f => [f.fileName, f])).values()];
 }
 
 function resolveFileDependencies(file: ProcessedFile, program: ts.Program, emitHost: EmitHost): ResolutionResult {

--- a/src/transpilation/resolve.ts
+++ b/src/transpilation/resolve.ts
@@ -171,7 +171,7 @@ function resolveDependency(
         resolvedPath + ".tsx", // tsx file
         path.join(resolvedPath, "index.tsx"), // tsx index
         resolvedPath + ".lua", // lua file in sources
-        path.join(resolvedPath, "index.lua") // lua index file in sources
+        path.join(resolvedPath, "index.lua"), // lua index file in sources
     ];
 
     for (const possibleFile of possibleProjectFiles) {

--- a/src/transpilation/resolve.ts
+++ b/src/transpilation/resolve.ts
@@ -221,7 +221,7 @@ function resolveLuaPath(fromPath: string, dependency: string, emitHost: EmitHost
 }
 
 function walkUpFileTreeUntil(fromDirectory: string, predicate: (dir: string) => boolean) {
-    const currentDir = fromDirectory.split(path.sep);
+    const currentDir = path.normalize(fromDirectory).split(path.sep);
     while (currentDir.length > 0) {
         const dir = currentDir.join(path.sep);
         if (predicate(dir)) {

--- a/src/transpilation/utils.ts
+++ b/src/transpilation/utils.ts
@@ -8,6 +8,7 @@ import * as lua from "../LuaAST";
 import * as diagnosticFactories from "./diagnostics";
 
 export interface EmitHost {
+    directoryExists(path: string): boolean;
     fileExists(path: string): boolean;
     getCurrentDirectory(): string;
     readFile(path: string): string | undefined;

--- a/test/transpile/module-resolution.spec.ts
+++ b/test/transpile/module-resolution.spec.ts
@@ -278,18 +278,23 @@ describe("module resolution with tsx", () => {
 
 describe("dependency with complicated inner structure", () => {
     const projectPath = path.resolve(__dirname, "module-resolution", "project-with-complicated-dependency");
+    const tsConfigPath = path.join(projectPath, "tsconfig.json");
+    const mainFilePath = path.join(projectPath, "main.ts");
+
+    const expectedResult = {
+        otherFileResult: "someFunc from otherfile.lua",
+        otherFileUtil: "util",
+        utilResult: "util",
+    };
 
     // Test fix for https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1055
     test("bundle should not contain duplicate files", () => {
         const mainFile = path.join(projectPath, "main.ts");
-        const { transpiledFiles } = util.testProject(path.join(projectPath, "tsconfig.json"))
-            .setMainFileName(path.join(projectPath, "main.ts"))
+        const { transpiledFiles } = util
+            .testProject(tsConfigPath)
+            .setMainFileName(mainFilePath)
             .setOptions({ luaBundle: "bundle.lua", luaBundleEntry: mainFile })
-            .expectToEqual({
-                otherFileResult: "someFunc from otherfile.lua",
-                otherFileUtil: "util",
-                utilResult: "util"
-            })
+            .expectToEqual(expectedResult)
             .getLuaResult();
 
         expect(transpiledFiles).toHaveLength(1);
@@ -299,4 +304,8 @@ describe("dependency with complicated inner structure", () => {
         expect(utilModuleOccurrences).toBe(1);
     });
 
+    // Test fix for https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1054
+    test("should be able to resolve dependency files in subdirectories", () => {
+        util.testProject(tsConfigPath).setMainFileName(mainFilePath).expectToEqual(expectedResult);
+    });
 });

--- a/test/transpile/module-resolution/project-with-complicated-dependency/main.ts
+++ b/test/transpile/module-resolution/project-with-complicated-dependency/main.ts
@@ -1,0 +1,5 @@
+import * as dependency1 from "dependency1";
+
+export const otherFileResult = dependency1.otherFileFromDependency1();
+export const utilResult = dependency1.callUtil();
+export const otherFileUtil = dependency1.otherFileUtil();

--- a/test/transpile/module-resolution/project-with-complicated-dependency/node_modules/dependency1/index.d.ts
+++ b/test/transpile/module-resolution/project-with-complicated-dependency/node_modules/dependency1/index.d.ts
@@ -1,0 +1,4 @@
+/** @noSelfInFile */
+export declare function otherFileFromDependency1(): string;
+export declare function callUtil(): string;
+export declare function otherFileUtil(): string;

--- a/test/transpile/module-resolution/project-with-complicated-dependency/node_modules/dependency1/index.lua
+++ b/test/transpile/module-resolution/project-with-complicated-dependency/node_modules/dependency1/index.lua
@@ -1,0 +1,10 @@
+local otherfile = require("otherfile")
+local util = require("util")
+
+return {
+    otherFileFromDependency1 = otherfile.someFunc,
+    callUtil = function()
+        return util.utilf()
+    end,
+    otherFileUtil = otherfile.callUtil
+}

--- a/test/transpile/module-resolution/project-with-complicated-dependency/node_modules/dependency1/index.lua
+++ b/test/transpile/module-resolution/project-with-complicated-dependency/node_modules/dependency1/index.lua
@@ -1,10 +1,14 @@
 local otherfile = require("otherfile")
 local util = require("util")
+local subdirfile = require("subdir.subdirfile")
+local othersubdirfile = require("subdir.othersubdirfile")
 
 return {
     otherFileFromDependency1 = otherfile.someFunc,
     callUtil = function()
         return util.utilf()
     end,
-    otherFileUtil = otherfile.callUtil
+    otherFileUtil = otherfile.callUtil,
+    subdirfileResult = subdirfile.subdirfileResult,
+    othersubdirfileResult = othersubdirfile.othersubdirfileResult
 }

--- a/test/transpile/module-resolution/project-with-complicated-dependency/node_modules/dependency1/otherfile.lua
+++ b/test/transpile/module-resolution/project-with-complicated-dependency/node_modules/dependency1/otherfile.lua
@@ -1,0 +1,10 @@
+local util = require("util")
+
+return {
+    someFunc = function()
+        return "someFunc from otherfile.lua"
+    end,
+    callUtil = function()
+        return util.utilf()
+    end
+}

--- a/test/transpile/module-resolution/project-with-complicated-dependency/node_modules/dependency1/subdir/othersubdirfile.lua
+++ b/test/transpile/module-resolution/project-with-complicated-dependency/node_modules/dependency1/subdir/othersubdirfile.lua
@@ -1,0 +1,3 @@
+return {
+    result = "result from other subdirectory file"
+}

--- a/test/transpile/module-resolution/project-with-complicated-dependency/node_modules/dependency1/subdir/subdirfile.lua
+++ b/test/transpile/module-resolution/project-with-complicated-dependency/node_modules/dependency1/subdir/subdirfile.lua
@@ -1,0 +1,5 @@
+local othersubdirfile = require("subdir.othersubdirfile")
+return {
+    subdirfileResult = "result from subdirectory file!",
+    othersubdirfileResult = othersubdirfile.result
+}

--- a/test/transpile/module-resolution/project-with-complicated-dependency/node_modules/dependency1/util.lua
+++ b/test/transpile/module-resolution/project-with-complicated-dependency/node_modules/dependency1/util.lua
@@ -1,0 +1,3 @@
+return {
+    utilf = function() return "util" end,
+}

--- a/test/transpile/module-resolution/project-with-complicated-dependency/tsconfig.json
+++ b/test/transpile/module-resolution/project-with-complicated-dependency/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "moduleResolution": "Node",
+        "target": "esnext",
+        "lib": ["esnext"],
+        "types": [],
+        "rootDir": "."
+    }
+}


### PR DESCRIPTION
Added ResolutionContext class with cache to break module resolution cycles, and to prevent doing double work when resolving the same file from multiple places.

Fixes #1055 by de-duplicating the lua bundle contents file list by file name.

Fixes #1054 by reworking how resolution works from lua files, searching up in the directory tree until the lua root is found.