### PR TITLE
More resolution fixes

### DIFF
--- a/src/transpilation/bundle.ts
+++ b/src/transpilation/bundle.ts
@@ -18,11 +18,11 @@ local ____moduleCache = {}
 local ____originalRequire = require
 local function require(file)
     if ____moduleCache[file] then
-        return ____moduleCache[file]
+        return ____moduleCache[file].value
     end
     if ____modules[file] then
-        ____moduleCache[file] = ____modules[file]()
-        return ____moduleCache[file]
+        ____moduleCache[file] = { value = ____modules[file]() }
+        return ____moduleCache[file].value
     else
         if ____originalRequire then
             return ____originalRequire(file)

--- a/src/transpilation/resolve.ts
+++ b/src/transpilation/resolve.ts
@@ -227,7 +227,7 @@ function resolveLuaPath(fromPath: string, dependency: string, emitHost: EmitHost
             emitHost.directoryExists(path.join(dir, splitDependency[0]))
         );
         if (luaRoot) {
-            return path.join(luaRoot, dependency.replace(".", path.sep)) + ".lua";
+            return path.join(luaRoot, dependency.replace(/\./g, path.sep)) + ".lua";
         }
     }
 }

--- a/src/transpilation/resolve.ts
+++ b/src/transpilation/resolve.ts
@@ -134,9 +134,14 @@ function resolveFileDependencies(file: ProcessedFile, context: ResolutionContext
 
         // Do not resolve noResolution paths
         if (required.startsWith("@NoResolution:")) {
-            const path = required.replace("@NoResolution:", "");
-            replaceRequireInCode(file, required, path);
-            replaceRequireInSourceMap(file, required, path);
+            // Remove @NoResolution prefix if not building in library mode
+            if (!isBuildModeLibrary(context.program)) {
+                const path = required.replace("@NoResolution:", "");
+                replaceRequireInCode(file, required, path);
+                replaceRequireInSourceMap(file, required, path);
+            }
+
+            // Skip
             continue;
         }
 

--- a/test/transpile/module-resolution.spec.ts
+++ b/test/transpile/module-resolution.spec.ts
@@ -315,27 +315,38 @@ test("module resolution should not try to resolve @noResolution annotation", () 
     util.testModule`
         import * as json from "json";
         const test = json.decode("{}");
-    `.addExtraFile("json.d.ts", `
-        /** @noResolution */
-        declare module "json" {
-            function encode(this: void, data: unknown): string;
-            function decode(this: void, data: string): unknown;
-        }
-    `).expectToHaveNoDiagnostics();
+    `
+        .addExtraFile(
+            "json.d.ts",
+            `
+                /** @noResolution */
+                declare module "json" {
+                    function encode(this: void, data: unknown): string;
+                    function decode(this: void, data: string): unknown;
+                }
+            `
+        )
+        .expectToHaveNoDiagnostics();
 });
 
 test("module resolution should not rewrite @NoResolution requires in library mode", () => {
     const { transpiledFiles } = util.testModule`
         import * as json from "json";
         const test = json.decode("{}");
-    `.addExtraFile("json.d.ts", `
-        /** @noResolution */
-        declare module "json" {
-            function encode(this: void, data: unknown): string;
-            function decode(this: void, data: string): unknown;
-        }
-    `).setOptions({ buildMode: BuildMode.Library }).getLuaResult();
+    `
+        .addExtraFile(
+            "json.d.ts",
+            `
+                /** @noResolution */
+                declare module "json" {
+                    function encode(this: void, data: unknown): string;
+                    function decode(this: void, data: string): unknown;
+                }
+            `
+        )
+        .setOptions({ buildMode: BuildMode.Library })
+        .getLuaResult();
 
     expect(transpiledFiles).toHaveLength(1);
-    expect(transpiledFiles[0].lua).toContain("require(\"@NoResolution:");
+    expect(transpiledFiles[0].lua).toContain('require("@NoResolution:');
 });

--- a/test/transpile/module-resolution.spec.ts
+++ b/test/transpile/module-resolution.spec.ts
@@ -284,6 +284,7 @@ describe("dependency with complicated inner structure", () => {
     const expectedResult = {
         otherFileResult: "someFunc from otherfile.lua",
         otherFileUtil: "util",
+        subsubresult: "result from subsub dir",
         utilResult: "util",
     };
 

--- a/test/transpile/module-resolution.spec.ts
+++ b/test/transpile/module-resolution.spec.ts
@@ -2,7 +2,7 @@ import * as path from "path";
 import * as tstl from "../../src";
 import * as util from "../util";
 import * as ts from "typescript";
-import { transpileProject } from "../../src";
+import { BuildMode, transpileProject } from "../../src";
 
 describe("basic module resolution", () => {
     const projectPath = path.resolve(__dirname, "module-resolution", "project-with-node-modules");
@@ -309,4 +309,33 @@ describe("dependency with complicated inner structure", () => {
     test("should be able to resolve dependency files in subdirectories", () => {
         util.testProject(tsConfigPath).setMainFileName(mainFilePath).expectToEqual(expectedResult);
     });
+});
+
+test("module resolution should not try to resolve @noResolution annotation", () => {
+    util.testModule`
+        import * as json from "json";
+        const test = json.decode("{}");
+    `.addExtraFile("json.d.ts", `
+        /** @noResolution */
+        declare module "json" {
+            function encode(this: void, data: unknown): string;
+            function decode(this: void, data: string): unknown;
+        }
+    `).expectToHaveNoDiagnostics();
+});
+
+test("module resolution should not rewrite @NoResolution requires in library mode", () => {
+    const { transpiledFiles } = util.testModule`
+        import * as json from "json";
+        const test = json.decode("{}");
+    `.addExtraFile("json.d.ts", `
+        /** @noResolution */
+        declare module "json" {
+            function encode(this: void, data: unknown): string;
+            function decode(this: void, data: string): unknown;
+        }
+    `).setOptions({ buildMode: BuildMode.Library }).getLuaResult();
+
+    expect(transpiledFiles).toHaveLength(1);
+    expect(transpiledFiles[0].lua).toContain("require(\"@NoResolution:");
 });

--- a/test/transpile/module-resolution/project-with-complicated-dependency/main.ts
+++ b/test/transpile/module-resolution/project-with-complicated-dependency/main.ts
@@ -3,3 +3,4 @@ import * as dependency1 from "dependency1";
 export const otherFileResult = dependency1.otherFileFromDependency1();
 export const utilResult = dependency1.callUtil();
 export const otherFileUtil = dependency1.otherFileUtil();
+export const subsubresult = dependency1.subsubdirfileResult;

--- a/test/transpile/module-resolution/project-with-complicated-dependency/node_modules/dependency1/index.d.ts
+++ b/test/transpile/module-resolution/project-with-complicated-dependency/node_modules/dependency1/index.d.ts
@@ -2,3 +2,4 @@
 export declare function otherFileFromDependency1(): string;
 export declare function callUtil(): string;
 export declare function otherFileUtil(): string;
+export const subsubdirfileResult: string;

--- a/test/transpile/module-resolution/project-with-complicated-dependency/node_modules/dependency1/index.lua
+++ b/test/transpile/module-resolution/project-with-complicated-dependency/node_modules/dependency1/index.lua
@@ -2,6 +2,7 @@ local otherfile = require("otherfile")
 local util = require("util")
 local subdirfile = require("subdir.subdirfile")
 local othersubdirfile = require("subdir.othersubdirfile")
+local subsubdirfile = require("subdir.subsubdir.subsubdirfile")
 
 return {
     otherFileFromDependency1 = otherfile.someFunc,
@@ -10,5 +11,6 @@ return {
     end,
     otherFileUtil = otherfile.callUtil,
     subdirfileResult = subdirfile.subdirfileResult,
-    othersubdirfileResult = othersubdirfile.othersubdirfileResult
+    othersubdirfileResult = othersubdirfile.othersubdirfileResult,
+    subsubdirfileResult = subsubdirfile.subsubresult
 }

--- a/test/transpile/module-resolution/project-with-complicated-dependency/node_modules/dependency1/subdir/subsubdir/subsubdirfile.lua
+++ b/test/transpile/module-resolution/project-with-complicated-dependency/node_modules/dependency1/subdir/subsubdir/subsubdirfile.lua
@@ -1,0 +1,3 @@
+return {
+    subsubresult = "result from subsub dir"
+}

--- a/test/unit/bundle.spec.ts
+++ b/test/unit/bundle.spec.ts
@@ -109,6 +109,29 @@ test("cyclic imports", () => {
         .expectToEqual(new util.ExecutionError("stack overflow"));
 });
 
+test("does not evaluate files multiple times", () => {
+    util.testBundle`
+        import "./countingfile";
+        import "./otherfile";
+
+        export const count = _count;
+    `
+        .addExtraFile(
+            "otherfile.ts",
+            `
+                import "./countingfile";
+            `
+        )
+        .addExtraFile(
+            "countingfile.ts",
+            `
+                declare var _count: number | undefined;
+                _count = (_count ?? 0) + 1;
+            `
+        )
+        .expectToEqual({ count: 1 });
+});
+
 test("no entry point", () => {
     util.testBundle``
         .setOptions({ luaBundleEntry: undefined })


### PR DESCRIPTION
* Fixes #1063 by correctly replacing all instances of `.` with `/` instead of just the first one
* Fixes #1062 by no longer stripping the @NoResolution prefix from requires when building in library mode, signaling to clients not to try to resolve this require.
* Fixes #1061 by wrapping cached bundle modules in a table, to prevent modules that do not return anything (like lualib) from evaluating more than once, since it returned nil and the cache never realised it had already seen the file.