### PR TITLE
Module resolution should ignore functions that look like requires but are not

### DIFF
--- a/src/transpilation/resolve.ts
+++ b/src/transpilation/resolve.ts
@@ -286,8 +286,12 @@ function findRequiredPaths(code: string): string[] {
 
 function replaceRequireInCode(file: ProcessedFile, originalRequire: string, newRequire: string): void {
     const requirePath = formatPathToLuaPath(newRequire.replace(".lua", ""));
+
+    // Escape special characters to prevent the regex from breaking...
+    const escapedRequire = originalRequire.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
+
     file.code = file.code.replace(
-        new RegExp(`(^|\\s|;|=)require\\("${originalRequire}"\\)`),
+        new RegExp(`(^|\\s|;|=)require\\("${escapedRequire}"\\)`),
         `$1require("${requirePath}")`
     );
 }

--- a/src/transpilation/resolve.ts
+++ b/src/transpilation/resolve.ts
@@ -286,7 +286,10 @@ function findRequiredPaths(code: string): string[] {
 
 function replaceRequireInCode(file: ProcessedFile, originalRequire: string, newRequire: string): void {
     const requirePath = formatPathToLuaPath(newRequire.replace(".lua", ""));
-    file.code = file.code.replace(new RegExp(`(^|\\s|;|=)require\\("${originalRequire}"\\)`), `$1require("${requirePath}")`);
+    file.code = file.code.replace(
+        new RegExp(`(^|\\s|;|=)require\\("${originalRequire}"\\)`),
+        `$1require("${requirePath}")`
+    );
 }
 
 function replaceRequireInSourceMap(file: ProcessedFile, originalRequire: string, newRequire: string): void {

--- a/src/transpilation/resolve.ts
+++ b/src/transpilation/resolve.ts
@@ -274,11 +274,11 @@ function isBuildModeLibrary(program: ts.Program) {
 function findRequiredPaths(code: string): string[] {
     // Find all require("<path>") paths in a lua code string
     const paths: string[] = [];
-    const pattern = /require\("(.+)"\)/g;
+    const pattern = /(^|\s|;|=)require\("(.+)"\)/g;
     // eslint-disable-next-line @typescript-eslint/ban-types
     let match: RegExpExecArray | null;
     while ((match = pattern.exec(code))) {
-        paths.push(match[1]);
+        paths.push(match[2]);
     }
 
     return paths;
@@ -286,7 +286,7 @@ function findRequiredPaths(code: string): string[] {
 
 function replaceRequireInCode(file: ProcessedFile, originalRequire: string, newRequire: string): void {
     const requirePath = formatPathToLuaPath(newRequire.replace(".lua", ""));
-    file.code = file.code.replace(`require("${originalRequire}")`, `require("${requirePath}")`);
+    file.code = file.code.replace(new RegExp(`(^|\\s|;|=)require\\("${originalRequire}"\\)`), `$1require("${requirePath}")`);
 }
 
 function replaceRequireInSourceMap(file: ProcessedFile, originalRequire: string, newRequire: string): void {

--- a/test/transpile/module-resolution.spec.ts
+++ b/test/transpile/module-resolution.spec.ts
@@ -329,6 +329,7 @@ test("module resolution should not try to resolve @noResolution annotation", () 
         .expectToHaveNoDiagnostics();
 });
 
+// https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1062
 test("module resolution should not rewrite @NoResolution requires in library mode", () => {
     const { transpiledFiles } = util.testModule`
         import * as json from "json";
@@ -349,4 +350,37 @@ test("module resolution should not rewrite @NoResolution requires in library mod
 
     expect(transpiledFiles).toHaveLength(1);
     expect(transpiledFiles[0].lua).toContain('require("@NoResolution:');
+});
+
+// https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1050
+test("module resolution should not try to resolve resolve-like functions", () => {
+    util.testModule`
+        function custom_require(this: void, value: string) {
+            return value;
+        }
+
+        namespace ns {
+            export function require(this: void, value: string) {
+                return value;
+            }
+        }
+
+        class MyClass {
+            require(value: string) {
+                return value;
+            }
+        }
+        const inst = new MyClass();
+
+        export const result = [
+            custom_require("value 1"),
+            ns.require("value 2"),
+            inst.require("value 3")
+        ];
+
+    `
+        .expectToHaveNoDiagnostics()
+        .expectToEqual({
+            result: ["value 1", "value 2", "value 3"],
+        });
 });


### PR DESCRIPTION
Characters allowed before `require(`:

* Start of line
* whitespace
* `;`
* `=`

If there is any other character in front of require: ignore it

Part of #1050