### PR TITLE
Check baseUrl when resolving imported files

### DIFF
--- a/src/transpilation/resolve.ts
+++ b/src/transpilation/resolve.ts
@@ -167,7 +167,7 @@ function resolveDependency(
     }
 
     // Check if file is a file in the project
-    const resolvedPath = path.join(fileDirectory, dependency);
+    const resolvedPath = path.join(options.baseUrl ?? fileDirectory, dependency);
 
     const possibleProjectFiles = [
         resolvedPath, // JSON files need their extension as part of the import path, caught by this branch,

--- a/test/util.ts
+++ b/test/util.ts
@@ -178,8 +178,14 @@ export abstract class TestBuilder {
     @memoize
     public getProgram(): ts.Program {
         this.hasProgram = true;
+
+        // Exclude lua files from TS program, but keep them in extraFiles so module resolution can find them
+        const nonLuaExtraFiles = Object.fromEntries(
+            Object.entries(this.extraFiles).filter(([fileName]) => !fileName.endsWith(".lua"))
+        );
+
         return tstl.createVirtualProgram(
-            { ...this.extraFiles, [normalizeSlashes(this.mainFileName)]: this.getTsCode() },
+            { ...nonLuaExtraFiles, [normalizeSlashes(this.mainFileName)]: this.getTsCode() },
             this.options
         );
     }


### PR DESCRIPTION
If baseUrl is provided as setting, use baseUrl as base path for imported files instead of the importing file directory.

Part of #1050 