### PR TITLE
Fix noSelf in object literal methods

### DIFF
--- a/src/transformation/utils/function-context.ts
+++ b/src/transformation/utils/function-context.ts
@@ -113,17 +113,21 @@ function getSignatureDeclarations(
 ): ts.SignatureDeclaration[] {
     return signatures.flatMap(signature => {
         const signatureDeclaration = signature.getDeclaration();
-        if (
+        let inferredType: ts.Type | undefined;
+        if (ts.isMethodDeclaration(signatureDeclaration) && !getExplicitThisParameter(signatureDeclaration)) {
+            inferredType = context.checker.getContextualTypeForObjectLiteralElement(signatureDeclaration);
+        } else if (
             (ts.isFunctionExpression(signatureDeclaration) || ts.isArrowFunction(signatureDeclaration)) &&
             !getExplicitThisParameter(signatureDeclaration)
         ) {
             // Infer type of function expressions/arrow functions
-            const inferredType = inferAssignedType(context, signatureDeclaration);
-            if (inferredType) {
-                const inferredSignatures = getAllCallSignatures(inferredType);
-                if (inferredSignatures.length > 0) {
-                    return inferredSignatures.map(s => s.getDeclaration());
-                }
+            inferredType = inferAssignedType(context, signatureDeclaration);
+        }
+
+        if (inferredType) {
+            const inferredSignatures = getAllCallSignatures(inferredType);
+            if (inferredSignatures.length > 0) {
+                return inferredSignatures.map(s => s.getDeclaration());
             }
         }
 

--- a/src/transformation/utils/function-context.ts
+++ b/src/transformation/utils/function-context.ts
@@ -114,7 +114,11 @@ function getSignatureDeclarations(
     return signatures.flatMap(signature => {
         const signatureDeclaration = signature.getDeclaration();
         let inferredType: ts.Type | undefined;
-        if (ts.isMethodDeclaration(signatureDeclaration) && !getExplicitThisParameter(signatureDeclaration)) {
+        if (
+            ts.isMethodDeclaration(signatureDeclaration) &&
+            ts.isObjectLiteralExpression(signatureDeclaration.parent) &&
+            !getExplicitThisParameter(signatureDeclaration)
+        ) {
             inferredType = context.checker.getContextualTypeForObjectLiteralElement(signatureDeclaration);
         } else if (
             (ts.isFunctionExpression(signatureDeclaration) || ts.isArrowFunction(signatureDeclaration)) &&

--- a/src/typescript-internal.d.ts
+++ b/src/typescript-internal.d.ts
@@ -26,5 +26,6 @@ declare module "typescript" {
 
     interface TypeChecker {
         getElementTypeOfArrayType(type: Type): Type | undefined;
+        getContextualTypeForObjectLiteralElement(element: ObjectLiteralElementLike): Type | undefined;
     }
 }

--- a/test/unit/objectLiteral.spec.ts
+++ b/test/unit/objectLiteral.spec.ts
@@ -63,3 +63,36 @@ test.each(['{x: "foobar"}.x', '{x: "foobar"}["x"]', '{x: () => "foobar"}.x()', '
         util.testExpression(expression).expectToMatchJsResult();
     }
 );
+
+test("noSelf in object literal functions", () => {
+    // language=TypeScript
+    util.testFunction`
+        const foo: Record<string, (this: void, arg: string) => string> = {
+            method(a) {
+                return a;
+            },
+            func: function(a) {
+                return a;
+            },
+            arrow: (a) => {
+                return a;
+            }
+        };
+        return [foo.method("a") ?? "nil", foo.func("b") ?? "nil", foo.arrow("c") ?? "nil"]
+    `.expectToMatchJsResult();
+    // language=TypeScript
+    util.testFunction`
+        const foo: Record<string, /** @noSelf */(arg: string) => string> = {
+            method(a) {
+                return a;
+            },
+            func: function(a) {
+                return a;
+            },
+            arrow: (a) => {
+                return a;
+            }
+        };
+        return [foo.method("a") ?? "nil", foo.func("b") ?? "nil", foo.arrow("c") ?? "nil"]
+    `.expectToMatchJsResult();
+});

--- a/test/unit/objectLiteral.spec.ts
+++ b/test/unit/objectLiteral.spec.ts
@@ -64,35 +64,65 @@ test.each(['{x: "foobar"}.x', '{x: "foobar"}["x"]', '{x: () => "foobar"}.x()', '
     }
 );
 
-test("noSelf in object literal functions", () => {
-    // language=TypeScript
-    util.testFunction`
-        const foo: Record<string, (this: void, arg: string) => string> = {
-            method(a) {
-                return a;
-            },
-            func: function(a) {
-                return a;
-            },
-            arrow: (a) => {
-                return a;
+describe("noSelf in functions", () => {
+    test("Explicit this: void parameter", () => {
+        // language=TypeScript
+        util.testFunction`
+            const obj: Record<string, (this: void, arg: string) => string> = {
+                method(a) {
+                    return a;
+                },
+                func: function(a) {
+                    return a;
+                },
+                arrow: (a) => {
+                    return a;
+                }
+            };
+            return [obj.method("a") ?? "nil", obj.func("b") ?? "nil", obj.arrow("c") ?? "nil"];
+        `.expectToMatchJsResult();
+    });
+
+    test("No self annotation", () => {
+        // language=TypeScript
+        util.testFunction`
+            const obj: Record<string, /** @noSelf */(arg: string) => string> = {
+                method(a) {
+                    return a;
+                },
+                func: function(a) {
+                    return a;
+                },
+                arrow: (a) => {
+                    return a;
+                }
+            };
+            return [obj.method("a") ?? "nil", obj.func("b") ?? "nil", obj.arrow("c") ?? "nil"];
+        `.expectToMatchJsResult();
+    });
+
+    test("individual function types", () => {
+        // language=TypeScript
+        util.testFunction`
+            interface FunctionContainer {
+                method: (this: void, a: string) => string
+                func: (this: void, a: string) => string
+                arrow: (this: void, a: string) => string
             }
-        };
-        return [foo.method("a") ?? "nil", foo.func("b") ?? "nil", foo.arrow("c") ?? "nil"]
-    `.expectToMatchJsResult();
-    // language=TypeScript
-    util.testFunction`
-        const foo: Record<string, /** @noSelf */(arg: string) => string> = {
-            method(a) {
-                return a;
-            },
-            func: function(a) {
-                return a;
-            },
-            arrow: (a) => {
-                return a;
+
+            const obj: FunctionContainer = {
+                method(a) {
+                    return a
+                },
+                func: function(a) {
+                    return a
+                },
+                arrow: (a) => {
+                    return a
+                }
             }
-        };
-        return [foo.method("a") ?? "nil", foo.func("b") ?? "nil", foo.arrow("c") ?? "nil"]
-    `.expectToMatchJsResult();
+
+            return [obj.method("a") ?? "nil", obj.func("b") ?? "nil", obj.arrow("c") ?? "nil"];
+        `.expectToMatchJsResult();
+    });
 });


### PR DESCRIPTION
Fixes #1081.

Found the internal method on `ts.TypeChecker` that does what is needed.