### PR TITLE
Fix context failed to be resolved due to parentheses

### DIFF
--- a/test/unit/classes/classes.spec.ts
+++ b/test/unit/classes/classes.spec.ts
@@ -782,12 +782,12 @@ test("methods accessed via this index pass correct context", () => {
 });
 
 // https://github.com/TypeScriptToLua/TypeScriptToLua/issues/959
-test("methods in parentheses pass correct context", () => {
+test.each(['(this["bar"])', '((((this["bar"]))))'])("methods in parentheses pass correct context %s", callPath => {
     util.testModule`
         class Example {
             baz = 3;
             foo() {
-                (this["bar"])()
+                ${callPath}()
             }
 
             bar() {

--- a/test/unit/classes/classes.spec.ts
+++ b/test/unit/classes/classes.spec.ts
@@ -761,3 +761,41 @@ test("constructor class name available with constructor", () => {
         .setReturnExport("className")
         .expectToEqual("MyClass");
 });
+
+// https://github.com/TypeScriptToLua/TypeScriptToLua/issues/959
+test("methods accessed via this index pass correct context", () => {
+    util.testModule`
+        class Example {
+            baz = 3;
+            foo() {
+                this["bar"]()
+            }
+
+            bar() {
+                return this.baz;
+            }
+        }
+
+        const inst = new Example();
+        export const result = inst.foo();
+    `.expectToMatchJsResult();
+});
+
+// https://github.com/TypeScriptToLua/TypeScriptToLua/issues/959
+test("methods in parentheses pass correct context", () => {
+    util.testModule`
+        class Example {
+            baz = 3;
+            foo() {
+                (this["bar"])()
+            }
+
+            bar() {
+                return this.baz;
+            }
+        }
+
+        const inst = new Example();
+        export const result = inst.foo();
+    `.expectToMatchJsResult();
+});


### PR DESCRIPTION
I have introduced an additional TS transformer before we transform to lua. The transformer simply looks for any call expressions and when it finds them it will unwrap any (nested) `ParenthesisExpression`s that might be in its expression field. This means that calls like `ts.isPropertyAssignment(callExpression.expression)` will not suddenly be `false` due to a random `ParenthesisExpression`.

For now I only transformed callexpression.expressions, in the future we could extend this to do other TS AST transformations before transforming to Lua.

Fixes #959 