### PR TITLE
feat: switch statements for lua 5.1+ (universal)

### DIFF
--- a/src/transformation/visitors/break-continue.ts
+++ b/src/transformation/visitors/break-continue.ts
@@ -8,6 +8,7 @@ import { findScope, ScopeType } from "../utils/scope";
 export const transformBreakStatement: FunctionVisitor<ts.BreakStatement> = (breakStatement, context) => {
     const breakableScope = findScope(context, ScopeType.Loop | ScopeType.Switch);
     if (breakableScope?.type === ScopeType.Switch) {
+        // Break is handled by the switch statement (see transformSwitchStatement)
         return lua.createBreakStatement(breakStatement);
     } else {
         return lua.createBreakStatement(breakStatement);

--- a/src/transformation/visitors/break-continue.ts
+++ b/src/transformation/visitors/break-continue.ts
@@ -8,7 +8,7 @@ import { findScope, ScopeType } from "../utils/scope";
 export const transformBreakStatement: FunctionVisitor<ts.BreakStatement> = (breakStatement, context) => {
     const breakableScope = findScope(context, ScopeType.Loop | ScopeType.Switch);
     if (breakableScope?.type === ScopeType.Switch) {
-        return lua.createGotoStatement(`____switch${breakableScope.id}_end`);
+        return undefined;
     } else {
         return lua.createBreakStatement(breakStatement);
     }

--- a/src/transformation/visitors/break-continue.ts
+++ b/src/transformation/visitors/break-continue.ts
@@ -6,13 +6,8 @@ import { unsupportedForTarget } from "../utils/diagnostics";
 import { findScope, ScopeType } from "../utils/scope";
 
 export const transformBreakStatement: FunctionVisitor<ts.BreakStatement> = (breakStatement, context) => {
-    const breakableScope = findScope(context, ScopeType.Loop | ScopeType.Switch);
-    if (breakableScope?.type === ScopeType.Switch) {
-        // Break is handled by the switch statement (see transformSwitchStatement)
-        return lua.createBreakStatement(breakStatement);
-    } else {
-        return lua.createBreakStatement(breakStatement);
-    }
+    void context;
+    return lua.createBreakStatement(breakStatement);
 };
 
 export const transformContinueStatement: FunctionVisitor<ts.ContinueStatement> = (statement, context) => {

--- a/src/transformation/visitors/break-continue.ts
+++ b/src/transformation/visitors/break-continue.ts
@@ -8,7 +8,7 @@ import { findScope, ScopeType } from "../utils/scope";
 export const transformBreakStatement: FunctionVisitor<ts.BreakStatement> = (breakStatement, context) => {
     const breakableScope = findScope(context, ScopeType.Loop | ScopeType.Switch);
     if (breakableScope?.type === ScopeType.Switch) {
-        return undefined;
+        return lua.createBreakStatement(breakStatement);
     } else {
         return lua.createBreakStatement(breakStatement);
     }

--- a/src/transformation/visitors/switch.ts
+++ b/src/transformation/visitors/switch.ts
@@ -41,10 +41,7 @@ export const transformSwitchStatement: FunctionVisitor<ts.SwitchStatement> = (st
         caseBody[i] = statement.caseBlock.clauses
             .slice(i, end >= 0 ? end + i + 1 : undefined)
             .reduce<lua.Statement[]>(
-                (statements, clause) => [
-                    ...statements,
-                    lua.createDoStatement(context.transformStatements(clause.statements)),
-                ],
+                (statements, clause) => [...statements, ...context.transformStatements(clause.statements)],
                 []
             );
     }
@@ -88,5 +85,5 @@ export const transformSwitchStatement: FunctionVisitor<ts.SwitchStatement> = (st
     const expression = context.transformExpression(statement.expression);
     statements.unshift(lua.createVariableDeclarationStatement(switchVariable, expression));
 
-    return statements;
+    return lua.createDoStatement(statements);
 };

--- a/src/transformation/visitors/switch.ts
+++ b/src/transformation/visitors/switch.ts
@@ -66,9 +66,9 @@ export const transformSwitchStatement: FunctionVisitor<ts.SwitchStatement> = (st
         // Build up the condition for each if statement
         let isInitialCondition = true;
         let condition: lua.Expression | undefined = undefined;
-        for (let i = 0; i < statement.caseBlock.clauses.length; i++) {
-            const clause = statement.caseBlock.clauses[i];
-            const previousClause: ts.CaseOrDefaultClause | undefined = statement.caseBlock.clauses[i - 1];
+        for (let i = 0; i < clauses.length; i++) {
+            const clause = clauses[i];
+            const previousClause: ts.CaseOrDefaultClause | undefined = clauses[i - 1];
 
             // Skip redundant default clauses, will be handled in final default case
             if (i === 0 && ts.isDefaultClause(clause)) continue;
@@ -121,14 +121,15 @@ export const transformSwitchStatement: FunctionVisitor<ts.SwitchStatement> = (st
         const start = clauses.findIndex(c => ts.isDefaultClause(c));
         if (start >= 0) {
             // Find the last clause that we can fallthrough to
-            const end = statement.caseBlock.clauses.findIndex(
+            const end = clauses.findIndex(
                 (clause, index) => index >= start && containsBreakOrReturn(clause.statements)
             );
 
             // Combine the default and all fallthrough statements
             const defaultStatements: lua.Statement[] = [];
-            const clauses = statement.caseBlock.clauses.slice(start, end >= 0 ? end + 1 : undefined);
-            clauses.forEach(c => defaultStatements.push(...context.transformStatements(c.statements)));
+            clauses
+                .slice(start, end >= 0 ? end + 1 : undefined)
+                .forEach(c => defaultStatements.push(...context.transformStatements(c.statements)));
 
             // Add the default clause if it has any statements
             if (defaultStatements.length) {

--- a/src/transformation/visitors/switch.ts
+++ b/src/transformation/visitors/switch.ts
@@ -27,32 +27,9 @@ export const transformSwitchStatement: FunctionVisitor<ts.SwitchStatement> = (st
     const switchVariable = lua.createIdentifier(switchName);
     const conditionVariable = lua.createIdentifier(conditionName);
 
-    // Collect all the expressions into a single expression for use in the default clause
-    let allExpressions: lua.BinaryExpression;
-    statement.caseBlock.clauses.forEach(clause => {
-        if (!ts.isDefaultClause(clause)) {
-            allExpressions = allExpressions
-                ? lua.createBinaryExpression(
-                      allExpressions,
-                      lua.createBinaryExpression(
-                          switchVariable,
-                          context.transformExpression(clause.expression),
-                          lua.SyntaxKind.EqualityOperator
-                      ),
-                      lua.SyntaxKind.OrOperator
-                  )
-                : lua.createBinaryExpression(
-                      switchVariable,
-                      context.transformExpression(clause.expression),
-                      lua.SyntaxKind.EqualityOperator
-                  );
-        }
-    });
-
-    let statements: lua.Statement[] = [];
-
     // If the switch only has a default clause, wrap it in a single do.
     // Otherwise, we need to generate a set of if statements to emulate the switch.
+    let statements: lua.Statement[] = [];
     const clauses = statement.caseBlock.clauses;
     if (clauses.length === 1 && ts.isDefaultClause(clauses[0])) {
         const defaultClause = clauses[0].statements;

--- a/src/transformation/visitors/switch.ts
+++ b/src/transformation/visitors/switch.ts
@@ -94,11 +94,6 @@ export const transformSwitchStatement: FunctionVisitor<ts.SwitchStatement> = (st
                 );
                 isInitialCondition = false;
             } else {
-                // If the default is not fallen into skip it and handle in the final default output instead
-                if (previousClause && containsBreakOrReturn(previousClause.statements)) {
-                    continue;
-                }
-
                 // If the default is proceeded by empty clauses and will be emitted we may need to initialize the condition
                 if (isInitialCondition) {
                     statements.push(
@@ -109,6 +104,9 @@ export const transformSwitchStatement: FunctionVisitor<ts.SwitchStatement> = (st
                     );
                     isInitialCondition = false;
                 }
+
+                // Skip default clause if is the last clause, as it will fallthrough to the final default below
+                if (i === clauses.length - 1) continue;
             }
 
             // Transform the clause and append the final break statement if necessary

--- a/src/transformation/visitors/switch.ts
+++ b/src/transformation/visitors/switch.ts
@@ -116,8 +116,8 @@ export const transformSwitchStatement: FunctionVisitor<ts.SwitchStatement> = (st
             condition = undefined;
         }
 
-        // If no conditions above match, we need to create the final default case code-path
-        // As we only handle fallthrough into defaults in the previous if statement chain
+        // If no conditions above match, we need to create the final default case code-path,
+        // as we only handle fallthrough into defaults in the previous if statement chain
         const start = clauses.findIndex(c => ts.isDefaultClause(c));
         if (start >= 0) {
             // Find the last clause that we can fallthrough to

--- a/src/transformation/visitors/switch.ts
+++ b/src/transformation/visitors/switch.ts
@@ -6,6 +6,7 @@ import { performHoisting, popScope, pushScope, ScopeType } from "../utils/scope"
 const containsBreakStatement = (statements: ts.Node[]): boolean => {
     for (const s of statements) {
         if (
+            ts.isIfStatement(s) ||
             ts.isSwitchStatement(s) ||
             ts.isWhileStatement(s) ||
             ts.isDoStatement(s) ||
@@ -85,5 +86,5 @@ export const transformSwitchStatement: FunctionVisitor<ts.SwitchStatement> = (st
     const expression = context.transformExpression(statement.expression);
     statements.unshift(lua.createVariableDeclarationStatement(switchVariable, expression));
 
-    return lua.createDoStatement(statements);
+    return lua.createRepeatStatement(lua.createBlock(statements), lua.createBooleanLiteral(true));
 };

--- a/src/transformation/visitors/switch.ts
+++ b/src/transformation/visitors/switch.ts
@@ -80,8 +80,8 @@ export const transformSwitchStatement: FunctionVisitor<ts.SwitchStatement> = (st
             if (!ts.isDefaultClause(clause)) {
                 condition = coalesceCondition(condition, switchVariable, clause.expression, context);
 
-                // Skip empty clauses
-                if (clause.statements.length === 0) continue;
+                // Skip empty clauses unless final clause (i.e side-effects)
+                if (i !== clauses.length - 1 && clause.statements.length === 0) continue;
 
                 // Declare or assign condition variable
                 statements.push(

--- a/src/transformation/visitors/switch.ts
+++ b/src/transformation/visitors/switch.ts
@@ -3,22 +3,14 @@ import * as lua from "../../LuaAST";
 import { FunctionVisitor } from "../context";
 import { performHoisting, popScope, pushScope, ScopeType } from "../utils/scope";
 
-const containsBreakStatement = (statements: ts.Node[]): boolean => {
+const containsBreakOrReturn = (statements: ts.Node[]): boolean => {
     for (const s of statements) {
-        if (
-            ts.isIfStatement(s) ||
-            ts.isSwitchStatement(s) ||
-            ts.isWhileStatement(s) ||
-            ts.isDoStatement(s) ||
-            ts.isForStatement(s) ||
-            ts.isForInStatement(s) ||
-            ts.isForOfStatement(s)
-        ) {
-            // Ignore: Break statements are valid as children of these
-            //         statements without breaking the clause
-        } else if (ts.isBreakStatement(s)) {
+        if (ts.isBreakStatement(s) || ts.isReturnStatement(s)) {
             return true;
-        } else if (containsBreakStatement(s.getChildren())) {
+        } else if (!ts.isBlock(s)) {
+            // Can only ensure a break scoped in a block is deterministic
+            continue;
+        } else if (containsBreakOrReturn(s.getChildren())) {
             return true;
         }
     }
@@ -33,51 +25,77 @@ export const transformSwitchStatement: FunctionVisitor<ts.SwitchStatement> = (st
     const switchName = `____switch${scope.id}`;
     const switchVariable = lua.createIdentifier(switchName);
 
-    // Collect the fallthrough bodies for each case as defined by the switch.
-    const caseBody: lua.Statement[][] = [];
-    for (let i = 0; i < statement.caseBlock.clauses.length; i++) {
-        const end = statement.caseBlock.clauses
-            .slice(i)
-            .findIndex(clause => containsBreakStatement([...clause.statements]));
-        caseBody[i] = statement.caseBlock.clauses
-            .slice(i, end >= 0 ? end + i + 1 : undefined)
-            .reduce<lua.Statement[]>(
-                (statements, clause) => [...statements, ...context.transformStatements(clause.statements)],
-                []
-            );
-    }
+    // Collect the case clause expressions and accounting for deterministic fallthrough
+    let allExpressions: lua.BinaryExpression;
+    statement.caseBlock.clauses.forEach(clause => {
+        if (!ts.isDefaultClause(clause)) {
+            allExpressions = allExpressions
+                ? lua.createBinaryExpression(
+                      allExpressions,
+                      lua.createBinaryExpression(
+                          switchVariable,
+                          context.transformExpression(clause.expression),
+                          lua.SyntaxKind.EqualityOperator
+                      ),
+                      lua.SyntaxKind.OrOperator
+                  )
+                : lua.createBinaryExpression(
+                      switchVariable,
+                      context.transformExpression(clause.expression),
+                      lua.SyntaxKind.EqualityOperator
+                  );
+        }
+    });
 
     let statements: lua.Statement[] = [];
 
     // Default will either be the only statement, or the else in the if chain
     const defaultIndex = statement.caseBlock.clauses.findIndex(c => ts.isDefaultClause(c));
-    const defaultBody = defaultIndex >= 0 ? caseBody[defaultIndex] : undefined;
+    const defaultBody = defaultIndex >= 0 ? statement.caseBlock.clauses[defaultIndex].statements : undefined;
     if (defaultBody && statement.caseBlock.clauses.length === 1) {
-        statements.push(lua.createDoStatement(defaultBody));
+        statements.push(lua.createDoStatement(context.transformStatements(defaultBody)));
     } else {
-        let concatenatedIf: lua.IfStatement | undefined = undefined;
-        let previousCondition: lua.IfStatement | lua.Block | undefined = defaultBody
-            ? lua.createBlock(defaultBody)
-            : undefined;
+        let previousClause: ts.CaseOrDefaultClause;
+        let condition: lua.Expression;
+        statement.caseBlock.clauses.forEach(clause => {
+            if (!condition || (previousClause && containsBreakOrReturn([...previousClause.statements]))) {
+                if (ts.isDefaultClause(clause)) {
+                    condition = lua.createUnaryExpression(allExpressions, lua.SyntaxKind.NotOperator);
+                } else {
+                    condition = lua.createBinaryExpression(
+                        switchVariable,
+                        context.transformExpression(clause.expression),
+                        lua.SyntaxKind.EqualityOperator
+                    );
+                }
+            } else {
+                if (ts.isDefaultClause(clause)) {
+                    condition = lua.createBinaryExpression(
+                        condition,
+                        lua.createUnaryExpression(allExpressions, lua.SyntaxKind.NotOperator),
+                        lua.SyntaxKind.OrOperator
+                    );
+                } else {
+                    condition = lua.createBinaryExpression(
+                        condition,
+                        lua.createBinaryExpression(
+                            switchVariable,
+                            context.transformExpression(clause.expression),
+                            lua.SyntaxKind.EqualityOperator
+                        ),
+                        lua.SyntaxKind.OrOperator
+                    );
+                }
+            }
 
-        // Starting from the back, concatenating ifs into one big if/elseif/[else] statement
-        for (let i = statement.caseBlock.clauses.length - 1; i >= 0; i--) {
-            const clause = statement.caseBlock.clauses[i];
+            if (condition && clause.statements.length) {
+                statements.push(
+                    lua.createIfStatement(condition, lua.createBlock(context.transformStatements(clause.statements)))
+                );
+            }
 
-            // Skip default clause to keep index aligned, handle in else block
-            if (ts.isDefaultClause(clause)) continue;
-
-            // If the clause condition holds, go to the correct label
-            const condition = lua.createBinaryExpression(
-                switchVariable,
-                context.transformExpression(clause.expression),
-                lua.SyntaxKind.EqualityOperator
-            );
-
-            concatenatedIf = lua.createIfStatement(condition, lua.createBlock(caseBody[i]), previousCondition);
-            previousCondition = concatenatedIf;
-        }
-        if (concatenatedIf) statements.push(concatenatedIf);
+            previousClause = clause;
+        });
     }
 
     statements = performHoisting(context, statements);

--- a/src/transformation/visitors/switch.ts
+++ b/src/transformation/visitors/switch.ts
@@ -3,8 +3,8 @@ import * as lua from "../../LuaAST";
 import { FunctionVisitor, TransformationContext } from "../context";
 import { performHoisting, popScope, pushScope, ScopeType } from "../utils/scope";
 
-const containsBreakOrReturn = (statements: ts.Node[]): boolean => {
-    for (const s of statements) {
+const containsBreakOrReturn = (nodes: Iterable<ts.Node>): boolean => {
+    for (const s of nodes) {
         if (ts.isBreakStatement(s) || ts.isReturnStatement(s)) {
             return true;
         } else if (ts.isBlock(s) && containsBreakOrReturn(s.getChildren())) {
@@ -72,7 +72,7 @@ export const transformSwitchStatement: FunctionVisitor<ts.SwitchStatement> = (st
 
             // Skip redundant default clauses, will be handled in final default case
             if (i === 0 && ts.isDefaultClause(clause)) continue;
-            if (ts.isDefaultClause(clause) && previousClause && containsBreakOrReturn([...previousClause.statements])) {
+            if (ts.isDefaultClause(clause) && previousClause && containsBreakOrReturn(previousClause.statements)) {
                 continue;
             }
 
@@ -122,7 +122,7 @@ export const transformSwitchStatement: FunctionVisitor<ts.SwitchStatement> = (st
         if (start >= 0) {
             // Find the last clause that we can fallthrough to
             const end = statement.caseBlock.clauses.findIndex(
-                (clause, index) => index >= start && containsBreakOrReturn([...clause.statements])
+                (clause, index) => index >= start && containsBreakOrReturn(clause.statements)
             );
 
             // Combine the default and all fallthrough statements

--- a/src/transformation/visitors/switch.ts
+++ b/src/transformation/visitors/switch.ts
@@ -39,8 +39,6 @@ export const transformSwitchStatement: FunctionVisitor<ts.SwitchStatement> = (st
         }
     } else {
         // Build up the condition for each if statement
-        // Fallthrough is handled by accepting the last condition as an additional or clause
-        // Default is the not of all known case expressions
         let isInitialCondition = true;
         let condition: lua.Expression | undefined = undefined;
         for (let i = 0; i < statement.caseBlock.clauses.length; i++) {

--- a/src/transformation/visitors/switch.ts
+++ b/src/transformation/visitors/switch.ts
@@ -1,55 +1,80 @@
 import * as ts from "typescript";
-import { LuaTarget } from "../../CompilerOptions";
 import * as lua from "../../LuaAST";
 import { FunctionVisitor } from "../context";
-import { unsupportedForTarget } from "../utils/diagnostics";
 import { performHoisting, popScope, pushScope, ScopeType } from "../utils/scope";
 
-export const transformSwitchStatement: FunctionVisitor<ts.SwitchStatement> = (statement, context) => {
-    if (context.luaTarget === LuaTarget.Universal || context.luaTarget === LuaTarget.Lua51) {
-        context.diagnostics.push(unsupportedForTarget(statement, "Switch statements", LuaTarget.Lua51));
+const containsBreakStatement = (statements: ts.Node[]): boolean => {
+    for (const s of statements) {
+        if (
+            ts.isSwitchStatement(s) ||
+            ts.isWhileStatement(s) ||
+            ts.isDoStatement(s) ||
+            ts.isForStatement(s) ||
+            ts.isForInStatement(s) ||
+            ts.isForOfStatement(s)
+        ) {
+            // Ignore: Break statements are valid as children of these
+            //         statements without breaking the clause
+        } else if (ts.isBreakStatement(s)) {
+            return true;
+        } else if (containsBreakStatement(s.getChildren())) {
+            return true;
+        }
     }
 
+    return false;
+};
+
+export const transformSwitchStatement: FunctionVisitor<ts.SwitchStatement> = (statement, context) => {
     const scope = pushScope(context, ScopeType.Switch);
 
     // Give the switch a unique name to prevent nested switches from acting up.
     const switchName = `____switch${scope.id}`;
     const switchVariable = lua.createIdentifier(switchName);
 
-    let statements: lua.Statement[] = [];
+    // Collect the fallthrough bodies for each case as defined by the switch.
+    const caseBody: lua.Statement[][] = [];
+    for (let i = 0; i < statement.caseBlock.clauses.length; i++) {
+        const end = statement.caseBlock.clauses
+            .slice(i)
+            .findIndex(clause => containsBreakStatement([...clause.statements]));
+        caseBody[i] = statement.caseBlock.clauses
+            .slice(i, end >= 0 ? end + i + 1 : undefined)
+            .reduce<lua.Statement[]>(
+                (statements, clause) => [
+                    ...statements,
+                    lua.createDoStatement(context.transformStatements(clause.statements)),
+                ],
+                []
+            );
+    }
 
     // Starting from the back, concatenating ifs into one big if/elseif statement
-    const concatenatedIf = statement.caseBlock.clauses.reduceRight((previousCondition, clause, index) => {
-        if (ts.isDefaultClause(clause)) {
-            // Skip default clause here (needs to be included to ensure index lines up with index later)
-            return previousCondition;
-        }
+    const defaultIndex = statement.caseBlock.clauses.findIndex(c => ts.isDefaultClause(c));
+    const concatenatedIf = statement.caseBlock.clauses.reduceRight<lua.IfStatement | lua.Block | undefined>(
+        (previousCondition, clause, index) => {
+            if (ts.isDefaultClause(clause)) {
+                // Skip default clause here (needs to be included to ensure index lines up with index later)
+                return previousCondition;
+            }
 
-        // If the clause condition holds, go to the correct label
-        const condition = lua.createBinaryExpression(
-            switchVariable,
-            context.transformExpression(clause.expression),
-            lua.SyntaxKind.EqualityOperator
-        );
+            // If the clause condition holds, go to the correct label
+            const condition = lua.createBinaryExpression(
+                switchVariable,
+                context.transformExpression(clause.expression),
+                lua.SyntaxKind.EqualityOperator
+            );
 
-        const goto = lua.createGotoStatement(`${switchName}_case_${index}`);
-        return lua.createIfStatement(condition, lua.createBlock([goto]), previousCondition);
-    }, undefined as lua.IfStatement | undefined);
+            return lua.createIfStatement(condition, lua.createBlock(caseBody[index]), previousCondition);
+        },
+        defaultIndex >= 0 ? lua.createBlock(caseBody[defaultIndex]) : undefined
+    );
+
+    let statements: lua.Statement[] = [];
 
     if (concatenatedIf) {
-        statements.push(concatenatedIf);
+        statements.push(concatenatedIf as unknown as lua.IfStatement);
     }
-
-    const hasDefaultCase = statement.caseBlock.clauses.some(ts.isDefaultClause);
-    statements.push(lua.createGotoStatement(`${switchName}_${hasDefaultCase ? "case_default" : "end"}`));
-
-    for (const [index, clause] of statement.caseBlock.clauses.entries()) {
-        const labelName = `${switchName}_case_${ts.isCaseClause(clause) ? index : "default"}`;
-        statements.push(lua.createLabelStatement(labelName));
-        statements.push(lua.createDoStatement(context.transformStatements(clause.statements)));
-    }
-
-    statements.push(lua.createLabelStatement(`${switchName}_end`));
 
     statements = performHoisting(context, statements);
     popScope(context);

--- a/test/unit/__snapshots__/switch.spec.ts.snap
+++ b/test/unit/__snapshots__/switch.spec.ts.snap
@@ -7,8 +7,7 @@ function ____exports.__main(self)
     local out = {}
     repeat
         local ____switch3 = 5
-        local ____cond3 = false
-        ____cond3 = ____cond3 or (((____switch3 == 0) or (____switch3 == 1)) or (____switch3 == 2))
+        local ____cond3 = ((____switch3 == 0) or (____switch3 == 1)) or (____switch3 == 2)
         if ____cond3 then
             __TS__ArrayPush(out, \\"0,1,2\\")
         end
@@ -16,9 +15,6 @@ function ____exports.__main(self)
         if ____cond3 then
             __TS__ArrayPush(out, \\"3\\")
             break
-        end
-        if ____cond3 then
-            __TS__ArrayPush(out, \\"default\\")
         end
         ____cond3 = ____cond3 or (____switch3 == 4)
         if ____cond3 then
@@ -34,14 +30,177 @@ end
 return ____exports"
 `;
 
+exports[`switch handles side-effects (0) 1`] = `
+"require(\\"lualib_bundle\\");
+local ____exports = {}
+function ____exports.__main(self)
+    local out = {}
+    local y = 0
+    local function foo(self)
+        return (function()
+            local ____tmp = y
+            y = ____tmp + 1
+            return ____tmp
+        end)()
+    end
+    local x = 0
+    repeat
+        local ____switch5 = x
+        local ____cond5 = ____switch5 == foo(nil)
+        if ____cond5 then
+            __TS__ArrayPush(out, 1)
+        end
+        ____cond5 = ____cond5 or (____switch5 == foo(nil))
+        if ____cond5 then
+            __TS__ArrayPush(out, 2)
+        end
+        ____cond5 = ____cond5 or (____switch5 == foo(nil))
+        if ____cond5 then
+            __TS__ArrayPush(out, 3)
+        end
+        if ____cond5 then
+            __TS__ArrayPush(out, \\"default\\")
+        end
+        if not ____cond5 then
+            __TS__ArrayPush(out, \\"default\\")
+        end
+    until true
+    __TS__ArrayPush(out, y)
+    return out
+end
+return ____exports"
+`;
+
+exports[`switch handles side-effects (1) 1`] = `
+"require(\\"lualib_bundle\\");
+local ____exports = {}
+function ____exports.__main(self)
+    local out = {}
+    local y = 0
+    local function foo(self)
+        return (function()
+            local ____tmp = y
+            y = ____tmp + 1
+            return ____tmp
+        end)()
+    end
+    local x = 1
+    repeat
+        local ____switch5 = x
+        local ____cond5 = ____switch5 == foo(nil)
+        if ____cond5 then
+            __TS__ArrayPush(out, 1)
+        end
+        ____cond5 = ____cond5 or (____switch5 == foo(nil))
+        if ____cond5 then
+            __TS__ArrayPush(out, 2)
+        end
+        ____cond5 = ____cond5 or (____switch5 == foo(nil))
+        if ____cond5 then
+            __TS__ArrayPush(out, 3)
+        end
+        if ____cond5 then
+            __TS__ArrayPush(out, \\"default\\")
+        end
+        if not ____cond5 then
+            __TS__ArrayPush(out, \\"default\\")
+        end
+    until true
+    __TS__ArrayPush(out, y)
+    return out
+end
+return ____exports"
+`;
+
+exports[`switch handles side-effects (2) 1`] = `
+"require(\\"lualib_bundle\\");
+local ____exports = {}
+function ____exports.__main(self)
+    local out = {}
+    local y = 0
+    local function foo(self)
+        return (function()
+            local ____tmp = y
+            y = ____tmp + 1
+            return ____tmp
+        end)()
+    end
+    local x = 2
+    repeat
+        local ____switch5 = x
+        local ____cond5 = ____switch5 == foo(nil)
+        if ____cond5 then
+            __TS__ArrayPush(out, 1)
+        end
+        ____cond5 = ____cond5 or (____switch5 == foo(nil))
+        if ____cond5 then
+            __TS__ArrayPush(out, 2)
+        end
+        ____cond5 = ____cond5 or (____switch5 == foo(nil))
+        if ____cond5 then
+            __TS__ArrayPush(out, 3)
+        end
+        if ____cond5 then
+            __TS__ArrayPush(out, \\"default\\")
+        end
+        if not ____cond5 then
+            __TS__ArrayPush(out, \\"default\\")
+        end
+    until true
+    __TS__ArrayPush(out, y)
+    return out
+end
+return ____exports"
+`;
+
+exports[`switch handles side-effects (3) 1`] = `
+"require(\\"lualib_bundle\\");
+local ____exports = {}
+function ____exports.__main(self)
+    local out = {}
+    local y = 0
+    local function foo(self)
+        return (function()
+            local ____tmp = y
+            y = ____tmp + 1
+            return ____tmp
+        end)()
+    end
+    local x = 3
+    repeat
+        local ____switch5 = x
+        local ____cond5 = ____switch5 == foo(nil)
+        if ____cond5 then
+            __TS__ArrayPush(out, 1)
+        end
+        ____cond5 = ____cond5 or (____switch5 == foo(nil))
+        if ____cond5 then
+            __TS__ArrayPush(out, 2)
+        end
+        ____cond5 = ____cond5 or (____switch5 == foo(nil))
+        if ____cond5 then
+            __TS__ArrayPush(out, 3)
+        end
+        if ____cond5 then
+            __TS__ArrayPush(out, \\"default\\")
+        end
+        if not ____cond5 then
+            __TS__ArrayPush(out, \\"default\\")
+        end
+    until true
+    __TS__ArrayPush(out, y)
+    return out
+end
+return ____exports"
+`;
+
 exports[`switch uses elseif 1`] = `
 "local ____exports = {}
 function ____exports.__main(self)
     local result = -1
     repeat
         local ____switch3 = 2
-        local ____cond3 = false
-        ____cond3 = ____cond3 or (____switch3 == 0)
+        local ____cond3 = ____switch3 == 0
         if ____cond3 then
             do
                 result = 200

--- a/test/unit/__snapshots__/switch.spec.ts.snap
+++ b/test/unit/__snapshots__/switch.spec.ts.snap
@@ -1,5 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`switch empty fallthrough to default (0) 1`] = `
+"require(\\"lualib_bundle\\");
+local ____exports = {}
+function ____exports.__main(self)
+    local out = {}
+    repeat
+        local ____switch3 = 0
+        local ____cond3 = ____switch3 == 1
+        if ____cond3 then
+            __TS__ArrayPush(out, \\"default\\")
+        end
+        if not ____cond3 then
+            __TS__ArrayPush(out, \\"default\\")
+        end
+    until true
+    return out
+end
+return ____exports"
+`;
+
+exports[`switch empty fallthrough to default (1) 1`] = `
+"require(\\"lualib_bundle\\");
+local ____exports = {}
+function ____exports.__main(self)
+    local out = {}
+    repeat
+        local ____switch3 = 1
+        local ____cond3 = ____switch3 == 1
+        if ____cond3 then
+            __TS__ArrayPush(out, \\"default\\")
+        end
+        if not ____cond3 then
+            __TS__ArrayPush(out, \\"default\\")
+        end
+    until true
+    return out
+end
+return ____exports"
+`;
+
 exports[`switch produces optimal output 1`] = `
 "require(\\"lualib_bundle\\");
 local ____exports = {}

--- a/test/unit/__snapshots__/switch.spec.ts.snap
+++ b/test/unit/__snapshots__/switch.spec.ts.snap
@@ -8,10 +8,6 @@ function ____exports.__main(self)
     repeat
         local ____switch3 = 0
         local ____cond3 = ____switch3 == 1
-        if ____cond3 then
-            __TS__ArrayPush(out, \\"default\\")
-            break
-        end
         do
             __TS__ArrayPush(out, \\"default\\")
         end
@@ -29,10 +25,6 @@ function ____exports.__main(self)
     repeat
         local ____switch3 = 1
         local ____cond3 = ____switch3 == 1
-        if ____cond3 then
-            __TS__ArrayPush(out, \\"default\\")
-            break
-        end
         do
             __TS__ArrayPush(out, \\"default\\")
         end

--- a/test/unit/__snapshots__/switch.spec.ts.snap
+++ b/test/unit/__snapshots__/switch.spec.ts.snap
@@ -1,52 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`switch not allowed in 5.1: code 1`] = `
-"local ____exports = {}
-function ____exports.__main(self)
-    local ____switch3 = \\"abc\\"
-    goto ____switch3_end
-    ::____switch3_end::
-end
-return ____exports"
-`;
-
-exports[`switch not allowed in 5.1: diagnostics 1`] = `"main.ts(2,9): error TSTL: Switch statements is/are not supported for target Lua 5.1."`;
-
 exports[`switch uses elseif 1`] = `
 "local ____exports = {}
 function ____exports.__main(self)
     local result = -1
     local ____switch3 = 2
     if ____switch3 == 0 then
-        goto ____switch3_case_0
+        do
+            do
+                result = 200
+            end
+        end
     elseif ____switch3 == 1 then
-        goto ____switch3_case_1
+        do
+            do
+                result = 100
+            end
+        end
     elseif ____switch3 == 2 then
-        goto ____switch3_case_2
-    end
-    goto ____switch3_end
-    ::____switch3_case_0::
-    do
         do
-            result = 200
-            goto ____switch3_end
+            do
+                result = 1
+            end
         end
     end
-    ::____switch3_case_1::
-    do
-        do
-            result = 100
-            goto ____switch3_end
-        end
-    end
-    ::____switch3_case_2::
-    do
-        do
-            result = 1
-            goto ____switch3_end
-        end
-    end
-    ::____switch3_end::
     return result
 end
 return ____exports"

--- a/test/unit/__snapshots__/switch.spec.ts.snap
+++ b/test/unit/__snapshots__/switch.spec.ts.snap
@@ -1,5 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`switch collapses empty case and minimizes conditions 1`] = `
+"require(\\"lualib_bundle\\");
+local ____exports = {}
+function ____exports.__main(self)
+    local out = {}
+    repeat
+        local ____switch3 = 5
+        if ((____switch3 == 0) or (____switch3 == 1)) or (____switch3 == 2) then
+            __TS__ArrayPush(out, \\"0,1,2\\")
+        end
+        if (((____switch3 == 0) or (____switch3 == 1)) or (____switch3 == 2)) or (____switch3 == 3) then
+            __TS__ArrayPush(out, \\"3\\")
+            break
+        end
+        if not (((((____switch3 == 0) or (____switch3 == 1)) or (____switch3 == 2)) or (____switch3 == 3)) or (____switch3 == 4)) then
+            __TS__ArrayPush(out, \\"default\\")
+        end
+        if (not (((((____switch3 == 0) or (____switch3 == 1)) or (____switch3 == 2)) or (____switch3 == 3)) or (____switch3 == 4))) or (____switch3 == 4) then
+            __TS__ArrayPush(out, \\"4\\")
+        end
+    until true
+    return out
+end
+return ____exports"
+`;
+
 exports[`switch uses elseif 1`] = `
 "local ____exports = {}
 function ____exports.__main(self)
@@ -11,12 +37,14 @@ function ____exports.__main(self)
                 result = 200
                 break
             end
-        elseif ____switch3 == 1 then
+        end
+        if (____switch3 == 0) or (____switch3 == 1) then
             do
                 result = 100
                 break
             end
-        elseif ____switch3 == 2 then
+        end
+        if ((____switch3 == 0) or (____switch3 == 1)) or (____switch3 == 2) then
             do
                 result = 1
                 break

--- a/test/unit/__snapshots__/switch.spec.ts.snap
+++ b/test/unit/__snapshots__/switch.spec.ts.snap
@@ -56,47 +56,57 @@ function ____exports.__main(self)
         end
         ____cond3 = ____cond3 or (____switch3 == 3)
         if ____cond3 then
-            __TS__ArrayPush(out, \\"3\\")
+            do
+                __TS__ArrayPush(out, \\"3\\")
+                break
+            end
+        end
+        ____cond3 = ____cond3 or (____switch3 == 4)
+        if ____cond3 then
+            __TS__ArrayPush(out, \\"4\\")
         end
         if not ____cond3 then
             __TS__ArrayPush(out, \\"default\\")
-            __TS__ArrayPush(out, \\"3\\")
+            do
+                __TS__ArrayPush(out, \\"3\\")
+                break
+            end
         end
     until true
     repeat
-        local ____switch4 = 2
-        local ____cond4 = (____switch4 == 0) or (____switch4 == 1)
-        if ____cond4 then
+        local ____switch6 = 2
+        local ____cond6 = (____switch6 == 0) or (____switch6 == 1)
+        if ____cond6 then
             __TS__ArrayPush(out, \\"0,1\\")
             break
         end
-        if not ____cond4 then
+        if not ____cond6 then
             __TS__ArrayPush(out, \\"default\\")
             __TS__ArrayPush(out, \\"0,1\\")
             break
         end
     until true
     repeat
-        local ____switch5 = 5
-        local ____cond5 = ____switch5 == 0
-        if ____cond5 then
+        local ____switch7 = 5
+        local ____cond7 = ____switch7 == 0
+        if ____cond7 then
             __TS__ArrayPush(out, \\"0\\")
         end
-        ____cond5 = ____cond5 or (____switch5 == 1)
-        if ____cond5 then
+        ____cond7 = ____cond7 or (____switch7 == 1)
+        if ____cond7 then
             __TS__ArrayPush(out, \\"1\\")
             break
         end
-        ____cond5 = ____cond5 or (____switch5 == 2)
-        if ____cond5 then
+        ____cond7 = ____cond7 or (____switch7 == 2)
+        if ____cond7 then
             __TS__ArrayPush(out, \\"0,1,2\\")
         end
-        ____cond5 = ____cond5 or (____switch5 == 3)
-        if ____cond5 then
+        ____cond7 = ____cond7 or (____switch7 == 3)
+        if ____cond7 then
             __TS__ArrayPush(out, \\"3\\")
             break
         end
-        if not ____cond5 then
+        if not ____cond7 then
             __TS__ArrayPush(out, \\"default\\")
         end
     until true

--- a/test/unit/__snapshots__/switch.spec.ts.snap
+++ b/test/unit/__snapshots__/switch.spec.ts.snap
@@ -10,8 +10,9 @@ function ____exports.__main(self)
         local ____cond3 = ____switch3 == 1
         if ____cond3 then
             __TS__ArrayPush(out, \\"default\\")
+            break
         end
-        if not ____cond3 then
+        do
             __TS__ArrayPush(out, \\"default\\")
         end
     until true
@@ -30,8 +31,9 @@ function ____exports.__main(self)
         local ____cond3 = ____switch3 == 1
         if ____cond3 then
             __TS__ArrayPush(out, \\"default\\")
+            break
         end
-        if not ____cond3 then
+        do
             __TS__ArrayPush(out, \\"default\\")
         end
     until true
@@ -44,15 +46,14 @@ exports[`switch produces optimal output 1`] = `
 "require(\\"lualib_bundle\\");
 local ____exports = {}
 function ____exports.__main(self)
+    local x = 0
     local out = {}
     repeat
         local ____switch3 = 0
         local ____cond3 = ((____switch3 == 0) or (____switch3 == 1)) or (____switch3 == 2)
         if ____cond3 then
             __TS__ArrayPush(out, \\"0,1,2\\")
-        end
-        if ____cond3 then
-            __TS__ArrayPush(out, \\"default\\")
+            break
         end
         ____cond3 = ____cond3 or (____switch3 == 3)
         if ____cond3 then
@@ -63,53 +64,24 @@ function ____exports.__main(self)
         end
         ____cond3 = ____cond3 or (____switch3 == 4)
         if ____cond3 then
-            __TS__ArrayPush(out, \\"4\\")
+            break
         end
-        if not ____cond3 then
-            __TS__ArrayPush(out, \\"default\\")
+        do
+            x = x + 1
+            __TS__ArrayPush(
+                out,
+                \\"default = \\" .. tostring(x)
+            )
             do
                 __TS__ArrayPush(out, \\"3\\")
                 break
             end
         end
     until true
-    repeat
-        local ____switch6 = 2
-        local ____cond6 = (____switch6 == 0) or (____switch6 == 1)
-        if ____cond6 then
-            __TS__ArrayPush(out, \\"0,1\\")
-            break
-        end
-        if not ____cond6 then
-            __TS__ArrayPush(out, \\"default\\")
-            __TS__ArrayPush(out, \\"0,1\\")
-            break
-        end
-    until true
-    repeat
-        local ____switch7 = 5
-        local ____cond7 = ____switch7 == 0
-        if ____cond7 then
-            __TS__ArrayPush(out, \\"0\\")
-        end
-        ____cond7 = ____cond7 or (____switch7 == 1)
-        if ____cond7 then
-            __TS__ArrayPush(out, \\"1\\")
-            break
-        end
-        ____cond7 = ____cond7 or (____switch7 == 2)
-        if ____cond7 then
-            __TS__ArrayPush(out, \\"0,1,2\\")
-        end
-        ____cond7 = ____cond7 or (____switch7 == 3)
-        if ____cond7 then
-            __TS__ArrayPush(out, \\"3\\")
-            break
-        end
-        if not ____cond7 then
-            __TS__ArrayPush(out, \\"default\\")
-        end
-    until true
+    __TS__ArrayPush(
+        out,
+        tostring(x)
+    )
     return out
 end
 return ____exports"

--- a/test/unit/__snapshots__/switch.spec.ts.snap
+++ b/test/unit/__snapshots__/switch.spec.ts.snap
@@ -4,21 +4,17 @@ exports[`switch uses elseif 1`] = `
 "local ____exports = {}
 function ____exports.__main(self)
     local result = -1
-    local ____switch3 = 2
-    if ____switch3 == 0 then
-        do
+    do
+        local ____switch3 = 2
+        if ____switch3 == 0 then
             do
                 result = 200
             end
-        end
-    elseif ____switch3 == 1 then
-        do
+        elseif ____switch3 == 1 then
             do
                 result = 100
             end
-        end
-    elseif ____switch3 == 2 then
-        do
+        elseif ____switch3 == 2 then
             do
                 result = 1
             end

--- a/test/unit/__snapshots__/switch.spec.ts.snap
+++ b/test/unit/__snapshots__/switch.spec.ts.snap
@@ -4,22 +4,25 @@ exports[`switch uses elseif 1`] = `
 "local ____exports = {}
 function ____exports.__main(self)
     local result = -1
-    do
+    repeat
         local ____switch3 = 2
         if ____switch3 == 0 then
             do
                 result = 200
+                break
             end
         elseif ____switch3 == 1 then
             do
                 result = 100
+                break
             end
         elseif ____switch3 == 2 then
             do
                 result = 1
+                break
             end
         end
-    end
+    until true
     return result
 end
 return ____exports"

--- a/test/unit/__snapshots__/switch.spec.ts.snap
+++ b/test/unit/__snapshots__/switch.spec.ts.snap
@@ -1,228 +1,66 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`switch collapses empty case and minimizes conditions 1`] = `
+exports[`switch produces optimal output 1`] = `
 "require(\\"lualib_bundle\\");
 local ____exports = {}
 function ____exports.__main(self)
     local out = {}
     repeat
-        local ____switch3 = 5
+        local ____switch3 = 0
         local ____cond3 = ((____switch3 == 0) or (____switch3 == 1)) or (____switch3 == 2)
         if ____cond3 then
             __TS__ArrayPush(out, \\"0,1,2\\")
         end
+        if ____cond3 then
+            __TS__ArrayPush(out, \\"default\\")
+        end
         ____cond3 = ____cond3 or (____switch3 == 3)
         if ____cond3 then
             __TS__ArrayPush(out, \\"3\\")
-            break
-        end
-        ____cond3 = ____cond3 or (____switch3 == 4)
-        if ____cond3 then
-            __TS__ArrayPush(out, \\"4\\")
         end
         if not ____cond3 then
             __TS__ArrayPush(out, \\"default\\")
-            __TS__ArrayPush(out, \\"4\\")
+            __TS__ArrayPush(out, \\"3\\")
         end
     until true
-    return out
-end
-return ____exports"
-`;
-
-exports[`switch handles side-effects (0) 1`] = `
-"require(\\"lualib_bundle\\");
-local ____exports = {}
-function ____exports.__main(self)
-    local out = {}
-    local y = 0
-    local function foo(self)
-        return (function()
-            local ____tmp = y
-            y = ____tmp + 1
-            return ____tmp
-        end)()
-    end
-    local x = 0
     repeat
-        local ____switch5 = x
-        local ____cond5 = ____switch5 == foo(nil)
-        if ____cond5 then
-            __TS__ArrayPush(out, 1)
+        local ____switch4 = 2
+        local ____cond4 = (____switch4 == 0) or (____switch4 == 1)
+        if ____cond4 then
+            __TS__ArrayPush(out, \\"0,1\\")
+            break
         end
-        ____cond5 = ____cond5 or (____switch5 == foo(nil))
-        if ____cond5 then
-            __TS__ArrayPush(out, 2)
-        end
-        ____cond5 = ____cond5 or (____switch5 == foo(nil))
-        if ____cond5 then
-            __TS__ArrayPush(out, 3)
-        end
-        if ____cond5 then
+        if not ____cond4 then
             __TS__ArrayPush(out, \\"default\\")
+            __TS__ArrayPush(out, \\"0,1\\")
+            break
+        end
+    until true
+    repeat
+        local ____switch5 = 5
+        local ____cond5 = ____switch5 == 0
+        if ____cond5 then
+            __TS__ArrayPush(out, \\"0\\")
+        end
+        ____cond5 = ____cond5 or (____switch5 == 1)
+        if ____cond5 then
+            __TS__ArrayPush(out, \\"1\\")
+            break
+        end
+        ____cond5 = ____cond5 or (____switch5 == 2)
+        if ____cond5 then
+            __TS__ArrayPush(out, \\"0,1,2\\")
+        end
+        ____cond5 = ____cond5 or (____switch5 == 3)
+        if ____cond5 then
+            __TS__ArrayPush(out, \\"3\\")
+            break
         end
         if not ____cond5 then
             __TS__ArrayPush(out, \\"default\\")
         end
     until true
-    __TS__ArrayPush(out, y)
     return out
-end
-return ____exports"
-`;
-
-exports[`switch handles side-effects (1) 1`] = `
-"require(\\"lualib_bundle\\");
-local ____exports = {}
-function ____exports.__main(self)
-    local out = {}
-    local y = 0
-    local function foo(self)
-        return (function()
-            local ____tmp = y
-            y = ____tmp + 1
-            return ____tmp
-        end)()
-    end
-    local x = 1
-    repeat
-        local ____switch5 = x
-        local ____cond5 = ____switch5 == foo(nil)
-        if ____cond5 then
-            __TS__ArrayPush(out, 1)
-        end
-        ____cond5 = ____cond5 or (____switch5 == foo(nil))
-        if ____cond5 then
-            __TS__ArrayPush(out, 2)
-        end
-        ____cond5 = ____cond5 or (____switch5 == foo(nil))
-        if ____cond5 then
-            __TS__ArrayPush(out, 3)
-        end
-        if ____cond5 then
-            __TS__ArrayPush(out, \\"default\\")
-        end
-        if not ____cond5 then
-            __TS__ArrayPush(out, \\"default\\")
-        end
-    until true
-    __TS__ArrayPush(out, y)
-    return out
-end
-return ____exports"
-`;
-
-exports[`switch handles side-effects (2) 1`] = `
-"require(\\"lualib_bundle\\");
-local ____exports = {}
-function ____exports.__main(self)
-    local out = {}
-    local y = 0
-    local function foo(self)
-        return (function()
-            local ____tmp = y
-            y = ____tmp + 1
-            return ____tmp
-        end)()
-    end
-    local x = 2
-    repeat
-        local ____switch5 = x
-        local ____cond5 = ____switch5 == foo(nil)
-        if ____cond5 then
-            __TS__ArrayPush(out, 1)
-        end
-        ____cond5 = ____cond5 or (____switch5 == foo(nil))
-        if ____cond5 then
-            __TS__ArrayPush(out, 2)
-        end
-        ____cond5 = ____cond5 or (____switch5 == foo(nil))
-        if ____cond5 then
-            __TS__ArrayPush(out, 3)
-        end
-        if ____cond5 then
-            __TS__ArrayPush(out, \\"default\\")
-        end
-        if not ____cond5 then
-            __TS__ArrayPush(out, \\"default\\")
-        end
-    until true
-    __TS__ArrayPush(out, y)
-    return out
-end
-return ____exports"
-`;
-
-exports[`switch handles side-effects (3) 1`] = `
-"require(\\"lualib_bundle\\");
-local ____exports = {}
-function ____exports.__main(self)
-    local out = {}
-    local y = 0
-    local function foo(self)
-        return (function()
-            local ____tmp = y
-            y = ____tmp + 1
-            return ____tmp
-        end)()
-    end
-    local x = 3
-    repeat
-        local ____switch5 = x
-        local ____cond5 = ____switch5 == foo(nil)
-        if ____cond5 then
-            __TS__ArrayPush(out, 1)
-        end
-        ____cond5 = ____cond5 or (____switch5 == foo(nil))
-        if ____cond5 then
-            __TS__ArrayPush(out, 2)
-        end
-        ____cond5 = ____cond5 or (____switch5 == foo(nil))
-        if ____cond5 then
-            __TS__ArrayPush(out, 3)
-        end
-        if ____cond5 then
-            __TS__ArrayPush(out, \\"default\\")
-        end
-        if not ____cond5 then
-            __TS__ArrayPush(out, \\"default\\")
-        end
-    until true
-    __TS__ArrayPush(out, y)
-    return out
-end
-return ____exports"
-`;
-
-exports[`switch uses elseif 1`] = `
-"local ____exports = {}
-function ____exports.__main(self)
-    local result = -1
-    repeat
-        local ____switch3 = 2
-        local ____cond3 = ____switch3 == 0
-        if ____cond3 then
-            do
-                result = 200
-                break
-            end
-        end
-        ____cond3 = ____cond3 or (____switch3 == 1)
-        if ____cond3 then
-            do
-                result = 100
-                break
-            end
-        end
-        ____cond3 = ____cond3 or (____switch3 == 2)
-        if ____cond3 then
-            do
-                result = 1
-                break
-            end
-        end
-    until true
-    return result
 end
 return ____exports"
 `;

--- a/test/unit/__snapshots__/switch.spec.ts.snap
+++ b/test/unit/__snapshots__/switch.spec.ts.snap
@@ -7,17 +7,25 @@ function ____exports.__main(self)
     local out = {}
     repeat
         local ____switch3 = 5
-        if ((____switch3 == 0) or (____switch3 == 1)) or (____switch3 == 2) then
+        local ____cond3 = false
+        ____cond3 = ____cond3 or (((____switch3 == 0) or (____switch3 == 1)) or (____switch3 == 2))
+        if ____cond3 then
             __TS__ArrayPush(out, \\"0,1,2\\")
         end
-        if (((____switch3 == 0) or (____switch3 == 1)) or (____switch3 == 2)) or (____switch3 == 3) then
+        ____cond3 = ____cond3 or (____switch3 == 3)
+        if ____cond3 then
             __TS__ArrayPush(out, \\"3\\")
             break
         end
-        if not (((((____switch3 == 0) or (____switch3 == 1)) or (____switch3 == 2)) or (____switch3 == 3)) or (____switch3 == 4)) then
+        if ____cond3 then
             __TS__ArrayPush(out, \\"default\\")
         end
-        if (not (((((____switch3 == 0) or (____switch3 == 1)) or (____switch3 == 2)) or (____switch3 == 3)) or (____switch3 == 4))) or (____switch3 == 4) then
+        ____cond3 = ____cond3 or (____switch3 == 4)
+        if ____cond3 then
+            __TS__ArrayPush(out, \\"4\\")
+        end
+        if not ____cond3 then
+            __TS__ArrayPush(out, \\"default\\")
             __TS__ArrayPush(out, \\"4\\")
         end
     until true
@@ -32,19 +40,23 @@ function ____exports.__main(self)
     local result = -1
     repeat
         local ____switch3 = 2
-        if ____switch3 == 0 then
+        local ____cond3 = false
+        ____cond3 = ____cond3 or (____switch3 == 0)
+        if ____cond3 then
             do
                 result = 200
                 break
             end
         end
-        if (____switch3 == 0) or (____switch3 == 1) then
+        ____cond3 = ____cond3 or (____switch3 == 1)
+        if ____cond3 then
             do
                 result = 100
                 break
             end
         end
-        if ((____switch3 == 0) or (____switch3 == 1)) or (____switch3 == 2) then
+        ____cond3 = ____cond3 or (____switch3 == 2)
+        if ____cond3 then
             do
                 result = 1
                 break

--- a/test/unit/switch.spec.ts
+++ b/test/unit/switch.spec.ts
@@ -400,16 +400,16 @@ test("switch collapses empty case and minimizes conditions", () => {
         .expectToMatchJsResult();
 });
 
-test("switch handles side-effects", () => {
+test.each([0, 1, 2, 3])("switch handles side-effects (%p)", inp => {
     util.testFunction`
         const out = [];
-        
+
         let y = 0;
         function foo() {
             return y++;
         }
 
-        let x = 0;
+        let x = ${inp} as number;
         switch (x) {
             case foo():
                 out.push(1);
@@ -417,9 +417,13 @@ test("switch handles side-effects", () => {
                 out.push(2);
             case foo():
                 out.push(3);
+            default:
+                out.push("default");
         }
 
         out.push(y);
         return out;
-    `.expectToMatchJsResult();
+    `
+        .expectLuaToMatchSnapshot()
+        .expectToMatchJsResult();
 });

--- a/test/unit/switch.spec.ts
+++ b/test/unit/switch.spec.ts
@@ -1,5 +1,3 @@
-import * as tstl from "../../src";
-import { unsupportedForTarget } from "../../src/transformation/utils/diagnostics";
 import * as util from "../util";
 
 test.each([0, 1, 2, 3])("switch (%p)", inp => {
@@ -286,14 +284,6 @@ test("switch uses elseif", () => {
     `
         .expectLuaToMatchSnapshot()
         .expectToMatchJsResult();
-});
-
-test("switch not allowed in 5.1", () => {
-    util.testFunction`
-        switch ("abc") {}
-    `
-        .setOptions({ luaTarget: tstl.LuaTarget.Lua51 })
-        .expectDiagnosticsToMatchSnapshot([unsupportedForTarget.code]);
 });
 
 // https://github.com/TypeScriptToLua/TypeScriptToLua/issues/967

--- a/test/unit/switch.spec.ts
+++ b/test/unit/switch.spec.ts
@@ -401,8 +401,12 @@ test("switch produces optimal output", () => {
                 out.push("0,1,2");
             default:
                 out.push("default");
-            case 3:
+            case 3: {
                 out.push("3");
+                break;
+            }
+            case 4:
+                out.push("4");
         }
 
         switch (2 as number) {

--- a/test/unit/switch.spec.ts
+++ b/test/unit/switch.spec.ts
@@ -207,7 +207,7 @@ test.each([0, 1, 2, 3])("switchWithBrackets (%p)", inp => {
     `.expectToMatchJsResult();
 });
 
-test.each([0, 1, 2, 3])("switchWithBracketsBreakInConditional (%p)", inp => {
+test.each([0, 1, 2, 3, 4])("switchWithBracketsBreakInConditional (%p)", inp => {
     util.testFunction`
         let result: number = -1;
 
@@ -223,6 +223,11 @@ test.each([0, 1, 2, 3])("switchWithBracketsBreakInConditional (%p)", inp => {
             }
             case 2: {
                 result = 2;
+
+                if (result != 2) break;
+            }
+            case 3: {
+                result = 3;
                 break;
             }
         }

--- a/test/unit/switch.spec.ts
+++ b/test/unit/switch.spec.ts
@@ -264,7 +264,7 @@ test.each([0, 1, 2, 3])("switchWithBracketsBreakInInternalLoop (%p)", inp => {
     `.expectToMatchJsResult();
 });
 
-test("switch uses elseif", () => {
+test("switch executes only one", () => {
     util.testFunction`
         let result: number = -1;
 
@@ -286,9 +286,7 @@ test("switch uses elseif", () => {
         }
 
         return result;
-    `
-        .expectLuaToMatchSnapshot()
-        .expectToMatchJsResult();
+    `.expectToMatchJsResult();
 });
 
 // https://github.com/TypeScriptToLua/TypeScriptToLua/issues/967
@@ -378,12 +376,35 @@ test("switch does not pollute parent scope", () => {
     `.expectToMatchJsResult();
 });
 
-test("switch collapses empty case and minimizes conditions", () => {
+test("switch produces optimal output", () => {
     util.testFunction`
         const out = [];
-        switch (5 as number) {
+        switch (0 as number) {
             case 0:
             case 1:
+            case 2:
+                out.push("0,1,2");
+            default:
+                out.push("default");
+            case 3:
+                out.push("3");
+        }
+
+        switch (2 as number) {
+            default:
+                out.push("default");
+            case 0:
+            case 1:
+                out.push("0,1");
+                break;
+        }
+
+        switch (5 as number) {
+            case 0:
+                out.push("0");
+            case 1:
+                out.push("1");
+                break;
             case 2:
                 out.push("0,1,2");
             case 3:
@@ -391,8 +412,6 @@ test("switch collapses empty case and minimizes conditions", () => {
                 break;
             default:
                 out.push("default");
-            case 4:
-                out.push("4");
         }
         return out;
     `
@@ -423,7 +442,5 @@ test.each([0, 1, 2, 3])("switch handles side-effects (%p)", inp => {
 
         out.push(y);
         return out;
-    `
-        .expectLuaToMatchSnapshot()
-        .expectToMatchJsResult();
+    `.expectToMatchJsResult();
 });

--- a/test/unit/switch.spec.ts
+++ b/test/unit/switch.spec.ts
@@ -459,3 +459,31 @@ test.each([0, 1, 2, 3])("switch handles side-effects (%p)", inp => {
         return out;
     `.expectToMatchJsResult();
 });
+
+test.each([0, 1, 2, 3])("switch handles async side-effects (%p)", inp => {
+    util.testFunction`
+        (async () => {
+            const out = [];
+
+            let y = 0;
+            async function foo() {
+                return new Promise<number>((resolve) => y++ && resolve(0));
+            }
+
+            let x = ${inp} as number;
+            switch (x) {
+                case await foo():
+                    out.push(1);
+                case await foo():
+                    out.push(2);
+                case await foo():
+                    out.push(3);
+                default:
+                    out.push("default");
+            }
+
+            out.push(y);
+            return out;
+        })();
+    `.expectToMatchJsResult();
+});

--- a/test/unit/switch.spec.ts
+++ b/test/unit/switch.spec.ts
@@ -311,6 +311,17 @@ test("switch default case not last - second", () => {
     `.expectToMatchJsResult();
 });
 
+test("switch default case only", () => {
+    util.testFunction`
+        let out = 0;
+        switch (4 as number) {
+            default:
+                out = 1
+        }
+        return out;
+    `.expectToMatchJsResult();
+});
+
 test("switch fallthrough enters default", () => {
     util.testFunction`
         const out = [];

--- a/test/unit/switch.spec.ts
+++ b/test/unit/switch.spec.ts
@@ -457,6 +457,7 @@ test.each([0, 1, 2, 3])("switch handles side-effects (%p)", inp => {
                 out.push(3);
             default:
                 out.push("default");
+            case foo():
         }
 
         out.push(y);

--- a/test/unit/switch.spec.ts
+++ b/test/unit/switch.spec.ts
@@ -364,6 +364,21 @@ test("switch fallthrough stops after default", () => {
     `.expectToMatchJsResult();
 });
 
+test.each([0, 1])("switch empty fallthrough to default (%p)", inp => {
+    util.testFunction`
+        const out = [];
+        switch (${inp} as number) {
+            case 1:
+            default:
+                out.push("default");
+            
+        }
+        return out;
+    `
+        .expectLuaToMatchSnapshot()
+        .expectToMatchJsResult();
+});
+
 test("switch does not pollute parent scope", () => {
     util.testFunction`
         let x: number = 0;

--- a/test/unit/switch.spec.ts
+++ b/test/unit/switch.spec.ts
@@ -377,3 +377,25 @@ test("switch does not pollute parent scope", () => {
         return y;
     `.expectToMatchJsResult();
 });
+
+test("switch collapses empty case and minimizes conditions", () => {
+    util.testFunction`
+        const out = [];
+        switch (5 as number) {
+            case 0:
+            case 1:
+            case 2:
+                out.push("0,1,2");
+            case 3:
+                out.push("3");
+                break;
+            default:
+                out.push("default");
+            case 4:
+                out.push("4");
+        }
+        return out;
+    `
+        .expectLuaToMatchSnapshot()
+        .expectToMatchJsResult();
+});

--- a/test/unit/switch.spec.ts
+++ b/test/unit/switch.spec.ts
@@ -399,3 +399,27 @@ test("switch collapses empty case and minimizes conditions", () => {
         .expectLuaToMatchSnapshot()
         .expectToMatchJsResult();
 });
+
+test("switch handles side-effects", () => {
+    util.testFunction`
+        const out = [];
+        
+        let y = 0;
+        function foo() {
+            return y++;
+        }
+
+        let x = 0;
+        switch (x) {
+            case foo():
+                out.push(1);
+            case foo():
+                out.push(2);
+            case foo():
+                out.push(3);
+        }
+
+        out.push(y);
+        return out;
+    `.expectToMatchJsResult();
+});

--- a/test/unit/switch.spec.ts
+++ b/test/unit/switch.spec.ts
@@ -360,3 +360,15 @@ test("switch fallthrough stops after default", () => {
         return out;
     `.expectToMatchJsResult();
 });
+
+test("switch does not pollute parent scope", () => {
+    util.testFunction`
+        let x: number = 0;
+        let y = 1;
+        switch (x) {
+            case 0:
+                let y = 2;
+        }
+        return y;
+    `.expectToMatchJsResult();
+});

--- a/test/unit/switch.spec.ts
+++ b/test/unit/switch.spec.ts
@@ -416,6 +416,54 @@ test.each([0, 1, 2, 3, 4])("switch handles side-effects (%p)", inp => {
     `.expectToMatchJsResult();
 });
 
+test.each([1, 2])("switch handles side-effects with empty fallthrough (%p)", inp => {
+    util.testFunction`
+        const out = [];
+
+        let y = 0;
+        function foo() {
+            return y++;
+        }
+
+        let x = 0 as number;
+        switch (x) {
+            // empty fallthrough 1 or many times
+            ${new Array(inp).fill("case foo():").join("\n")}
+            default:
+                out.push("default");
+            
+        }
+
+        out.push(y);
+        return out;
+    `.expectToMatchJsResult();
+});
+
+test.each([1, 2])("switch handles side-effects with empty fallthrough (preceding clause) (%p)", inp => {
+    util.testFunction`
+        const out = [];
+
+        let y = 0;
+        function foo() {
+            return y++;
+        }
+
+        let x = 0 as number;
+        switch (x) {
+            case 1:
+                out.push(1);
+            // empty fallthrough 1 or many times
+            ${new Array(inp).fill("case foo():").join("\n")}
+            default:
+                out.push("default");
+            
+        }
+
+        out.push(y);
+        return out;
+    `.expectToMatchJsResult();
+});
+
 test.each([0, 1, 2, 3, 4])("switch handles async side-effects (%p)", inp => {
     util.testFunction`
         (async () => {


### PR DESCRIPTION
Resolves #194 (or rather brings support for Lua 5.1 and universal).

Implemented using `repeat...until true`, `if`, and some conditional `or` chaining. Relies on switch fallthrough amalgamation / unrolling for default case fallthrough.

```ts
switch (0 as number) {
    case 0:
    case 1:
    case 2:
        out.push("0,1,2");
    default:
        out.push("default");
    case 3:
        out.push("3");
}
```

```lua
repeat
    local ____switch3 = 0
    local ____cond3 = ((____switch3 == 0) or (____switch3 == 1)) or (____switch3 == 2)
    if ____cond3 then
        __TS__ArrayPush(out, \\"0,1,2\\")
    end
    if ____cond3 then
        __TS__ArrayPush(out, \\"default\\")
    end
    ____cond3 = ____cond3 or (____switch3 == 3)
    if ____cond3 then
        __TS__ArrayPush(out, \\"3\\")
    end
    if not ____cond3 then
        __TS__ArrayPush(out, \\"default\\")
        __TS__ArrayPush(out, \\"3\\")
    end
until true
```

## Update:

The final approach was to `or` together the conditions into a variable and check that condition in the if statement to ensure that we do not add any additional comparisons that would trigger undesired side effects.

In order to handle the default case, we must still amalgamate the fallthrough cases that a default would fall into, and provide that as the final `or` clause, by checking that no previous condition had passed.

I am making my best attempt to ensure that any redundant or useless cases are removed, and empty cases coalesced.

Unforeseen bonus, the generated code is a bit easier to reason about!

### Orignal:

The approach I took is to gather the fall-through bodies based on the defined order in the switch statement and amalgamate them until I hit a break statement that would break the control flow of the switch case. I then move the resulting default block to a new else statement. It is crucial to handle the code generation for the default case before moving it into the else block, as the rules of fall through would dictate that the case directly after the default would execute.

Took lots of testing until it clicked in my head that this method is indeed conformant with how a switch statement executes. `switchWithBracketsBreakInInternalLoop` was the real kicker, and made me realize handling break statements in their proper scope was missing. By skipping the child tree of any loop or switch the code will not pick up unnecessary breaks of switch control flow.

Performance would be the only open question, although I would not expect this method to be any slower than jumping with goto, as it is really just an unrolled switch statement.

Also send me your code clarity, clean-up, cognitive load lightening, and readability suggestions, please!