### PR TITLE
support for global $vararg in bundles

### DIFF
--- a/test/unit/language-extensions/vararg.spec.ts
+++ b/test/unit/language-extensions/vararg.spec.ts
@@ -6,6 +6,7 @@ test.each([
     'let result: string; { result = [...$vararg].join(""); }',
     'let result: string; if (true) { result = [...$vararg].join(""); }',
     'let result: string; do { result = [...$vararg].join(""); } while (false);',
+    'function foo(...args: unknown[]) { return args.join(""); } const result = foo(...$vararg);',
 ])("$vararg valid use (%p)", statement => {
     util.testModule`
         ${statement}
@@ -29,4 +30,27 @@ test.each([
     `
         .withLanguageExtensions()
         .expectDiagnosticsToMatchSnapshot([invalidVarargUse.code]);
+});
+
+test("$vararg in bundle entry point", () => {
+    util.testModule`
+        export const result = [...$vararg].join("");
+    `
+        .setMainFileName("src/main.ts")
+        .setOptions({ rootDir: "src", luaBundle: "bundle.lua", luaBundleEntry: "src/main.ts" })
+        .withLanguageExtensions()
+        .setLuaFactory(code => `return (function(...) ${code} end)("A", "B", "C", "D")`)
+        .expectToEqual({ result: "ABCD" });
+});
+
+test("$vararg in bundle sub-module", () => {
+    util.testModule`
+        export { result } from "./module";
+    `
+        .setMainFileName("src/main.ts")
+        .addExtraFile("src/module.ts", 'export const result = [...$vararg].join("")')
+        .setOptions({ rootDir: "src", luaBundle: "bundle.lua", luaBundleEntry: "src/main.ts" })
+        .withLanguageExtensions()
+        .setLuaFactory(code => `return (function(...) ${code} end)()`)
+        .expectToEqual({ result: "module" });
 });

--- a/test/unit/language-extensions/vararg.spec.ts
+++ b/test/unit/language-extensions/vararg.spec.ts
@@ -51,6 +51,5 @@ test("$vararg in bundle sub-module", () => {
         .addExtraFile("src/module.ts", 'export const result = [...$vararg].join("")')
         .setOptions({ rootDir: "src", luaBundle: "bundle.lua", luaBundleEntry: "src/main.ts" })
         .withLanguageExtensions()
-        .setLuaFactory(code => `return (function(...) ${code} end)()`)
         .expectToEqual({ result: "module" });
 });

--- a/test/util.ts
+++ b/test/util.ts
@@ -529,7 +529,7 @@ class AccessorTestBuilder extends TestBuilder {
     protected accessor = "";
 
     protected getLuaCodeWithWrapper(code: string) {
-        return `return (function()\n${code}\nend)()${this.accessor}`;
+        return `return (function(...)\n${code}\nend)()${this.accessor}`;
     }
 
     @memoize


### PR DESCRIPTION
fixes #1048

To emulate normal Lua functionality, the entry point receives the global vararg and sub-modules receive their own name when evaluating `$vararg` (`...`).