### PR TITLE
Only consider baseUrl for non-relative imports

### DIFF
--- a/src/transpilation/resolve.ts
+++ b/src/transpilation/resolve.ts
@@ -167,8 +167,15 @@ function resolveDependency(
         console.log(`Resolving "${dependency}" from ${normalizeSlashes(fileDirectory)}`);
     }
 
+    // Check if the import is relative
+    const isRelative = ["/", "./", "../"].some(p => dependency.startsWith(p));
+
+    // If the import is relative, always resolve it relative to the requiring file
+    // If the import is not relative, resolve it relative to options.baseUrl if it is set
+    const relativeTo = isRelative ? fileDirectory : options.baseUrl ?? fileDirectory;
+
     // Check if file is a file in the project
-    const resolvedPath = path.join(options.baseUrl ?? fileDirectory, dependency);
+    const resolvedPath = path.join(relativeTo, dependency);
 
     const possibleProjectFiles = [
         resolvedPath, // JSON files need their extension as part of the import path, caught by this branch,


### PR DESCRIPTION
According to [TypeScript's documentation](https://www.typescriptlang.org/docs/handbook/module-resolution.html#relative-vs-non-relative-module-imports), `baseUrl` should only be used to resolve absolute imports.

The way imports are currently resolved requires absolute paths for all imports if `baseUrl` is set, which broke our codebase when we updated TSTL.

## Example

Assume that `baseUrl` is set to `source/` and that this is how our code is structured:

```
 | ...
 | tsconfig.json
 \ source
   | foo.ts
   | bar.ts
   \ baz
     | index.ts
     | bar.ts
```

If `baz/index.ts` contains `import { Bar } from './bar'`, that import will resolve to `source/bar.ts` instead of the correct file `source/baz/bar.ts`.

If `source/bar.ts` does not exist, the resolver fallback will successfully assume the correct path, but it will also emit an error that the path could not be resolved. In general we'd much prefer to not ignore errors and resolveDependency on fallbacks, not to mention the errors emitted would make CI builds fail.

## Fix

I've fixed this by checking whether or not the import is considered relative before considering `options.baseUrl` in `src/transpilation/resolve.ts:resolveDependency` but I don't know if that is the correct way to fix it or not, only that it works in our case and that TSTL's tests pass.

## Affects

This change only affects relative imports, and only when `baseUrl` is set.  
The definition used for "relative" is "/, ./, or ../" and comes from [the same docs page as linked above](https://www.typescriptlang.org/docs/handbook/module-resolution.html#relative-vs-non-relative-module-imports).
> A relative import is one that starts with /, ./ or ../. 