### PR TITLE
Hoisting switch fix

### DIFF
--- a/src/transformation/utils/lua-ast.ts
+++ b/src/transformation/utils/lua-ast.ts
@@ -175,7 +175,7 @@ export function createLocalOrExportedOrGlobalDeclaration(
         const isTopLevelVariable = scope.type === ScopeType.File;
 
         if (context.isModule || !isTopLevelVariable) {
-            if (scope.type === ScopeType.Switch || (!isFunctionDeclaration && hasMultipleReferences(scope, lhs))) {
+            if (!isFunctionDeclaration && hasMultipleReferences(scope, lhs)) {
                 // Split declaration and assignment of identifiers that reference themselves in their declaration
                 declaration = lua.createVariableDeclarationStatement(lhs, undefined, tsOriginal);
                 if (rhs) {
@@ -185,15 +185,13 @@ export function createLocalOrExportedOrGlobalDeclaration(
                 declaration = lua.createVariableDeclarationStatement(lhs, rhs, tsOriginal);
             }
 
-            // Remember local variable declarations for hoisting later
-            if (!scope.variableDeclarations) {
-                scope.variableDeclarations = [];
-            }
+            if (!isFunctionDeclaration) {
+                // Remember local variable declarations for hoisting later
+                if (!scope.variableDeclarations) {
+                    scope.variableDeclarations = [];
+                }
 
-            scope.variableDeclarations.push(declaration);
-
-            if (scope.type === ScopeType.Switch) {
-                declaration = undefined;
+                scope.variableDeclarations.push(declaration);
             }
         } else if (rhs) {
             // global

--- a/src/transformation/utils/scope.ts
+++ b/src/transformation/utils/scope.ts
@@ -216,7 +216,11 @@ function shouldHoistSymbol(context: TransformationContext, symbolId: lua.SymbolI
     return false;
 }
 
-function hoistVariableDeclarations(context: TransformationContext, scope: Scope, statements: lua.Statement[]) {
+function hoistVariableDeclarations(
+    context: TransformationContext,
+    scope: Scope,
+    statements: lua.Statement[]
+): { unhoistedStatements: lua.Statement[]; hoistedIdentifiers: lua.Identifier[] } {
     if (!scope.variableDeclarations) {
         return { unhoistedStatements: statements, hoistedIdentifiers: [] };
     }
@@ -246,7 +250,11 @@ function hoistVariableDeclarations(context: TransformationContext, scope: Scope,
     return { unhoistedStatements, hoistedIdentifiers };
 }
 
-function hoistFunctionDefinitions(context: TransformationContext, scope: Scope, statements: lua.Statement[]) {
+function hoistFunctionDefinitions(
+    context: TransformationContext,
+    scope: Scope,
+    statements: lua.Statement[]
+): { unhoistedStatements: lua.Statement[]; hoistedStatements: lua.Statement[]; hoistedIdentifiers: lua.Identifier[] } {
     if (!scope.functionDefinitions) {
         return { unhoistedStatements: statements, hoistedStatements: [], hoistedIdentifiers: [] };
     }
@@ -283,6 +291,9 @@ function hoistFunctionDefinitions(context: TransformationContext, scope: Scope, 
     return { unhoistedStatements, hoistedStatements, hoistedIdentifiers };
 }
 
-function hoistImportStatements(scope: Scope, statements: lua.Statement[]) {
+function hoistImportStatements(
+    scope: Scope,
+    statements: lua.Statement[]
+): { unhoistedStatements: lua.Statement[]; hoistedStatements: lua.Statement[] } {
     return { unhoistedStatements: statements, hoistedStatements: scope.importStatements ?? [] };
 }

--- a/src/transformation/utils/scope.ts
+++ b/src/transformation/utils/scope.ts
@@ -263,7 +263,9 @@ function hoistFunctionDefinitions(context: TransformationContext, scope: Scope, 
                 continue; // statements array may not contain all statements in the scope (switch-case)
             }
             unhoistedStatements.splice(index, 1);
+
             if (lua.isVariableDeclarationStatement(functionDefinition.definition)) {
+                // Separate function definition and variable declaration
                 assert(functionDefinition.definition.right);
                 hoistedIdentifiers.push(...functionDefinition.definition.left);
                 hoistedStatements.push(

--- a/src/transformation/visitors/switch.ts
+++ b/src/transformation/visitors/switch.ts
@@ -62,7 +62,14 @@ export const transformSwitchStatement: FunctionVisitor<ts.SwitchStatement> = (st
     if (clauses.length === 1 && ts.isDefaultClause(clauses[0])) {
         const defaultClause = clauses[0].statements;
         if (defaultClause.length) {
-            statements.push(lua.createDoStatement(context.transformStatements(defaultClause)));
+            const {
+                statements: defaultStatements,
+                hoistedStatements,
+                hoistedIdentifiers,
+            } = separateHoistedStatements(context, context.transformStatements(defaultClause));
+            prefixStatements.push(...hoistedStatements);
+            prefixIdentifiers.push(...hoistedIdentifiers);
+            statements.push(lua.createDoStatement(defaultStatements));
         }
     } else {
         // Build up the condition for each if statement

--- a/test/unit/__snapshots__/switch.spec.ts.snap
+++ b/test/unit/__snapshots__/switch.spec.ts.snap
@@ -34,6 +34,82 @@ end
 return ____exports"
 `;
 
+exports[`switch hoisting hoisting from default clause is not duplicated when falling through 1`] = `
+"local ____exports = {}
+function ____exports.__main(self)
+    local x = 1
+    local result = \\"\\"
+    repeat
+        local ____switch3 = x
+        local hoisted
+        function hoisted(self)
+            return \\"hoisted\\"
+        end
+        local ____cond3 = ____switch3 == 1
+        if ____cond3 then
+            result = hoisted(nil)
+            break
+        end
+        ____cond3 = ____cond3 or (____switch3 == 2)
+        if ____cond3 then
+            result = \\"2\\"
+        end
+        if ____cond3 then
+            result = \\"default\\"
+        end
+        ____cond3 = ____cond3 or (____switch3 == 3)
+        if ____cond3 then
+            result = \\"3\\"
+            break
+        end
+        do
+            result = \\"default\\"
+            result = \\"3\\"
+        end
+    until true
+    return result
+end
+return ____exports"
+`;
+
+exports[`switch hoisting hoisting from fallthrough clause after default is not duplicated 1`] = `
+"local ____exports = {}
+function ____exports.__main(self)
+    local x = 1
+    local result = \\"\\"
+    repeat
+        local ____switch3 = x
+        local hoisted
+        function hoisted(self)
+            return \\"hoisted\\"
+        end
+        local ____cond3 = ____switch3 == 1
+        if ____cond3 then
+            result = hoisted(nil)
+            break
+        end
+        ____cond3 = ____cond3 or (____switch3 == 2)
+        if ____cond3 then
+            result = \\"2\\"
+        end
+        if ____cond3 then
+            result = \\"default\\"
+        end
+        ____cond3 = ____cond3 or (____switch3 == 3)
+        if ____cond3 then
+            result = \\"3\\"
+            break
+        end
+        do
+            result = \\"default\\"
+            result = \\"3\\"
+        end
+    until true
+    return result
+end
+return ____exports"
+`;
+
 exports[`switch produces optimal output 1`] = `
 "require(\\"lualib_bundle\\");
 local ____exports = {}

--- a/test/unit/switch.spec.ts
+++ b/test/unit/switch.spec.ts
@@ -580,4 +580,66 @@ describe("switch hoisting", () => {
             return result;
         `.expectToMatchJsResult();
     });
+
+    test("hoisting from default clause", () => {
+        util.testFunction`
+            let x = 1;
+            let result = "";
+            switch (x) {
+                case 1:
+                    result = hoisted();
+                    break;
+                default:
+                    function hoisted() {
+                        return "hoisted";
+                    }
+                    break;
+            }
+            return result;
+        `.expectToMatchJsResult();
+    });
+
+    test("hoisting from default clause is not duplicated when falling through", () => {
+        util.testFunction`
+            let x = 1;
+            let result = "";
+            switch (x) {
+                case 1:
+                    result = hoisted();
+                    break;
+                case 2:
+                    result = "2";
+                default:
+                    function hoisted() {
+                        return "hoisted";
+                    }
+                    result = "default";
+                case 3:
+                    result = "3";
+                }
+            return result;
+        `.expectToMatchJsResult();
+    });
+
+    test("hoisting from fallthrough clause after default is not duplicated", () => {
+        util.testFunction`
+            let x = 1;
+            let result = "";
+            switch (x) {
+                case 1:
+                    result = hoisted();
+                    break;
+                case 2:
+                    result = "2";
+                default:
+                    result = "default";
+                case 3:
+                    function hoisted() {
+                        return "hoisted";
+                    }
+                    result = "3";
+                }
+            return result;
+        `.expectToMatchJsResult();
+    });
 });

--- a/test/unit/switch.spec.ts
+++ b/test/unit/switch.spec.ts
@@ -646,4 +646,19 @@ describe("switch hoisting", () => {
             .expectToMatchJsResult()
             .expectLuaToMatchSnapshot();
     });
+
+    test("hoisting in a solo default clause", () => {
+        util.testFunction`
+            let x = 1;
+            let result = "";
+            switch (x) {
+                default:
+                    result = hoisted();
+                    function hoisted() {
+                        return "hoisted";
+                    }
+            }
+            return result;
+        `.expectToMatchJsResult();
+    });
 });

--- a/test/unit/switch.spec.ts
+++ b/test/unit/switch.spec.ts
@@ -618,7 +618,9 @@ describe("switch hoisting", () => {
                     result = "3";
                 }
             return result;
-        `.expectToMatchJsResult();
+        `
+            .expectToMatchJsResult()
+            .expectLuaToMatchSnapshot();
     });
 
     test("hoisting from fallthrough clause after default is not duplicated", () => {
@@ -640,6 +642,8 @@ describe("switch hoisting", () => {
                     result = "3";
                 }
             return result;
-        `.expectToMatchJsResult();
+        `
+            .expectToMatchJsResult()
+            .expectLuaToMatchSnapshot();
     });
 });

--- a/test/unit/switch.spec.ts
+++ b/test/unit/switch.spec.ts
@@ -369,7 +369,7 @@ test.each([0, 1])("switch empty fallthrough to default (%p)", inp => {
             case 1:
             default:
                 out.push("default");
-            
+
         }
         return out;
     `
@@ -431,7 +431,7 @@ test.each([1, 2])("switch handles side-effects with empty fallthrough (%p)", inp
             ${new Array(inp).fill("case foo():").join("\n")}
             default:
                 out.push("default");
-            
+
         }
 
         out.push(y);
@@ -456,7 +456,7 @@ test.each([1, 2])("switch handles side-effects with empty fallthrough (preceding
             ${new Array(inp).fill("case foo():").join("\n")}
             default:
                 out.push("default");
-            
+
         }
 
         out.push(y);
@@ -521,4 +521,63 @@ test("switch produces optimal output", () => {
 
 test.each([0, 1, 2, 3, 4, 5])("switch produces valid optimal output (%p)", inp => {
     optimalOutput(inp).expectToMatchJsResult();
+});
+
+describe("switch hoisting", () => {
+    test("hoisting between cases", () => {
+        util.testFunction`
+            let x = 1;
+            let result = "";
+            switch (x) {
+                case 1:
+                    result = hoisted();
+                    break;
+                case 2:
+                    function hoisted() {
+                        return "hoisted";
+                    }
+                    break;
+            }
+            return result;
+        `.expectToMatchJsResult();
+    });
+
+    test("indirect hoisting between cases", () => {
+        util.testFunction`
+            let x = 1;
+            let result = "";
+            switch (x) {
+                case 1:
+                    function callHoisted() {
+                        return hoisted();
+                    }
+                    result = callHoisted();
+                    break;
+                case 2:
+                    function hoisted() {
+                        return "hoisted";
+                    }
+                    break;
+            }
+            return result;
+        `.expectToMatchJsResult();
+    });
+
+    test("hoisting in case expression", () => {
+        util.testFunction`
+            let x = 1;
+            let result = "";
+            switch (x) {
+                case hoisted():
+                    result = "hoisted";
+                    break;
+                case 2:
+                    function hoisted() {
+                        return 1;
+                    }
+                    break;
+            }
+            return result;
+        `.expectToMatchJsResult();
+    });
 });


### PR DESCRIPTION
fixes #1099 

To fix hoisting in switch statements, I've added `separateHoistedStatements` as an intermediate step to `performHoisting`. This keeps the results separate, which `transformSwitchStatement` uses directly so it can properly order statements after all clauses are transformed.

Previously, switch cases had some custom code to handle hoisting all locals to the top. I've refactored this to use the standard hoisting code path and just force-hoist everything that is immediately in a switch's scope.

Additionally, there was some very hard to follow 'magic' which handled function hoisting so that it could be output as `local function foo()` in some cases and `local foo; function foo()` in others when needed. This was incredibly hard to follow in the codebase, so I've changed it to always use the later form which works in all cases and keeps the implementation a bit more straightforward.