### PR TITLE
Runtime benchmarks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -218,7 +218,7 @@ module.exports = {
             },
         },
         {
-            files: "benchmark/src/memory_benchmarks/**/*.ts",
+            files: "benchmark/src/*_benchmarks/**/*.ts",
             rules: {
                 "import/no-default-export": "off",
             },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,80 +39,80 @@ jobs:
       - if: matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v1
 
-  # benchmark:
-  #   name: Benchmark
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Lua Install
-  #       run: sudo apt-get install lua5.3 luajit
-  #     - name: Glow Install
-  #       run: brew install glow
-  #     # Checkout master & commit
-  #     - name: Checkout master
-  #       uses: actions/checkout@v2
-  #       with:
-  #         ref: master
-  #         path: master
-  #     - name: Checkout commit
-  #       uses: actions/checkout@v2
-  #       with:
-  #         path: commit
-  #     - name: Use Node.js 12.13.1
-  #       uses: actions/setup-node@v1
-  #       with:
-  #         node-version: 12.13.1
-  #     # NPM
-  #     - name: NPM master
-  #       run: npm ci && npm run build
-  #       working-directory: master
-  #     - name: NPM commit
-  #       run: npm ci && npm run build
-  #       working-directory: commit
-  #     # Benchmark directory setup
-  #     - name: Ensure benchmark data dir exists
-  #       run: mkdir -p ./benchmark/data
-  #       working-directory: commit
-  #     - name: Copy commit benchmark to master
-  #       run: rm -rf ./master/benchmark && cp -rf ./commit/benchmark ./master/benchmark
-  #     # Run master benchmark first and output to commit benchmark data
-  #     - name: Build benchmark Lua 5.3 master
-  #       run: node ../../commit/dist/tstl.js -p tsconfig.53.json
-  #       working-directory: master/benchmark
-  #     - name: Run benchmark Lua 5.3 master
-  #       id: benchmark-lua-master
-  #       run: lua5.3 -- run.lua ../../../commit/benchmark/data/benchmark_master_53.json
-  #       working-directory: master/benchmark/dist
-  #     - name: Build benchmark LuaJIT master
-  #       run: node ../../commit/dist/tstl.js -p tsconfig.jit.json
-  #       working-directory: master/benchmark
-  #     - name: Run benchmark LuaJIT master
-  #       id: benchmark-jit-master
-  #       run: luajit -- run.lua ../../../commit/benchmark/data/benchmark_master_jit.json
-  #       working-directory: master/benchmark/dist
-  #     # Run commit benchmark and compare with master
-  #     - name: Build benchmark Lua 5.3 commit
-  #       run: node ../../commit/dist/tstl.js -p tsconfig.53.json
-  #       working-directory: commit/benchmark
-  #     - name: Run benchmark Lua 5.3 commit
-  #       id: benchmark-lua-commit
-  #       run: lua5.3 -- run.lua ../data/benchmark_master_vs_commit_53.json ../data/benchmark_master_53.json
-  #       working-directory: commit/benchmark/dist
-  #     - name: Build benchmark LuaJIT commit
-  #       run: node ../../commit/dist/tstl.js -p tsconfig.jit.json
-  #       working-directory: commit/benchmark
-  #     - name: Run benchmark LuaJIT commit
-  #       id: benchmark-jit-commit
-  #       run: luajit -- run.lua ../data/benchmark_master_vs_commit_jit.json ../data/benchmark_master_jit.json
-  #       working-directory: commit/benchmark/dist
-  #     - name: Combine benchmark results
-  #       id: script-combine-results
-  #       uses: actions/github-script@v3
-  #       with:
-  #         benchmark-result-path-lua: commit/benchmark/data/benchmark_master_vs_commit_53.json
-  #         benchmark-result-path-jit: commit/benchmark/data/benchmark_master_vs_commit_jit.json
-  #         result-encoding: string
-  #         script: |
-  #           const createBenchmarkCheck = require(`${process.env.GITHUB_WORKSPACE}/commit/.github/scripts/create_benchmark_check.js`);
-  #           return createBenchmarkCheck({ github, context, core });
-  #     - name: Benchmark results
-  #       run: echo "${{steps.script-combine-results.outputs.result}}" | glow -s dark -w 120 -
+  benchmark:
+    name: Benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - name: Lua Install
+        run: sudo apt-get install lua5.3 luajit
+      - name: Glow Install
+        run: brew install glow
+      # Checkout master & commit
+      - name: Checkout master
+        uses: actions/checkout@v2
+        with:
+          ref: master
+          path: master
+      - name: Checkout commit
+        uses: actions/checkout@v2
+        with:
+          path: commit
+      - name: Use Node.js 12.13.1
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.13.1
+      # NPM
+      - name: NPM master
+        run: npm ci && npm run build
+        working-directory: master
+      - name: NPM commit
+        run: npm ci && npm run build
+        working-directory: commit
+      # Benchmark directory setup
+      - name: Ensure benchmark data dir exists
+        run: mkdir -p ./benchmark/data
+        working-directory: commit
+      - name: Copy commit benchmark to master
+        run: rm -rf ./master/benchmark && cp -rf ./commit/benchmark ./master/benchmark
+      # Run master benchmark first and output to commit benchmark data
+      - name: Build benchmark Lua 5.3 master
+        run: node ../../commit/dist/tstl.js -p tsconfig.53.json
+        working-directory: master/benchmark
+      - name: Run benchmark Lua 5.3 master
+        id: benchmark-lua-master
+        run: lua5.3 -- run.lua ../../../commit/benchmark/data/benchmark_master_53.json
+        working-directory: master/benchmark/dist
+      - name: Build benchmark LuaJIT master
+        run: node ../../commit/dist/tstl.js -p tsconfig.jit.json
+        working-directory: master/benchmark
+      - name: Run benchmark LuaJIT master
+        id: benchmark-jit-master
+        run: luajit -- run.lua ../../../commit/benchmark/data/benchmark_master_jit.json
+        working-directory: master/benchmark/dist
+      # Run commit benchmark and compare with master
+      - name: Build benchmark Lua 5.3 commit
+        run: node ../../commit/dist/tstl.js -p tsconfig.53.json
+        working-directory: commit/benchmark
+      - name: Run benchmark Lua 5.3 commit
+        id: benchmark-lua-commit
+        run: lua5.3 -- run.lua ../data/benchmark_master_vs_commit_53.json ../data/benchmark_master_53.json
+        working-directory: commit/benchmark/dist
+      - name: Build benchmark LuaJIT commit
+        run: node ../../commit/dist/tstl.js -p tsconfig.jit.json
+        working-directory: commit/benchmark
+      - name: Run benchmark LuaJIT commit
+        id: benchmark-jit-commit
+        run: luajit -- run.lua ../data/benchmark_master_vs_commit_jit.json ../data/benchmark_master_jit.json
+        working-directory: commit/benchmark/dist
+      - name: Combine benchmark results
+        id: script-combine-results
+        uses: actions/github-script@v3
+        with:
+          benchmark-result-path-lua: commit/benchmark/data/benchmark_master_vs_commit_53.json
+          benchmark-result-path-jit: commit/benchmark/data/benchmark_master_vs_commit_jit.json
+          result-encoding: string
+          script: |
+            const createBenchmarkCheck = require(`${process.env.GITHUB_WORKSPACE}/commit/.github/scripts/create_benchmark_check.js`);
+            return createBenchmarkCheck({ github, context, core });
+      - name: Benchmark results
+        run: echo "${{steps.script-combine-results.outputs.result}}" | glow -s dark -w 120 -

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ yarn.lock
 
 benchmark/data/*
 benchmark/dist/*
-!benchmark/dist/json.lua

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 /dist
 /coverage
 /test/translation/transformation/characterEscapeSequence.ts
+/benchmark/dist

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -2,12 +2,12 @@
 
 These benchmarks are written in typescript and transpiled to lua by using tstl.
 
-### Currently only memory benchmarks are supported
+### Memory benchmarks
 
 To add a new benchmark add a new file to `memory_benchmarks`
 and **default** export a function with the following type: `() => void`.
 To prevent the benchmark from reporting "useful" results of your benchmark function as garbage, simply return the result.
-The memory used by the returned result wont count towards the total garbage amount.
+The memory used by the returned result won't count towards the total garbage amount.
 
 For example (memory_benchmarks/my_benchmark.ts):
 
@@ -25,19 +25,23 @@ export default function myBenchmark() {
 **Goal**
 
 The goal of memory benchmarks is to track how much (memory) `"garbage"` is created by tstl.
-For that reason garabage collection is disabled in the benchmarks.
+For that reason garbage collection is disabled in the benchmarks.
 
 You can force the creation of `"garbage"` by creating a lot of anonymous functions or temporary tables (see [lua-users.org](http://lua-users.org/wiki/OptimisingGarbageCollection) for more information).
 
 To avoid crashes in the CI your benchmark should not use more than 500MB of memory.
 
-**Running locally**
+### Runtime benchmarks
 
-1. Create a benchmark baseline called "benchmark_baseline.json":  
+To add a new runtime benchmark (execution time), add a new file to `runtime_benchmarks` and **default** export a function with the following type: `() => void`.
+
+### Running locally
+
+1. Create a benchmark baseline called "benchmark_baseline.json":
    `tstl -p tsconfig.53.json && cd dist && lua -- run.lua benchmark_baseline.json`
 2. Make some changes to tstl.
-3. Create an updated benchmark and compare with the baseline:  
+3. Create an updated benchmark and compare with the baseline:
    `tstl -p tsconfig.53.json && cd dist && lua -- run.lua benchmark_updated.json benchmark_baseline.json`
 4. The above command will output comparison data as json to stdout.
-   If you provide a path as third argument the comparison data will be written to that path instead.  
+   If you provide a path as third argument the comparison data will be written to that path instead.
    `tstl -p tsconfig.53.json && cd dist && lua -- run.lua benchmark_updated.json benchmark_baseline.json result.md`

--- a/benchmark/src/benchmark_types.ts
+++ b/benchmark/src/benchmark_types.ts
@@ -24,7 +24,6 @@ export function isMemoryBenchmarkResult(result: BenchmarkResult): result is Memo
 
 export interface RuntimeBenchmarkResult {
     kind: BenchmarkKind.Runtime;
-    // seconds, as returned by os.clock()
     time: number;
     benchmarkName: string;
 }

--- a/benchmark/src/benchmark_types.ts
+++ b/benchmark/src/benchmark_types.ts
@@ -1,10 +1,11 @@
 export enum BenchmarkKind {
     Memory = "memory",
+    Runtime = "runtime",
 }
 
 export type BenchmarkFunction = () => void;
 
-export type BenchmarkResult = MemoryBenchmarkResult;
+export type BenchmarkResult = MemoryBenchmarkResult | RuntimeBenchmarkResult;
 
 export enum MemoryBenchmarkCategory {
     TotalMemory = "totalMemory",
@@ -19,6 +20,17 @@ export interface MemoryBenchmarkResult {
 
 export function isMemoryBenchmarkResult(result: BenchmarkResult): result is MemoryBenchmarkResult {
     return result.kind === BenchmarkKind.Memory;
+}
+
+export interface RuntimeBenchmarkResult {
+    kind: BenchmarkKind.Runtime;
+    // seconds, as returned by os.clock()
+    time: number;
+    benchmarkName: string;
+}
+
+export function isRuntimeBenchmarkResult(result: BenchmarkResult): result is RuntimeBenchmarkResult {
+    return result.kind === BenchmarkKind.Runtime;
 }
 
 export interface ComparisonInfo {

--- a/benchmark/src/benchmark_util.ts
+++ b/benchmark/src/benchmark_util.ts
@@ -1,0 +1,60 @@
+import { BenchmarkResult } from "./benchmark_types";
+import { calculatePercentageChange, toFixed } from "./util";
+
+export const makeMarkdownTableRow = (cells: string[]) => `| ${cells.join(" | ")} |\n`;
+export const makeBold = (input: string) => `**${input}**`;
+
+export function compareNumericBenchmarks<T extends BenchmarkResult>(
+    newResults: T[],
+    oldResults: T[],
+    unit: string,
+    extractValue: (result: T) => number,
+    formatValue: (value: number) => string
+): string {
+    let comparisonTable = makeMarkdownTableRow([
+        "name",
+        `master (${unit})`,
+        `commit (${unit})`,
+        `change (${unit})`,
+        "change (%)",
+    ]);
+    comparisonTable += makeMarkdownTableRow(["---", "---", "---", "---", "---"]);
+
+    let oldValueSum = 0;
+    let newValueSum = 0;
+
+    newResults.forEach(newResult => {
+        const oldResult = oldResults.find(r => r.benchmarkName === newResult.benchmarkName);
+        const newValue = extractValue(newResult);
+        if (oldResult) {
+            const oldValue = extractValue(oldResult);
+            const percentageChange = calculatePercentageChange(oldValue, newValue);
+            const change = newValue - oldValue;
+            const row = [
+                newResult.benchmarkName,
+                formatValue(oldValue),
+                formatValue(newValue),
+                formatValue(change),
+                toFixed(percentageChange, 2),
+            ];
+            comparisonTable += makeMarkdownTableRow(row);
+            oldValueSum += oldValue;
+            newValueSum += newValue;
+        } else {
+            // No master found => new benchmark
+            const row = [newResult.benchmarkName, formatValue(newValue), "/", "/", "/"];
+            comparisonTable += makeMarkdownTableRow(row);
+        }
+    });
+
+    const sumPercentageChange = calculatePercentageChange(oldValueSum, newValueSum);
+    comparisonTable += makeMarkdownTableRow([
+        makeBold("sum"),
+        makeBold(formatValue(oldValueSum)),
+        makeBold(formatValue(newValueSum)),
+        makeBold(formatValue(newValueSum - oldValueSum)),
+        makeBold(toFixed(sumPercentageChange, 2)),
+    ]);
+
+    return comparisonTable;
+}

--- a/benchmark/src/run.ts
+++ b/benchmark/src/run.ts
@@ -41,14 +41,20 @@ function benchmark(): void {
 }
 benchmark();
 
+function sortByName({ benchmarkName: a }: BenchmarkResult, { benchmarkName: b }: BenchmarkResult): number {
+    if (a < b) return -1;
+    if (a > b) return 1;
+    return 0;
+}
+
 function compareBenchmarks(oldResults: BenchmarkResult[], newResults: BenchmarkResult[]): ComparisonInfo {
-    const oldResultsMemory = oldResults.filter(isMemoryBenchmarkResult);
-    const newResultsMemory = newResults.filter(isMemoryBenchmarkResult);
+    const oldResultsMemory = oldResults.filter(isMemoryBenchmarkResult).sort(sortByName);
+    const newResultsMemory = newResults.filter(isMemoryBenchmarkResult).sort(sortByName);
 
     const memoryComparisonInfo = compareMemoryBenchmarks(oldResultsMemory, newResultsMemory);
 
-    const oldResultsRuntime = oldResults.filter(isRuntimeBenchmarkResult);
-    const newResultsRuntime = newResults.filter(isRuntimeBenchmarkResult);
+    const oldResultsRuntime = oldResults.filter(isRuntimeBenchmarkResult).sort(sortByName);
+    const newResultsRuntime = newResults.filter(isRuntimeBenchmarkResult).sort(sortByName);
 
     const runtimeComparisonInfo = compareRuntimeBenchmarks(oldResultsRuntime, newResultsRuntime);
 

--- a/benchmark/src/runtime_benchmark.ts
+++ b/benchmark/src/runtime_benchmark.ts
@@ -1,0 +1,43 @@
+import { BenchmarkKind, ComparisonInfo, RuntimeBenchmarkResult } from "./benchmark_types";
+import { compareNumericBenchmarks } from "./benchmark_util";
+import { json, toFixed } from "./util";
+
+export function runRuntimeBenchmark(benchmarkFunction: () => void): RuntimeBenchmarkResult {
+    const result: RuntimeBenchmarkResult = {
+        kind: BenchmarkKind.Runtime,
+        benchmarkName: "NO_NAME",
+        time: 0,
+    };
+
+    // normalize times a bit
+    collectgarbage("collect");
+
+    const startTime = os.clock();
+    benchmarkFunction();
+    const time = os.clock() - startTime;
+
+    result.benchmarkName = debug.getinfo(benchmarkFunction).short_src;
+    result.time = time;
+    return result;
+}
+
+export function compareRuntimeBenchmarks(
+    oldResults: RuntimeBenchmarkResult[],
+    newResults: RuntimeBenchmarkResult[]
+): ComparisonInfo {
+    const summary =
+        "### runtime\n\n" +
+        compareNumericBenchmarks(
+            newResults,
+            oldResults,
+            "s",
+            result => result.time,
+            time => toFixed(time, 4)
+        );
+
+    const text = `**master:**\n\`\`\`json\n${json.encode(oldResults)}\n\`\`\`\n**commit:**\n\`\`\`json\n${json.encode(
+        newResults
+    )}\n\`\`\``;
+
+    return { summary, text };
+}

--- a/benchmark/src/runtime_benchmark.ts
+++ b/benchmark/src/runtime_benchmark.ts
@@ -35,7 +35,7 @@ export function compareRuntimeBenchmarks(
             time => toFixed(time, 4)
         );
 
-    const text = `**master:**\n\`\`\`json\n${json.encode(oldResults)}\n\`\`\`\n**commit:**\n\`\`\`json\n${json.encode(
+    const text = `### master\n\`\`\`json\n${json.encode(oldResults)}\n\`\`\`\n### commit\n\`\`\`json\n${json.encode(
         newResults
     )}\n\`\`\``;
 

--- a/benchmark/src/runtime_benchmarks/array_push.ts
+++ b/benchmark/src/runtime_benchmarks/array_push.ts
@@ -1,0 +1,8 @@
+export default function arrayPush(): number[] {
+    const n = 1000000;
+    const numberList: number[] = [];
+    for (let i = 0; i < n; i++) {
+        numberList[numberList.length] = i * i;
+    }
+    return numberList;
+}


### PR DESCRIPTION
Adds basic runtime benchmarks, modeled off of existing memory benchmarks.

At least can be used for local benchmarks; Still need to test with github workflows.