### PR TITLE
Add `string.replaceAll` lualib and optimize/fix `string.replace`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 16.9.0
+      - name: Use Node.js 15.14.0
         uses: actions/setup-node@v1
         with:
-          node-version: 16.9.0
+          node-version: 15.14.0
       - run: npm ci
       - run: npm run build
       - run: npx jest --maxWorkers 2 --coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 12.13.1
+      - name: Use Node.js 16.9.0
         uses: actions/setup-node@v1
         with:
-          node-version: 12.13.1
+          node-version: 16.9.0
       - run: npm ci
       - run: npm run build
       - run: npx jest --maxWorkers 2 --coverage

--- a/src/LuaLib.ts
+++ b/src/LuaLib.ts
@@ -83,6 +83,7 @@ export enum LuaLibFeature {
     StringPadEnd = "StringPadEnd",
     StringPadStart = "StringPadStart",
     StringReplace = "StringReplace",
+    StringReplaceAll = "StringReplaceAll",
     StringSlice = "StringSlice",
     StringSplit = "StringSplit",
     StringStartsWith = "StringStartsWith",

--- a/src/lualib/StringReplace.ts
+++ b/src/lualib/StringReplace.ts
@@ -2,21 +2,16 @@ function __TS__StringReplace(
     this: void,
     source: string,
     searchValue: string,
-    replaceValue: string | ((substring: string) => string)
+    replaceValue: string | ((match: string, offset: number, string: string) => string)
 ): string {
-    [searchValue] = string.gsub(searchValue, "[%%%(%)%.%+%-%*%?%[%^%$]", "%%%1");
-
-    if (typeof replaceValue === "string") {
-        [replaceValue] = string.gsub(replaceValue, "%%", "%%%%");
-        const [result] = string.gsub(source, searchValue, replaceValue, 1);
-        return result;
-    } else {
-        const [result] = string.gsub(
-            source,
-            searchValue,
-            match => (replaceValue as (substring: string) => string)(match),
-            1
-        );
-        return result;
+    const [startPos, endPos] = string.find(source, searchValue, undefined, true);
+    if (!startPos) {
+        return source;
     }
+    const sub = string.sub;
+    const before = sub(source, 1, startPos - 1);
+    const replacement =
+        typeof replaceValue === "string" ? replaceValue : replaceValue(searchValue, startPos - 1, source);
+    const after = sub(source, endPos + 1);
+    return before + replacement + after;
 }

--- a/src/lualib/StringReplaceAll.ts
+++ b/src/lualib/StringReplaceAll.ts
@@ -1,0 +1,40 @@
+function __TS__StringReplaceAll(
+    this: void,
+    source: string,
+    searchValue: string,
+    replaceValue: string | ((match: string, offset: number, string: string) => string)
+): string {
+    let replacer: (match: string, offset: number, string: string) => string;
+    if (typeof replaceValue === "string") {
+        replacer = () => replaceValue;
+    } else {
+        replacer = replaceValue;
+    }
+    const parts: string[] = [];
+    let partsIndex = 1;
+
+    const sub = string.sub;
+    if (searchValue.length === 0) {
+        parts[0] = replacer("", 0, source);
+        partsIndex = 2;
+        for (const i of $range(1, source.length)) {
+            parts[partsIndex - 1] = sub(source, i, i);
+            parts[partsIndex] = replacer("", i, source);
+            partsIndex += 2;
+        }
+    } else {
+        const find = string.find;
+        let currentPos = 1;
+        while (true) {
+            const [startPos, endPos] = find(source, searchValue, currentPos, true);
+            if (!startPos) break;
+            parts[partsIndex - 1] = sub(source, currentPos, startPos - 1);
+            parts[partsIndex] = replacer(searchValue, startPos - 1, source);
+            partsIndex += 2;
+
+            currentPos = endPos + 1;
+        }
+        parts[partsIndex - 1] = sub(source, currentPos);
+    }
+    return table.concat(parts);
+}

--- a/src/transformation/builtins/string.ts
+++ b/src/transformation/builtins/string.ts
@@ -28,6 +28,8 @@ export function transformStringPrototypeCall(
     switch (expressionName) {
         case "replace":
             return transformLuaLibFunction(context, LuaLibFeature.StringReplace, node, caller, ...params);
+        case "replaceAll":
+            return transformLuaLibFunction(context, LuaLibFeature.StringReplaceAll, node, caller, ...params);
         case "concat":
             return transformLuaLibFunction(context, LuaLibFeature.StringConcat, node, caller, ...params);
 

--- a/test/unit/builtins/string.spec.ts
+++ b/test/unit/builtins/string.spec.ts
@@ -54,8 +54,9 @@ test("string index (side effect)", () => {
     `.expectToMatchJsResult();
 });
 
-test.each([
+const replaceTestCases = [
     { inp: "hello test", searchValue: "", replaceValue: "" },
+    { inp: "hello test", searchValue: "", replaceValue: "_" },
     { inp: "hello test", searchValue: " ", replaceValue: "" },
     { inp: "hello test", searchValue: "hello", replaceValue: "" },
     { inp: "hello test", searchValue: "test", replaceValue: "" },
@@ -68,8 +69,15 @@ test.each([
     { inp: "hello test", searchValue: "test", replaceValue: () => "a" },
     { inp: "hello test", searchValue: "test", replaceValue: () => "%a" },
     { inp: "aaa", searchValue: "a", replaceValue: "b" },
-])("string.replace (%p)", ({ inp, searchValue, replaceValue }) => {
+];
+test.each(replaceTestCases)("string.replace (%p)", ({ inp, searchValue, replaceValue }) => {
     util.testExpression`"${inp}".replace(${util.formatCode(searchValue, replaceValue)})`.expectToMatchJsResult();
+});
+test.each(replaceTestCases)("string.replaceAll (%p)", ({ inp, searchValue, replaceValue }) => {
+    util.testExpression`"${inp}${inp}".replaceAll(${util.formatCode(
+        searchValue,
+        replaceValue
+    )})`.expectToMatchJsResult();
 });
 
 test.each([

--- a/test/unit/builtins/string.spec.ts
+++ b/test/unit/builtins/string.spec.ts
@@ -1,6 +1,5 @@
 import { LuaLibImportKind } from "../../../src";
 import * as util from "../../util";
-import { describe } from "jest-circus";
 
 test("Supported lua string function", () => {
     const tsHeader = `
@@ -70,31 +69,30 @@ describe.each(["replace", "replaceAll"])("string.%s", method => {
         { inp: "hello test.", searchValue: ".", replaceValue: "$" },
         { inp: "aaa", searchValue: "a", replaceValue: "b" },
     ];
-    describe("string replacer", () => {
-        test.each(testCases)("%p", ({ inp, searchValue, replaceValue }) => {
-            util.testExpression`"${inp}${inp}".${method}(${util.formatCode(
-                searchValue,
-                replaceValue
-            )})`.expectToMatchJsResult();
-        });
+
+    test.each(testCases)("string replacer %p", ({ inp, searchValue, replaceValue }) => {
+        util.testExpression`"${inp}${inp}".${method}(${util.formatCode(
+            searchValue,
+            replaceValue
+        )})`.expectToMatchJsResult();
     });
-    describe("function replacer", () => {
-        test.each(testCases)("%p", ({ inp, searchValue, replaceValue }) => {
-            util.testFunction`
-        const result = {
-            args: [],
-            string: ""
-        }
-        function replacer(...args: any[]): string {
-            result.args.push(...args)
-            return ${util.formatCode(replaceValue)}
-        }
-        result.string = "${inp}${inp}".${method}(${util.formatCode(searchValue)}, replacer)
-        return result
-    `.expectToMatchJsResult();
-        });
+
+    test.each(testCases)("function replacer %p", ({ inp, searchValue, replaceValue }) => {
+        util.testFunction`
+            const result = {
+                args: [],
+                string: ""
+            }
+            function replacer(...args: any[]): string {
+                result.args.push(...args)
+                return ${util.formatCode(replaceValue)}
+            }
+            result.string = "${inp}${inp}".${method}(${util.formatCode(searchValue)}, replacer)
+            return result
+        `.expectToMatchJsResult();
     });
 });
+
 test.each([
     ["", ""],
     ["hello", "test"],


### PR DESCRIPTION
Adds `string.replaceAll` to lualib #1121

Also optimizes `string.replace`.

This also fixes so that `string.replace(All)` with a function replacer gets called with the correct arguments.
