### PR TITLE
Add noResolvePaths option

### DIFF
--- a/src/CompilerOptions.ts
+++ b/src/CompilerOptions.ts
@@ -23,15 +23,16 @@ export interface LuaPluginImport {
 
 export type CompilerOptions = OmitIndexSignature<ts.CompilerOptions> & {
     buildMode?: BuildMode;
-    noImplicitSelf?: boolean;
-    noHeader?: boolean;
     luaBundle?: string;
     luaBundleEntry?: string;
     luaTarget?: LuaTarget;
     luaLibImport?: LuaLibImportKind;
-    sourceMapTraceback?: boolean;
     luaPlugins?: LuaPluginImport[];
+    noImplicitSelf?: boolean;
+    noHeader?: boolean;
+    noResolvePaths?: string[];
     plugins?: Array<ts.PluginImport | TransformerImport>;
+    sourceMapTraceback?: boolean;
     tstlVerbose?: boolean;
     [option: string]: any;
 };


### PR DESCRIPTION
Regarding #1101 and #1118

It could happen that someone is importing lua sources that internally require some environment-provided library. It would then be impossible to mark these as @noResolution in .d.ts files. Therefore I have added a `noResolvePaths` option (I'm open for other names) to our tsconfig that act as a global list of lua require paths.

For example tsconfig.json:
```json
{
    "compilerOptions": {
        // ....
    },
    "tstl": {
        "noResolvePaths": ["foo.bar", "baz"]
    }
}
```
Will cause the following requires to not throw a resolution error. They will also not be rewritten:
```lua
require("foo.bar")
require("baz")
```

Currently this IS case-sensitive.