### PR TITLE
Make await throw if awaited thing is a rejected promise

### DIFF
--- a/src/lualib/Await.ts
+++ b/src/lualib/Await.ts
@@ -48,5 +48,8 @@ function __TS__AsyncAwaiter(this: void, generator: (this: void) => void) {
 }
 
 function __TS__Await(this: void, thing: unknown) {
+    if (thing instanceof __TS__Promise && thing.state === __TS__PromiseState.Rejected) {
+        throw thing.rejectionReason;
+    }
     return coroutine.yield(thing);
 }


### PR DESCRIPTION
This resolves one of the problems reported in #1105, the catch clause was being completely ignored. This change makes it so the test code behaves like it does in the TS playground:

https://www.typescriptlang.org/play?#code/IYZwngdgxgBAZgV2gFwJYHsL3egFASgC4YAFAJ3QFtUQBTAHggUoCNayA+GAbwCgYBMZGTA9+giWVrIEZLMADuwVMhgRaC0hWp1cuKSHQAbAG60ANDCkArWlGT4YAXi427yXACJktEKvYUZJ74+ADc4gIAvjBQwMhQABYwuLSOfBISyAkUmp7AWAHoZDDoUFCyUgAmMKhYWbQwoJCwiCgYEMSeMADUMLThEpG8Q3A4BAB0sfEJKc5c6YJQmIZGtONG6ADmKfjDYUA