### PR TITLE
Correctly export decorated classes

### DIFF
--- a/src/transformation/utils/export.ts
+++ b/src/transformation/utils/export.ts
@@ -10,10 +10,11 @@ export function hasDefaultExportModifier(node: ts.Node): boolean {
     return (node.modifiers ?? []).some(modifier => modifier.kind === ts.SyntaxKind.DefaultKeyword);
 }
 
-export const createDefaultExportIdentifier = (original: ts.Node): lua.Identifier =>
-    lua.createIdentifier("default", original);
+export function hasExportModifier(node: ts.Node): boolean {
+    return (node.modifiers ?? []).some(modifier => modifier.kind === ts.SyntaxKind.ExportKeyword);
+}
 
-export const createDefaultExportStringLiteral = (original: ts.Node): lua.StringLiteral =>
+export const createDefaultExportStringLiteral = (original?: ts.Node): lua.StringLiteral =>
     lua.createStringLiteral("default", original);
 
 export function getExportedSymbolDeclaration(symbol: ts.Symbol): ts.Declaration | undefined {
@@ -141,4 +142,8 @@ export function createExportedIdentifier(
             : createExportsIdentifier();
 
     return lua.createTableIndexExpression(exportTable, lua.createStringLiteral(identifier.text));
+}
+
+export function createDefaultExportExpression(node: ts.Node): lua.AssignmentLeftHandSideExpression {
+    return lua.createTableIndexExpression(createExportsIdentifier(), createDefaultExportStringLiteral(node), node);
 }

--- a/src/transformation/visitors/modules/export.ts
+++ b/src/transformation/visitors/modules/export.ts
@@ -3,7 +3,7 @@ import * as lua from "../../../LuaAST";
 import { assert } from "../../../utils";
 import { FunctionVisitor, TransformationContext } from "../../context";
 import {
-    createDefaultExportIdentifier,
+    createDefaultExportExpression,
     createDefaultExportStringLiteral,
     createExportedIdentifier,
 } from "../../utils/export";
@@ -114,10 +114,9 @@ function transformExportSpecifier(context: TransformationContext, node: ts.Expor
     const exportedExpression = createShorthandIdentifier(context, exportedSymbol, exportedIdentifier);
 
     const isDefault = isDefaultExportSpecifier(node);
-    const identifierToExport = isDefault
-        ? createDefaultExportIdentifier(node)
-        : transformIdentifier(context, node.name);
-    const exportAssignmentLeftHandSide = createExportedIdentifier(context, identifierToExport);
+    const exportAssignmentLeftHandSide = isDefault
+        ? createDefaultExportExpression(node)
+        : createExportedIdentifier(context, transformIdentifier(context, node.name));
 
     return lua.createAssignmentStatement(exportAssignmentLeftHandSide, exportedExpression, node);
 }

--- a/test/unit/classes/decorators.spec.ts
+++ b/test/unit/classes/decorators.spec.ts
@@ -184,3 +184,56 @@ describe("Decorators /w descriptors", () => {
         }
     );
 });
+
+// https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1149
+test("exported class with decorator", () => {
+    util.testModule`
+        import { MyClass } from "./other";
+        const inst = new MyClass();
+        export const result = inst.foo();
+    `
+        .addExtraFile(
+            "other.ts",
+            `function myDecorator(target: {new(): any}) {
+                return class extends target {
+                    foo() {
+                        return "overridden";
+                    }
+                }
+            }
+
+            @myDecorator
+            export class MyClass {
+                foo() {
+                    return "foo";
+                }
+            }`
+        )
+        .expectToEqual({ result: "overridden" });
+});
+
+test("default exported class with decorator", () => {
+    util.testModule`
+        import MyClass from "./other";
+        const inst = new MyClass();
+        export const result = inst.foo();
+    `
+        .addExtraFile(
+            "other.ts",
+            `function myDecorator(target: {new(): any}) {
+                return class extends target {
+                    foo() {
+                        return "overridden";
+                    }
+                }
+            }
+
+            @myDecorator
+            export default class {
+                foo() {
+                    return "foo";
+                }
+            }`
+        )
+        .expectToEqual({ result: "overridden" });
+});


### PR DESCRIPTION
Exported classes are reassigned after their declaration:
```lua
local MyClass = __TS__Class()
____exports.MyClass = MyClass
...
MyClass = __TS__Decorate({myDecorator}, MyClass)
```

This results in the exported class being the undecorated version still. This was resolved by also just reassigning the exported variable:
```diff
  local MyClass = __TS__Class()
  ____exports.MyClass = MyClass
  ...
  MyClass = __TS__Decorate({myDecorator}, MyClass)
+ ____exports.MyClass = MyClass
```

Closes #1149