### PR TITLE
Better print format

### DIFF
--- a/src/LuaPrinter.ts
+++ b/src/LuaPrinter.ts
@@ -820,10 +820,19 @@ export class LuaPrinter {
         return intersperse(chunks, ", ");
     }
 
+    /**
+     * Returns true if the expression list (table field or parameters) should be printed on one line.
+     */
+    protected isSimpleExpressionList(expressions: lua.Expression[]): boolean {
+        if (expressions.length <= 1) return true;
+        if (expressions.length > 4) return false;
+        return expressions.every(isSimpleExpression);
+    }
+
     protected printExpressionList(expressions: lua.Expression[]): SourceChunk[] {
         const chunks: SourceChunk[] = [];
 
-        if (expressions.every(isSimpleExpression)) {
+        if (this.isSimpleExpressionList(expressions)) {
             chunks.push(...this.joinChunksWithComma(expressions.map(e => this.printExpression(e))));
         } else {
             chunks.push("\n");

--- a/src/LuaPrinter.ts
+++ b/src/LuaPrinter.ts
@@ -120,6 +120,42 @@ export class LuaPrinter {
         [lua.SyntaxKind.BitwiseLeftShiftOperator]: "<<",
         [lua.SyntaxKind.BitwiseNotOperator]: "~",
     };
+    private static operatorPrecedence: Record<lua.Operator, number> = {
+        [lua.SyntaxKind.OrOperator]: 1,
+        [lua.SyntaxKind.AndOperator]: 2,
+
+        [lua.SyntaxKind.EqualityOperator]: 3,
+        [lua.SyntaxKind.InequalityOperator]: 3,
+        [lua.SyntaxKind.LessThanOperator]: 3,
+        [lua.SyntaxKind.LessEqualOperator]: 3,
+        [lua.SyntaxKind.GreaterThanOperator]: 3,
+        [lua.SyntaxKind.GreaterEqualOperator]: 3,
+
+        [lua.SyntaxKind.BitwiseOrOperator]: 4,
+        [lua.SyntaxKind.BitwiseExclusiveOrOperator]: 5,
+        [lua.SyntaxKind.BitwiseAndOperator]: 6,
+
+        [lua.SyntaxKind.BitwiseLeftShiftOperator]: 7,
+        [lua.SyntaxKind.BitwiseRightShiftOperator]: 7,
+
+        [lua.SyntaxKind.ConcatOperator]: 8,
+
+        [lua.SyntaxKind.AdditionOperator]: 9,
+        [lua.SyntaxKind.SubtractionOperator]: 9,
+
+        [lua.SyntaxKind.MultiplicationOperator]: 10,
+        [lua.SyntaxKind.DivisionOperator]: 10,
+        [lua.SyntaxKind.FloorDivisionOperator]: 10,
+        [lua.SyntaxKind.ModuloOperator]: 10,
+
+        [lua.SyntaxKind.NotOperator]: 11,
+        [lua.SyntaxKind.LengthOperator]: 11,
+        [lua.SyntaxKind.NegationOperator]: 11,
+        [lua.SyntaxKind.BitwiseNotOperator]: 11,
+
+        [lua.SyntaxKind.PowerOperator]: 12,
+    };
+    private static rightAssociativeOperators = new Set([lua.SyntaxKind.ConcatOperator, lua.SyntaxKind.PowerOperator]);
 
     private currentIndent = "";
     private luaFile: string;
@@ -676,34 +712,49 @@ export class LuaPrinter {
         const chunks: SourceChunk[] = [];
 
         chunks.push(this.printOperator(expression.operator));
-        chunks.push(this.printExpressionInParenthesesIfNeeded(expression.operand));
+        chunks.push(
+            this.printExpressionInParenthesesIfNeeded(
+                expression.operand,
+                LuaPrinter.operatorPrecedence[expression.operator]
+            )
+        );
 
         return this.createSourceNode(expression, chunks);
     }
 
     public printBinaryExpression(expression: lua.BinaryExpression): SourceNode {
         const chunks: SourceChunk[] = [];
-
-        chunks.push(this.printExpressionInParenthesesIfNeeded(expression.left));
+        const isRightAssociative = LuaPrinter.rightAssociativeOperators.has(expression.operator);
+        const precedence = LuaPrinter.operatorPrecedence[expression.operator];
+        chunks.push(
+            this.printExpressionInParenthesesIfNeeded(expression.left, isRightAssociative ? precedence + 1 : precedence)
+        );
         chunks.push(" ", this.printOperator(expression.operator), " ");
-        chunks.push(this.printExpressionInParenthesesIfNeeded(expression.right));
+        chunks.push(
+            this.printExpressionInParenthesesIfNeeded(
+                expression.right,
+                isRightAssociative ? precedence : precedence + 1
+            )
+        );
 
         return this.createSourceNode(expression, chunks);
     }
 
-    private printExpressionInParenthesesIfNeeded(expression: lua.Expression): SourceNode {
-        return this.needsParenthesis(expression)
+    private printExpressionInParenthesesIfNeeded(expression: lua.Expression, minPrecedenceToOmit?: number): SourceNode {
+        return this.needsParenthesis(expression, minPrecedenceToOmit)
             ? this.createSourceNode(expression, ["(", this.printExpression(expression), ")"])
             : this.printExpression(expression);
     }
 
-    private needsParenthesis(expression: lua.Expression): boolean {
-        return (
-            lua.isBinaryExpression(expression) ||
-            lua.isFunctionExpression(expression) ||
-            lua.isTableExpression(expression) ||
-            (lua.isUnaryExpression(expression) && expression.operator === lua.SyntaxKind.NotOperator)
-        );
+    private needsParenthesis(expression: lua.Expression, minPrecedenceToOmit?: number): boolean {
+        if (lua.isBinaryExpression(expression) || lua.isUnaryExpression(expression)) {
+            return (
+                minPrecedenceToOmit === undefined ||
+                LuaPrinter.operatorPrecedence[expression.operator] < minPrecedenceToOmit
+            );
+        } else {
+            return lua.isFunctionExpression(expression) || lua.isTableExpression(expression);
+        }
     }
 
     public printCallExpression(expression: lua.CallExpression): SourceNode {

--- a/test/translation/__snapshots__/transformation.spec.ts.snap
+++ b/test/translation/__snapshots__/transformation.spec.ts.snap
@@ -21,7 +21,7 @@ backQuoteInTemplateString = \\"\` \` \`\\"
 escapedCharsInQuotes = \\"\\\\\\\\ \\\\0 \\\\b \\\\t \\\\n \\\\v \\\\f \\\\\\" ' \`\\"
 escapedCharsInDoubleQuotes = \\"\\\\\\\\ \\\\0 \\\\b \\\\t \\\\n \\\\v \\\\f \\\\\\" ' \`\\"
 escapedCharsInTemplateString = \\"\\\\\\\\ \\\\0 \\\\b \\\\t \\\\n \\\\v \\\\f \\\\\\" ' \`\\"
-nonEmptyTemplateString = (\\"Level 0: \\\\n\\\\t \\" .. ((\\"Level 1: \\\\n\\\\t\\\\t \\" .. ((\\"Level 3: \\\\n\\\\t\\\\t\\\\t \\" .. \\"Last level \\\\n --\\") .. \\" \\\\n --\\")) .. \\" \\\\n --\\")) .. \\" \\\\n --\\""
+nonEmptyTemplateString = (\\"Level 0: \\\\n\\\\t \\" .. (\\"Level 1: \\\\n\\\\t\\\\t \\" .. (\\"Level 3: \\\\n\\\\t\\\\t\\\\t \\" .. \\"Last level \\\\n --\\") .. \\" \\\\n --\\") .. \\" \\\\n --\\") .. \\" \\\\n --\\""
 `;
 
 exports[`Transformation (exportStatement) 1`] = `

--- a/test/translation/__snapshots__/transformation.spec.ts.snap
+++ b/test/translation/__snapshots__/transformation.spec.ts.snap
@@ -230,6 +230,30 @@ return ____exports"
 
 exports[`Transformation (modulesVariableNoExport) 1`] = `"foo = \\"bar\\""`;
 
+exports[`Transformation (printFormat) 1`] = `
+"stringConcat = ((\\"a\\" .. \\"b\\" .. \\"c\\") .. \\"d\\") .. \\"e\\"
+numbers = 2 * 2 + 3 + 4 * (5 + 6) ~= 7
+function func(...)
+end
+func(function()
+    local b = \\"A function\\"
+end)
+func(func())
+array = {func()}
+array2 = {
+    func(),
+    func()
+}
+object = {a = 1, b = 2, c = 3}
+bigObject = {
+    a = 1,
+    b = 2,
+    c = 3,
+    d = \\"value1\\",
+    e = \\"value2\\"
+}"
+`;
+
 exports[`Transformation (returnDefault) 1`] = `
 "function myFunc(self)
     return

--- a/test/translation/transformation/printFormat.ts
+++ b/test/translation/transformation/printFormat.ts
@@ -1,0 +1,27 @@
+const stringConcat = "a" + ("b" + "c") + "d" + "e";
+const numbers = 2 * 2 + 3 + 4 * (5 + 6) !== 7;
+
+function func(this: void, ...args: any) {}
+
+func(() => {
+    const b = "A function";
+});
+
+func(func());
+
+const array = [func()];
+const array2 = [func(), func()];
+
+const object = {
+    a: 1,
+    b: 2,
+    c: 3,
+};
+
+const bigObject = {
+    a: 1,
+    b: 2,
+    c: 3,
+    d: "value1",
+    e: "value2",
+};

--- a/test/unit/__snapshots__/expressions.spec.ts.snap
+++ b/test/unit/__snapshots__/expressions.spec.ts.snap
@@ -14,13 +14,13 @@ return ____exports"
 
 exports[`Binary expressions ordering parentheses ("1*(3+4*2)") 1`] = `
 "local ____exports = {}
-____exports.__result = 1 * (3 + (4 * 2))
+____exports.__result = 1 * (3 + 4 * 2)
 return ____exports"
 `;
 
 exports[`Binary expressions ordering parentheses ("1*30+4") 1`] = `
 "local ____exports = {}
-____exports.__result = (1 * 30) + 4
+____exports.__result = 1 * 30 + 4
 return ____exports"
 `;
 

--- a/test/unit/__snapshots__/spread.spec.ts.snap
+++ b/test/unit/__snapshots__/spread.spec.ts.snap
@@ -90,9 +90,7 @@ function ____exports.__main(self)
     end
     return test(
         nil,
-        {
-            fn = function(____, arg) return arg end
-        },
+        {fn = function(____, arg) return arg end},
         \\"foobar\\"
     )
 end
@@ -108,11 +106,9 @@ function ____exports.__main(self)
     end
     local function test(self, ...)
         do
-            pcall(
-                function()
-                    error(\\"foobar\\", 0)
-                end
-            )
+            pcall(function()
+                error(\\"foobar\\", 0)
+            end)
             do
                 return pick(nil, ...)
             end

--- a/test/unit/__snapshots__/switch.spec.ts.snap
+++ b/test/unit/__snapshots__/switch.spec.ts.snap
@@ -50,14 +50,14 @@ function ____exports.__main(self)
             result = hoisted(nil)
             break
         end
-        ____cond3 = ____cond3 or (____switch3 == 2)
+        ____cond3 = ____cond3 or ____switch3 == 2
         if ____cond3 then
             result = \\"2\\"
         end
         if ____cond3 then
             result = \\"default\\"
         end
-        ____cond3 = ____cond3 or (____switch3 == 3)
+        ____cond3 = ____cond3 or ____switch3 == 3
         if ____cond3 then
             result = \\"3\\"
             break
@@ -88,14 +88,14 @@ function ____exports.__main(self)
             result = hoisted(nil)
             break
         end
-        ____cond3 = ____cond3 or (____switch3 == 2)
+        ____cond3 = ____cond3 or ____switch3 == 2
         if ____cond3 then
             result = \\"2\\"
         end
         if ____cond3 then
             result = \\"default\\"
         end
-        ____cond3 = ____cond3 or (____switch3 == 3)
+        ____cond3 = ____cond3 or ____switch3 == 3
         if ____cond3 then
             result = \\"3\\"
             break
@@ -118,19 +118,19 @@ function ____exports.__main(self)
     local out = {}
     repeat
         local ____switch3 = 0
-        local ____cond3 = ((____switch3 == 0) or (____switch3 == 1)) or (____switch3 == 2)
+        local ____cond3 = ____switch3 == 0 or ____switch3 == 1 or ____switch3 == 2
         if ____cond3 then
             __TS__ArrayPush(out, \\"0,1,2\\")
             break
         end
-        ____cond3 = ____cond3 or (____switch3 == 3)
+        ____cond3 = ____cond3 or ____switch3 == 3
         if ____cond3 then
             do
                 __TS__ArrayPush(out, \\"3\\")
                 break
             end
         end
-        ____cond3 = ____cond3 or (____switch3 == 4)
+        ____cond3 = ____cond3 or ____switch3 == 4
         if ____cond3 then
             break
         end

--- a/test/unit/builtins/__snapshots__/console.spec.ts.snap
+++ b/test/unit/builtins/__snapshots__/console.spec.ts.snap
@@ -57,9 +57,7 @@ return ____exports"
 exports[`console.error ("console.error(\\"Hello %%s\\", \\"there\\")") 1`] = `
 "local ____exports = {}
 function ____exports.__main(self)
-    print(
-        string.format(\\"Hello %%s\\", \\"there\\")
-    )
+    print(string.format(\\"Hello %%s\\", \\"there\\"))
 end
 return ____exports"
 `;
@@ -67,9 +65,7 @@ return ____exports"
 exports[`console.error ("console.error(\\"Hello %s\\", \\"there\\")") 1`] = `
 "local ____exports = {}
 function ____exports.__main(self)
-    print(
-        string.format(\\"Hello %s\\", \\"there\\")
-    )
+    print(string.format(\\"Hello %s\\", \\"there\\"))
 end
 return ____exports"
 `;
@@ -101,9 +97,7 @@ return ____exports"
 exports[`console.info ("console.info(\\"Hello %%s\\", \\"there\\")") 1`] = `
 "local ____exports = {}
 function ____exports.__main(self)
-    print(
-        string.format(\\"Hello %%s\\", \\"there\\")
-    )
+    print(string.format(\\"Hello %%s\\", \\"there\\"))
 end
 return ____exports"
 `;
@@ -111,9 +105,7 @@ return ____exports"
 exports[`console.info ("console.info(\\"Hello %s\\", \\"there\\")") 1`] = `
 "local ____exports = {}
 function ____exports.__main(self)
-    print(
-        string.format(\\"Hello %s\\", \\"there\\")
-    )
+    print(string.format(\\"Hello %s\\", \\"there\\"))
 end
 return ____exports"
 `;
@@ -145,9 +137,7 @@ return ____exports"
 exports[`console.log ("console.log(\\"Hello %%s\\", \\"there\\")") 1`] = `
 "local ____exports = {}
 function ____exports.__main(self)
-    print(
-        string.format(\\"Hello %%s\\", \\"there\\")
-    )
+    print(string.format(\\"Hello %%s\\", \\"there\\"))
 end
 return ____exports"
 `;
@@ -155,9 +145,7 @@ return ____exports"
 exports[`console.log ("console.log(\\"Hello %s\\", \\"there\\")") 1`] = `
 "local ____exports = {}
 function ____exports.__main(self)
-    print(
-        string.format(\\"Hello %s\\", \\"there\\")
-    )
+    print(string.format(\\"Hello %s\\", \\"there\\"))
 end
 return ____exports"
 `;
@@ -181,9 +169,7 @@ return ____exports"
 exports[`console.trace ("console.trace()") 1`] = `
 "local ____exports = {}
 function ____exports.__main(self)
-    print(
-        debug.traceback()
-    )
+    print(debug.traceback())
 end
 return ____exports"
 `;
@@ -191,11 +177,7 @@ return ____exports"
 exports[`console.trace ("console.trace(\\"Hello %%s\\", \\"there\\")") 1`] = `
 "local ____exports = {}
 function ____exports.__main(self)
-    print(
-        debug.traceback(
-            string.format(\\"Hello %%s\\", \\"there\\")
-        )
-    )
+    print(debug.traceback(string.format(\\"Hello %%s\\", \\"there\\")))
 end
 return ____exports"
 `;
@@ -203,11 +185,7 @@ return ____exports"
 exports[`console.trace ("console.trace(\\"Hello %s\\", \\"there\\")") 1`] = `
 "local ____exports = {}
 function ____exports.__main(self)
-    print(
-        debug.traceback(
-            string.format(\\"Hello %s\\", \\"there\\")
-        )
-    )
+    print(debug.traceback(string.format(\\"Hello %s\\", \\"there\\")))
 end
 return ____exports"
 `;
@@ -215,9 +193,7 @@ return ____exports"
 exports[`console.trace ("console.trace(\\"Hello\\", \\"there\\")") 1`] = `
 "local ____exports = {}
 function ____exports.__main(self)
-    print(
-        debug.traceback(\\"Hello\\", \\"there\\")
-    )
+    print(debug.traceback(\\"Hello\\", \\"there\\"))
 end
 return ____exports"
 `;
@@ -225,9 +201,7 @@ return ____exports"
 exports[`console.trace ("console.trace(\\"message\\")") 1`] = `
 "local ____exports = {}
 function ____exports.__main(self)
-    print(
-        debug.traceback(\\"message\\")
-    )
+    print(debug.traceback(\\"message\\"))
 end
 return ____exports"
 `;
@@ -243,9 +217,7 @@ return ____exports"
 exports[`console.warn ("console.warn(\\"Hello %%s\\", \\"there\\")") 1`] = `
 "local ____exports = {}
 function ____exports.__main(self)
-    print(
-        string.format(\\"Hello %%s\\", \\"there\\")
-    )
+    print(string.format(\\"Hello %%s\\", \\"there\\"))
 end
 return ____exports"
 `;
@@ -253,9 +225,7 @@ return ____exports"
 exports[`console.warn ("console.warn(\\"Hello %s\\", \\"there\\")") 1`] = `
 "local ____exports = {}
 function ____exports.__main(self)
-    print(
-        string.format(\\"Hello %s\\", \\"there\\")
-    )
+    print(string.format(\\"Hello %s\\", \\"there\\"))
 end
 return ____exports"
 `;

--- a/test/unit/language-extensions/__snapshots__/multi.spec.ts.snap
+++ b/test/unit/language-extensions/__snapshots__/multi.spec.ts.snap
@@ -20,9 +20,7 @@ function ____exports.__main(self)
     local function multi(self, ...)
         return ...
     end
-    return ({
-        multi(nil)
-    }).forEach
+    return ({multi(nil)}).forEach
 end
 return ____exports"
 `;
@@ -42,9 +40,7 @@ exports[`invalid $multi call ($multi): diagnostics 1`] = `"main.ts(2,9): error T
 exports[`invalid $multi call (([a] = $multi(1)) => {}): code 1`] = `
 "local function ____(____, ____bindingPattern0)
     if ____bindingPattern0 == nil then
-        ____bindingPattern0 = {
-            ____(_G, 1)
-        }
+        ____bindingPattern0 = {____(_G, 1)}
     end
     local a = ____bindingPattern0[1]
 end"
@@ -65,21 +61,11 @@ end"
 
 exports[`invalid $multi call (const [a = 0] = $multi()): diagnostics 1`] = `"main.ts(2,25): error TSTL: The $multi function must be called in a return statement."`;
 
-exports[`invalid $multi call (const {} = $multi();): code 1`] = `
-"local ____ = {
-    {
-        ____(_G)
-    }
-}"
-`;
+exports[`invalid $multi call (const {} = $multi();): code 1`] = `"local ____ = {{____(_G)}}"`;
 
 exports[`invalid $multi call (const {} = $multi();): diagnostics 1`] = `"main.ts(2,20): error TSTL: The $multi function must be called in a return statement."`;
 
-exports[`invalid $multi call (const a = $multi();): code 1`] = `
-"a = {
-    ____(_G)
-}"
-`;
+exports[`invalid $multi call (const a = $multi();): code 1`] = `"a = {____(_G)}"`;
 
 exports[`invalid $multi call (const a = $multi();): diagnostics 1`] = `"main.ts(2,19): error TSTL: The $multi function must be called in a return statement."`;
 
@@ -180,9 +166,7 @@ local function multi(self, ...)
     return ...
 end
 local a
-local ____ = {
-    ____(nil)
-}
+local ____ = {____(nil)}
 a = ____[1]
 ____exports.a = a
 ____exports.a = a
@@ -198,9 +182,7 @@ local function multi(self, ...)
 end
 local a
 do
-    local ____ = {
-        ____(nil, 1, 2)
-    }
+    local ____ = {____(nil, 1, 2)}
     a = ____[1]
     ____exports.a = a
     while false do
@@ -238,9 +220,7 @@ local function multi(self, ...)
 end
 local a
 if (function()
-    local ____ = {
-        ____(nil, 1)
-    }
+    local ____ = {____(nil, 1)}
     a = ____[1]
     ____exports.a = a
     return ____

--- a/test/unit/language-extensions/__snapshots__/range.spec.ts.snap
+++ b/test/unit/language-extensions/__snapshots__/range.spec.ts.snap
@@ -36,11 +36,7 @@ exports[`$range invalid use ("const y = [...$range(1, 10)];"): code 1`] = `
 "require(\\"lualib_bundle\\");
 local ____exports = {}
 function ____exports.__main(self)
-    local y = {
-        __TS__Spread(
-            ____(nil, 1, 10)
-        )
-    }
+    local y = {__TS__Spread(____(nil, 1, 10))}
 end
 return ____exports"
 `;
@@ -50,9 +46,7 @@ exports[`$range invalid use ("const y = [...$range(1, 10)];"): diagnostics 1`] =
 exports[`$range invalid use ("for (const i in $range(1, 10, 2)) {}"): code 1`] = `
 "local ____exports = {}
 function ____exports.__main(self)
-    for i in pairs(
-        ____(nil, 1, 10, 2)
-    ) do
+    for i in pairs(____(nil, 1, 10, 2)) do
     end
 end
 return ____exports"
@@ -63,9 +57,7 @@ exports[`$range invalid use ("for (const i in $range(1, 10, 2)) {}"): diagnostic
 exports[`$range invalid use ("for (const i of $range(1, 10, 2) as number[]) {}"): code 1`] = `
 "local ____exports = {}
 function ____exports.__main(self)
-    for ____, i in ipairs(
-        ____(nil, 1, 10, 2)
-    ) do
+    for ____, i in ipairs(____(nil, 1, 10, 2)) do
     end
 end
 return ____exports"
@@ -77,9 +69,7 @@ exports[`$range invalid use ("for (const i of ($range(1, 10, 2))) {}"): code 1`]
 "require(\\"lualib_bundle\\");
 local ____exports = {}
 function ____exports.__main(self)
-    for ____, i in __TS__Iterator(
-        ____(nil, 1, 10, 2)
-    ) do
+    for ____, i in __TS__Iterator(____(nil, 1, 10, 2)) do
     end
 end
 return ____exports"

--- a/test/unit/language-extensions/__snapshots__/table.spec.ts.snap
+++ b/test/unit/language-extensions/__snapshots__/table.spec.ts.snap
@@ -47,23 +47,19 @@ return ____exports"
 exports[`LuaTable extension interface LuaTable in strict mode does not accept key type that could be nil ("unknown"): diagnostics 1`] = `"main.ts(1,38): error TS2344: Type 'unknown' does not satisfy the constraint 'AnyNotNil'."`;
 
 exports[`LuaTableDelete extension LuaTableDelete invalid use as expression ("const foo = [tableDelete({}, \\"foo\\")];"): code 1`] = `
-"foo = {
-    (function()
-        ({}).foo = nil
-        return nil
-    end)()
-}"
+"foo = {(function()
+    ({}).foo = nil
+    return nil
+end)()}"
 `;
 
 exports[`LuaTableDelete extension LuaTableDelete invalid use as expression ("const foo = [tableDelete({}, \\"foo\\")];"): diagnostics 1`] = `"main.ts(3,26): error TSTL: Table delete extension can only be called as a stand-alone statement. It cannot be used as an expression in another statement."`;
 
 exports[`LuaTableDelete extension LuaTableDelete invalid use as expression ("const foo = \`\${tableDelete({}, \\"foo\\")}\`;"): code 1`] = `
-"foo = tostring(
-    (function()
-        ({}).foo = nil
-        return nil
-    end)()
-)"
+"foo = tostring((function()
+    ({}).foo = nil
+    return nil
+end)())"
 `;
 
 exports[`LuaTableDelete extension LuaTableDelete invalid use as expression ("const foo = \`\${tableDelete({}, \\"foo\\")}\`;"): diagnostics 1`] = `"main.ts(3,28): error TSTL: Table delete extension can only be called as a stand-alone statement. It cannot be used as an expression in another statement."`;
@@ -90,23 +86,19 @@ exports[`LuaTableDelete extension LuaTableDelete invalid use as expression ("dec
 exports[`LuaTableDelete extension LuaTableDelete invalid use as expression ("declare function foo(arg: any): void; foo(tableDelete({}, \\"foo\\"));"): diagnostics 1`] = `"main.ts(3,55): error TSTL: Table delete extension can only be called as a stand-alone statement. It cannot be used as an expression in another statement."`;
 
 exports[`LuaTableGet & LuaTableSet extensions LuaTableSet invalid use as expression ("const foo = [setTable({}, \\"foo\\", 3)];"): code 1`] = `
-"foo = {
-    (function()
-        ({}).foo = 3
-        return nil
-    end)()
-}"
+"foo = {(function()
+    ({}).foo = 3
+    return nil
+end)()}"
 `;
 
 exports[`LuaTableGet & LuaTableSet extensions LuaTableSet invalid use as expression ("const foo = [setTable({}, \\"foo\\", 3)];"): diagnostics 1`] = `"main.ts(3,26): error TSTL: Table set extension can only be called as a stand-alone statement. It cannot be used as an expression in another statement."`;
 
 exports[`LuaTableGet & LuaTableSet extensions LuaTableSet invalid use as expression ("const foo = \`\${setTable({}, \\"foo\\", 3)}\`;"): code 1`] = `
-"foo = tostring(
-    (function()
-        ({}).foo = 3
-        return nil
-    end)()
-)"
+"foo = tostring((function()
+    ({}).foo = 3
+    return nil
+end)())"
 `;
 
 exports[`LuaTableGet & LuaTableSet extensions LuaTableSet invalid use as expression ("const foo = \`\${setTable({}, \\"foo\\", 3)}\`;"): diagnostics 1`] = `"main.ts(3,28): error TSTL: Table set extension can only be called as a stand-alone statement. It cannot be used as an expression in another statement."`;


### PR DESCRIPTION
This adds some improvements to improve readability of output lua:

 - Parenthesis are omitted if operator precedence allows it
 - Expressions list are always printed on 1 line if there is only 1 expression, always printed on multiple lines if there are > 4 expressions, and following old logic otherwise. This solves the following:
   -  functions that take only another function don't double indent
   -  a(b(c)), [a(b)] is printed on one line
   - Large object literals are printed on multiple lines (instead of one giant line)

Feel free to discuss these changes.