### PR TITLE
Fix __TS__AsyncAwaiter error handling

### DIFF
--- a/src/lualib/Await.ts
+++ b/src/lualib/Await.ts
@@ -30,7 +30,7 @@ function __TS__AsyncAwaiter(this: void, generator: (this: void) => void) {
             if (success) {
                 step(resultOrError, errorOrErrorHandler);
             } else {
-                reject(resultOrError);
+                reject(errorOrErrorHandler);
             }
         }
         function rejected(handler: ErrorHandler | undefined) {


### PR DESCRIPTION
Similar to line 64, this should use `errorOrErrorHandler` in order to capture the thrown error.

Happy to add tests if you can give me some pointers on how to do so. Here is an example where the current code breaks:
```
const success = async () => {};
const error = async () => {
  await success();
  throw new Error('Hello World');
}
error().catch((err) => {
  // prints true prior to change in this PR 
  print(err === undefined); 
});
```