### PR TITLE
Nullish coalescing with preceding statements

### DIFF
--- a/test/unit/nullishCoalescing.spec.ts
+++ b/test/unit/nullishCoalescing.spec.ts
@@ -40,3 +40,17 @@ test("nullish-coalescing operator with side effect rhs", () => {
         return [i, undefined ?? incI(), i];
     `.expectToMatchJsResult();
 });
+
+test("nullish-coalescing operator with vararg", () => {
+    util.testFunction`
+        
+        function foo(...args: any[]){
+            return args
+        }
+        function bar(...args: any[]) {
+            let x: boolean | undefined = false
+            const y = x ?? foo(...args)
+        }
+        return bar(1, 2)
+    `.expectToMatchJsResult();
+});


### PR DESCRIPTION
Uses preceding statements instead of an IIFE (in the case where the right hand side does not have preceding statements). 
Also fixes #1165.

After this, TSTL is officially IIFE free!
