### PR TITLE
Resolve plugin ts-node relative to tstl instead of relative to tsconfig

### DIFF
--- a/src/transpilation/utils.ts
+++ b/src/transpilation/utils.ts
@@ -35,6 +35,8 @@ export interface EmitFile extends BaseFile {
 export const getConfigDirectory = (options: ts.CompilerOptions) =>
     options.configFilePath ? path.dirname(options.configFilePath) : process.cwd();
 
+const getTstlDirectory = () => path.dirname(__dirname);
+
 export function resolvePlugin(
     kind: string,
     optionName: string,
@@ -59,7 +61,7 @@ export function resolvePlugin(
     const hasNoRequireHook = require.extensions[".ts"] === undefined;
     if (hasNoRequireHook && (resolved.endsWith(".ts") || resolved.endsWith(".tsx"))) {
         try {
-            const tsNodePath = resolve.sync("ts-node", { basedir });
+            const tsNodePath = resolve.sync("ts-node", { basedir: getTstlDirectory() });
             const tsNode: typeof import("ts-node") = require(tsNodePath);
             tsNode.register({ transpileOnly: true });
         } catch (err) {


### PR DESCRIPTION
Consider the following directory structure:

```
A/
  node_modules/
    ts-node/
    typescript-to-lua/
  plugin.ts
B/
  tsconfig.json
```

`B/tsconfig.json` contains a reference `../A/plugin.ts`.

Before this change, running `npx tstl -p ../B/tsconfig.json` would correctly resolve node_modules/typescript-to-lua, then correctly resolve `plugin.ts`, but then claim `ts-node` is not installed, even though it is right there in `node_modules/ts-node`.

This change makes tstl try to resolve ts-node relative to tstl's location, rather than relative to the location of whatever is being translated.