### PR TITLE
Binding fixes

### DIFF
--- a/src/transformation/utils/scope.ts
+++ b/src/transformation/utils/scope.ts
@@ -14,6 +14,7 @@ export enum ScopeType {
     Block = 1 << 5,
     Try = 1 << 6,
     Catch = 1 << 7,
+    LoopInitializer = 1 << 8,
 }
 
 interface FunctionDefinitionInfo {

--- a/src/transformation/visitors/function.ts
+++ b/src/transformation/visitors/function.ts
@@ -85,7 +85,11 @@ export function transformFunctionBodyHeader(
             }
 
             // Binding pattern
-            bindingPatternDeclarations.push(...transformBindingPattern(context, declaration.name, identifier));
+            const name = declaration.name;
+            const [precedingStatements, bindings] = transformInPrecedingStatementScope(context, () =>
+                transformBindingPattern(context, name, identifier)
+            );
+            bindingPatternDeclarations.push(...precedingStatements, ...bindings);
         } else if (declaration.initializer !== undefined) {
             // Default parameter
             headerStatements.push(

--- a/test/unit/destructuring.spec.ts
+++ b/test/unit/destructuring.spec.ts
@@ -53,6 +53,17 @@ test("in function parameter creates local variables", () => {
     expect(code).toContain("local b =");
 });
 
+test("in function parameter creates local variables in correct scope", () => {
+    util.testFunction`
+        let x = 7;
+        function foo([x]: [number]) {
+            x *= 2;
+        }
+        foo([1]);
+        return x;
+    `.expectToMatchJsResult();
+});
+
 test.each(testCases)("in variable declaration (%p)", ({ binding, value }) => {
     util.testFunction`
         let ${allBindings};

--- a/test/unit/loops.spec.ts
+++ b/test/unit/loops.spec.ts
@@ -279,6 +279,27 @@ test("forof destructing", () => {
     `.expectToMatchJsResult();
 });
 
+test("forof destructing scope", () => {
+    util.testFunction`
+        let x = 7;
+        for (let [x] of [[1], [2], [3]]) {
+            x *= 2;
+        }
+        return x;
+    `.expectToMatchJsResult();
+});
+
+// This catches the case where x is falsely seen as globally scoped and the 'local' is stripped out
+test("forof destructing scope (global)", () => {
+    util.testModule`
+        let x = 7;
+        for (let [x] of [[1], [2], [3]]) {
+            x *= 2;
+        }
+        if (x !== 7) throw x;
+    `.expectNoExecutionError();
+});
+
 test("forof nested destructing", () => {
     util.testFunction`
         const obj = { a: [3], b: [5] };


### PR DESCRIPTION
This fixes a couple of issues with binding patterns introduced by preceding statements.

Fixes #1177 

Also fixes this case: [Playground](https://typescripttolua.github.io/play/#code/MYewdgzgLgBARgGwIYwLwwNoYIwF0A0GATARgMy64DcAUKJLMEggnEsANYRqbU00AzEACcYACnrRMYXDBAD4yAJQwA3jRiaYTFm04QAdAAcArhAAWYsStQA+GEeEBLMFDFglS2gF9+O1uxcBkLCAKLslsBwaPZR1l5AA)
In this instance, aside from the issue with the binding variable not being generated inside the loop's scope, an additional bug was found that has apparently always existed where the `local` would be stripped off from the loop variable because it was falsely seen as being global in scope (because it was transformed before entering the loops body).