### PR TITLE
Correctly handle resolving promises with other promises

### DIFF
--- a/src/lualib/Promise.ts
+++ b/src/lualib/Promise.ts
@@ -128,6 +128,14 @@ class __TS__Promise<T> implements Promise<T> {
     }
 
     private resolve(data: T): void {
+        if (data instanceof __TS__Promise) {
+            data.then(
+                v => this.resolve(v),
+                err => this.reject(err)
+            );
+            return;
+        }
+
         // Resolve this promise, if it is still pending. This function is passed to the constructor function.
         if (this.state === __TS__PromiseState.Pending) {
             this.state = __TS__PromiseState.Fulfilled;

--- a/test/unit/builtins/promise.spec.ts
+++ b/test/unit/builtins/promise.spec.ts
@@ -794,6 +794,23 @@ test("resolving promise with pending promise will keep pending until promise2 re
         .expectToEqual(["promise 2", "result", "promise 1", "result"]);
 });
 
+test("resolving promise with pending promise will keep pending until promise2 rejects", () => {
+    util.testFunction`
+        const { promise, resolve } = defer<string>();
+        promise.catch(v => log("promise 1", v));
+
+        const { promise: promise2, reject: reject2 } = defer<string>();
+        promise2.catch(v => log("promise 2", v));
+
+        resolve(promise2);
+        reject2("rejection");
+
+        return allLogs;
+    `
+        .setTsHeader(promiseTestLib)
+        .expectToEqual(["promise 2", "rejection", "promise 1", "rejection"]);
+});
+
 describe("Promise.all", () => {
     test("resolves once all arguments are resolved", () => {
         util.testFunction`


### PR DESCRIPTION
Fixes #1185 

Turns out when resolving a promise with another promise, the other promise is unwrapped. There are three cases here:

- Resolving promise1 with resolved promise2: resolves promise1 with promise2's value (not promise 2 itself)
- Resolving promise1 with rejected promise2: rejects promise1 with promise2's rejection reason
- Resolving promise1 with pending promise2: promise1 will remain pending until promise2 is resolved or rejected
    - promise1 will resolve if promise2 resolves, or reject if promise2 rejects

All of this was verified to match JS behavior on [the TypeScript playground](https://www.typescriptlang.org/play?#code/GYVwdgxgLglg9mABAEwKbFQJwDwBUB8AFAJSIDeAUItYgDapSKaoDOctAbqgFyKHIBDKAN4CwAT1IBefIg5wYyRFL7TZZAL4BuKjXqNmAK1TRehZgLZheLKJhhgA5mrkKlKksvXbd1CAltEAAdMOABbGBZUZUQwVAB3RAAFUIiovCJzVgAaJlRDF0oaYry2TmiVZhYdEpojE0ZK-JqaDWIW6mYoEEwkMmDUyNRcqvYuEfyGxB8NCgp-MED+kPChibKuaZi0DBxbeycidooVtNQAOgghCAALQg4vRAWyi9o4R0IAIlOhxABGT65DjEY7zAKMZaDKK8H5RABME2MpjySKgcK2Kh2WGw+wcjiOOlhqDhl2udweMieAXYr3eXyJiDhgLkIJ0FFG5UIRLhx3q0DhXz5sAQn3aQA) 