### PR TITLE
Improve expression statement handling and language extensions calls

### DIFF
--- a/src/transformation/utils/diagnostics.ts
+++ b/src/transformation/utils/diagnostics.ts
@@ -128,14 +128,6 @@ export const invalidTableExtensionUse = createErrorDiagnosticFactory(
     "This function must be called directly and cannot be referred to."
 );
 
-export const invalidTableDeleteExpression = createErrorDiagnosticFactory(
-    "Table delete extension can only be called as a stand-alone statement. It cannot be used as an expression in another statement."
-);
-
-export const invalidTableSetExpression = createErrorDiagnosticFactory(
-    "Table set extension can only be called as a stand-alone statement. It cannot be used as an expression in another statement."
-);
-
 export const annotationRemoved = createErrorDiagnosticFactory(
     (kind: AnnotationKind) =>
         `'@${kind}' has been removed and will no longer have any effect.` +

--- a/src/transformation/visitors/identifier.ts
+++ b/src/transformation/visitors/identifier.ts
@@ -2,7 +2,7 @@ import * as ts from "typescript";
 import * as lua from "../../LuaAST";
 import { transformBuiltinIdentifierExpression } from "../builtins";
 import { createPromiseIdentifier, isPromiseClass } from "../builtins/promise";
-import { FunctionVisitor, TransformationContext } from "../context";
+import { FunctionVisitor, tempSymbolId, TransformationContext } from "../context";
 import { AnnotationKind, isForRangeType } from "../utils/annotations";
 import {
     invalidMultiFunctionUse,
@@ -25,7 +25,7 @@ import { isOptionalContinuation } from "./optional-chaining";
 
 export function transformIdentifier(context: TransformationContext, identifier: ts.Identifier): lua.Identifier {
     if (isOptionalContinuation(identifier)) {
-        return lua.createIdentifier(identifier.text);
+        return lua.createIdentifier(identifier.text, undefined, tempSymbolId);
     }
 
     if (isMultiFunctionNode(context, identifier)) {

--- a/src/transformation/visitors/language-extensions/index.ts
+++ b/src/transformation/visitors/language-extensions/index.ts
@@ -1,0 +1,20 @@
+import { TransformationContext } from "../../context";
+import * as ts from "typescript";
+import * as lua from "../../../LuaAST";
+import { transformOperatorMappingExpression } from "./operators";
+import { transformTableExtensionCall } from "./table";
+
+export function transformLanguageExtensionCallExpression(
+    context: TransformationContext,
+    node: ts.CallExpression,
+    isOptionalCall: boolean
+): lua.Expression | undefined {
+    const operatorMapping = transformOperatorMappingExpression(context, node, isOptionalCall);
+    if (operatorMapping) {
+        return operatorMapping;
+    }
+    const tableCall = transformTableExtensionCall(context, node, isOptionalCall);
+    if (tableCall) {
+        return tableCall;
+    }
+}

--- a/src/transformation/visitors/void.ts
+++ b/src/transformation/visitors/void.ts
@@ -1,28 +1,15 @@
 import * as ts from "typescript";
 import * as lua from "../../LuaAST";
-import { TransformationContext } from "../context";
-import { FunctionVisitor } from "../context/visitors";
+import { FunctionVisitor } from "../context";
+import { transformExpressionToStatement } from "./expression-statement";
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/void
 export const transformVoidExpression: FunctionVisitor<ts.VoidExpression> = (node, context) => {
     // If content is a literal it is safe to replace the entire expression with nil
     if (!ts.isLiteralExpression(node.expression)) {
-        // local ____ = <expression>
-        context.addPrecedingStatements(
-            lua.createVariableDeclarationStatement(
-                lua.createAnonymousIdentifier(),
-                context.transformExpression(node.expression)
-            )
-        );
+        const statements = transformExpressionToStatement(context, node.expression);
+        if (statements) context.addPrecedingStatements(statements);
     }
 
-    return lua.createNilLiteral(node);
+    return lua.createNilLiteral();
 };
-
-export const transformVoidExpressionStatement = (node: ts.VoidExpression, context: TransformationContext) =>
-    // In case of a void expression statement we can omit the IIFE
-    lua.createVariableDeclarationStatement(
-        lua.createAnonymousIdentifier(),
-        context.transformExpression(node.expression),
-        node
-    );

--- a/test/unit/__snapshots__/optionalChaining.spec.ts.snap
+++ b/test/unit/__snapshots__/optionalChaining.spec.ts.snap
@@ -4,9 +4,8 @@ exports[`Unsupported optional chains Builtin global method: code 1`] = `
 "require(\\"lualib_bundle\\");
 local ____Number_result_0 = Number
 if ____Number_result_0 ~= nil then
-    ____Number_result_0 = __TS__Number(\\"3\\")
-end
-local ____ = ____Number_result_0"
+    ____Number_result_0 = nil
+end"
 `;
 
 exports[`Unsupported optional chains Builtin global method: diagnostics 1`] = `"main.ts(2,17): error TSTL: Optional calls are not supported for builtin or language extension functions."`;
@@ -15,8 +14,7 @@ exports[`Unsupported optional chains Builtin global property: code 1`] = `
 "local ____console_log_result_0 = console
 if ____console_log_result_0 ~= nil then
     ____console_log_result_0 = nil
-end
-local ____ = ____console_log_result_0"
+end"
 `;
 
 exports[`Unsupported optional chains Builtin global property: diagnostics 1`] = `"main.ts(2,17): error TSTL: Optional calls are not supported for builtin or language extension functions."`;
@@ -25,8 +23,7 @@ exports[`Unsupported optional chains Builtin prototype method: code 1`] = `
 "local ____table_forEach_result_0 = ({1, 2, 3, 4}).forEach
 if ____table_forEach_result_0 ~= nil then
     ____table_forEach_result_0 = nil
-end
-local ____ = ____table_forEach_result_0"
+end"
 `;
 
 exports[`Unsupported optional chains Builtin prototype method: diagnostics 1`] = `"main.ts(2,17): error TSTL: Optional calls are not supported for builtin or language extension functions."`;
@@ -42,7 +39,6 @@ function ____exports.__main(self)
     if ____TestEnum_B_0 ~= nil then
         ____TestEnum_B_0 = B
     end
-    local ____ = ____TestEnum_B_0
 end
 return ____exports"
 `;
@@ -53,8 +49,7 @@ exports[`Unsupported optional chains Language extensions: code 1`] = `
 "local ____table_has_result_0 = ({}).has
 if ____table_has_result_0 ~= nil then
     ____table_has_result_0 = nil
-end
-local ____ = ____table_has_result_0"
+end"
 `;
 
 exports[`Unsupported optional chains Language extensions: diagnostics 1`] = `"main.ts(2,17): error TSTL: Optional calls are not supported for builtin or language extension functions."`;

--- a/test/unit/language-extensions/__snapshots__/table.spec.ts.snap
+++ b/test/unit/language-extensions/__snapshots__/table.spec.ts.snap
@@ -46,66 +46,6 @@ return ____exports"
 
 exports[`LuaTable extension interface LuaTable in strict mode does not accept key type that could be nil ("unknown"): diagnostics 1`] = `"main.ts(1,38): error TS2344: Type 'unknown' does not satisfy the constraint 'AnyNotNil'."`;
 
-exports[`LuaTableDelete extension LuaTableDelete invalid use as expression ("const foo = [tableDelete({}, \\"foo\\")];"): code 1`] = `
-"({}).foo = nil
-foo = {nil}"
-`;
-
-exports[`LuaTableDelete extension LuaTableDelete invalid use as expression ("const foo = [tableDelete({}, \\"foo\\")];"): diagnostics 1`] = `"main.ts(3,26): error TSTL: Table delete extension can only be called as a stand-alone statement. It cannot be used as an expression in another statement."`;
-
-exports[`LuaTableDelete extension LuaTableDelete invalid use as expression ("const foo = \`\${tableDelete({}, \\"foo\\")}\`;"): code 1`] = `
-"({}).foo = nil
-foo = tostring(nil)"
-`;
-
-exports[`LuaTableDelete extension LuaTableDelete invalid use as expression ("const foo = \`\${tableDelete({}, \\"foo\\")}\`;"): diagnostics 1`] = `"main.ts(3,28): error TSTL: Table delete extension can only be called as a stand-alone statement. It cannot be used as an expression in another statement."`;
-
-exports[`LuaTableDelete extension LuaTableDelete invalid use as expression ("const foo = tableDelete({}, \\"foo\\");"): code 1`] = `
-"({}).foo = nil
-foo = nil"
-`;
-
-exports[`LuaTableDelete extension LuaTableDelete invalid use as expression ("const foo = tableDelete({}, \\"foo\\");"): diagnostics 1`] = `"main.ts(3,25): error TSTL: Table delete extension can only be called as a stand-alone statement. It cannot be used as an expression in another statement."`;
-
-exports[`LuaTableDelete extension LuaTableDelete invalid use as expression ("declare function foo(arg: any): void; foo(tableDelete({}, \\"foo\\"));"): code 1`] = `
-"local ____foo_1 = foo
-local ____G_0 = _G;
-({}).foo = nil
-____foo_1(____G_0, nil)"
-`;
-
-exports[`LuaTableDelete extension LuaTableDelete invalid use as expression ("declare function foo(arg: any): void; foo(tableDelete({}, \\"foo\\"));"): diagnostics 1`] = `"main.ts(3,55): error TSTL: Table delete extension can only be called as a stand-alone statement. It cannot be used as an expression in another statement."`;
-
-exports[`LuaTableGet & LuaTableSet extensions LuaTableSet invalid use as expression ("const foo = [setTable({}, \\"foo\\", 3)];"): code 1`] = `
-"({}).foo = 3
-foo = {nil}"
-`;
-
-exports[`LuaTableGet & LuaTableSet extensions LuaTableSet invalid use as expression ("const foo = [setTable({}, \\"foo\\", 3)];"): diagnostics 1`] = `"main.ts(3,26): error TSTL: Table set extension can only be called as a stand-alone statement. It cannot be used as an expression in another statement."`;
-
-exports[`LuaTableGet & LuaTableSet extensions LuaTableSet invalid use as expression ("const foo = \`\${setTable({}, \\"foo\\", 3)}\`;"): code 1`] = `
-"({}).foo = 3
-foo = tostring(nil)"
-`;
-
-exports[`LuaTableGet & LuaTableSet extensions LuaTableSet invalid use as expression ("const foo = \`\${setTable({}, \\"foo\\", 3)}\`;"): diagnostics 1`] = `"main.ts(3,28): error TSTL: Table set extension can only be called as a stand-alone statement. It cannot be used as an expression in another statement."`;
-
-exports[`LuaTableGet & LuaTableSet extensions LuaTableSet invalid use as expression ("const foo = setTable({}, \\"foo\\", 3);"): code 1`] = `
-"({}).foo = 3
-foo = nil"
-`;
-
-exports[`LuaTableGet & LuaTableSet extensions LuaTableSet invalid use as expression ("const foo = setTable({}, \\"foo\\", 3);"): diagnostics 1`] = `"main.ts(3,25): error TSTL: Table set extension can only be called as a stand-alone statement. It cannot be used as an expression in another statement."`;
-
-exports[`LuaTableGet & LuaTableSet extensions LuaTableSet invalid use as expression ("declare function foo(arg: any): void; foo(setTable({}, \\"foo\\", 3));"): code 1`] = `
-"local ____foo_1 = foo
-local ____G_0 = _G;
-({}).foo = 3
-____foo_1(____G_0, nil)"
-`;
-
-exports[`LuaTableGet & LuaTableSet extensions LuaTableSet invalid use as expression ("declare function foo(arg: any): void; foo(setTable({}, \\"foo\\", 3));"): diagnostics 1`] = `"main.ts(3,55): error TSTL: Table set extension can only be called as a stand-alone statement. It cannot be used as an expression in another statement."`;
-
 exports[`LuaTableGet & LuaTableSet extensions invalid use ("const foo = (getTable as any)(1, 2);"): code 1`] = `"foo = getTable(_G, 1, 2)"`;
 
 exports[`LuaTableGet & LuaTableSet extensions invalid use ("const foo = (getTable as any)(1, 2);"): diagnostics 1`] = `"main.ts(3,26): error TSTL: This function must be called directly and cannot be referred to."`;

--- a/test/unit/language-extensions/table.spec.ts
+++ b/test/unit/language-extensions/table.spec.ts
@@ -212,7 +212,7 @@ describe("LuaTableDelete extension", () => {
             .expectToEqual({ table: { bar: 12 } });
     });
 
-    test("LUaTableDelete use as expression", () => {
+    test("LuaTableDelete use as expression", () => {
         util.testModule`
             declare const tableDelete: LuaTableDelete<{}, string>;
             export const result = tableDelete({}, "foo")


### PR DESCRIPTION
These changes go together:

With preceding statements, table function language extensions (`TableGet`, `TableSet`, etc.) can now be used as expressions.
`TableDelete` functions are typed to return `boolean`, but previously the return value could never be used; these now return `true` to be similar to delete expressions. Other methods return `nil`.
Additionally, I fixed table function extensions that use preceding statements or spread arguments. This required some refactoring; The result is based on `transformBuiltinCallExpression`. This additionally avoids unnecessary calls to `getTableExtensionKindForCall` and fixes some other minor bugs that I found.

transformExpressionStatement now omits the statement entirely if the inner expression result is "synthetic" with no side effects (a temp variable, or a literal without a source map position). This removes unnecessary `local ____ = ...` in several cases (e.g. `a?.b()`). This also decouples transformExpressionStatement from other language features: now table call language extensions can be transformed as an expression, and its return value (`nil` or `true`) is omitted when in an expression statement (not used).
- `void` expressions now also share some of this logic to omit unecessary `local ____ = ...`.

