### PR TITLE
Fix function with properties assigned to variable declaration

### DIFF
--- a/src/transformation/visitors/function.ts
+++ b/src/transformation/visitors/function.ts
@@ -277,8 +277,9 @@ export function transformFunctionLikeDeclaration(
 
     const [functionExpression, functionScope] = transformFunctionToExpression(context, node);
 
+    const isNamedFunctionExpression = ts.isFunctionExpression(node) && node.name;
     // Handle named function expressions which reference themselves
-    if (ts.isFunctionExpression(node) && node.name && functionScope.referencedSymbols) {
+    if (isNamedFunctionExpression && functionScope.referencedSymbols) {
         const symbol = context.checker.getSymbolAtLocation(node.name);
         if (symbol) {
             // TODO: Not using symbol ids because of https://github.com/microsoft/TypeScript/issues/37131
@@ -304,7 +305,9 @@ export function transformFunctionLikeDeclaration(
         }
     }
 
-    return functionExpression;
+    return isNamedFunctionExpression && isFunctionTypeWithProperties(context.checker.getTypeAtLocation(node))
+        ? createCallableTable(functionExpression)
+        : functionExpression;
 }
 
 export const transformFunctionDeclaration: FunctionVisitor<ts.FunctionDeclaration> = (node, context) => {

--- a/test/unit/functions/functionProperties.spec.ts
+++ b/test/unit/functions/functionProperties.spec.ts
@@ -60,6 +60,14 @@ test("void function with property assigned to variable", () => {
     `.expectToMatchJsResult();
 });
 
+test("named function with property assigned to variable", () => {
+    util.testFunction`
+        const foo = function baz(s: string) { return s; }
+        foo.bar = "bar";
+        return foo("foo") + foo.bar;
+    `.expectToMatchJsResult();
+});
+
 test("recursively referenced function with property assigned to variable", () => {
     util.testFunction`
         const foo = function(s: string) { return s + foo.bar; };
@@ -171,5 +179,24 @@ test("call function with property using bind method", () => {
         function foo(s: string) { return this + s; }
         foo.baz = "baz";
         return foo.bind("foo", "bar")() + foo.baz;
+    `.expectToMatchJsResult();
+});
+
+// https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1196
+test("Does not wrap simple variable declaration", () => {
+    util.testFunction`
+        function foo(s: string) { return s; }
+        foo.bar = "bar";
+        const foo2 = foo;
+        return foo2("foo") + foo2.bar;
+    `.expectToMatchJsResult();
+});
+
+test("Wraps function in inner expression", () => {
+    util.testFunction`
+        type Foo = { (s: string): string; bar: string; }
+        const foo = (s => s)! as Foo
+        foo.bar = "bar";
+        return foo("foo") + foo.bar;
     `.expectToMatchJsResult();
 });


### PR DESCRIPTION
Fixes #1196: Only function expressions/arrow functions are wrapped in variable declarations.
Still leaves #1197 open.

Also fixed a bug I found, where a named, _not_ self-recursive function is assigned to a variable wasn't wrapped. 

