### PR TITLE
Use power operator instead of math.pow

### DIFF
--- a/src/transformation/builtins/math.ts
+++ b/src/transformation/builtins/math.ts
@@ -70,6 +70,21 @@ export function transformMathCall(
             return lua.createCallExpression(lua.createTableIndexExpression(math, log), [add], node);
         }
 
+        case "pow": {
+            if (
+                context.luaTarget === LuaTarget.Universal ||
+                context.luaTarget === LuaTarget.Lua51 ||
+                context.luaTarget === LuaTarget.Lua52
+            ) {
+                // Translate to to math.pow(base, power)
+                const method = lua.createStringLiteral(expressionName);
+                return lua.createCallExpression(lua.createTableIndexExpression(math, method), params, node);
+            }
+
+            // In newer versions translate to base ^ power instead
+            return lua.createBinaryExpression(params[0], params[1], lua.SyntaxKind.PowerOperator, node);
+        }
+
         // math.floor(x + 0.5)
         case "round": {
             const floor = lua.createStringLiteral("floor");
@@ -93,7 +108,6 @@ export function transformMathCall(
         case "log":
         case "max":
         case "min":
-        case "pow":
         case "random":
         case "sin":
         case "sqrt":

--- a/src/transformation/builtins/math.ts
+++ b/src/transformation/builtins/math.ts
@@ -71,17 +71,7 @@ export function transformMathCall(
         }
 
         case "pow": {
-            if (
-                context.luaTarget === LuaTarget.Universal ||
-                context.luaTarget === LuaTarget.Lua51 ||
-                context.luaTarget === LuaTarget.Lua52
-            ) {
-                // Translate to to math.pow(base, power)
-                const method = lua.createStringLiteral(expressionName);
-                return lua.createCallExpression(lua.createTableIndexExpression(math, method), params, node);
-            }
-
-            // In newer versions translate to base ^ power instead
+            // Translate to base ^ power
             return lua.createBinaryExpression(params[0], params[1], lua.SyntaxKind.PowerOperator, node);
         }
 

--- a/test/unit/builtins/math.spec.ts
+++ b/test/unit/builtins/math.spec.ts
@@ -84,11 +84,14 @@ util.testEachVersion("Math.atan2", () => util.testExpression`Math.atan2(4, 5)`, 
     [tstl.LuaTarget.Lua54]: builder => builder.tap(expectMathAtan2),
 });
 
-util.testEachVersion("Math.atan2(4, 5)", () => util.testExpression`Math.atan2(4, 5)`, {
-    [tstl.LuaTarget.Universal]: builder => builder.expectToMatchJsResult(),
-    [tstl.LuaTarget.LuaJIT]: false,
-    [tstl.LuaTarget.Lua51]: builder => builder.expectToMatchJsResult(),
-    [tstl.LuaTarget.Lua52]: builder => builder.expectToMatchJsResult(),
-    [tstl.LuaTarget.Lua53]: builder => builder.expectToMatchJsResult(),
-    [tstl.LuaTarget.Lua54]: builder => builder.expectToMatchJsResult(),
-});
+util.testEachVersion(
+    "Math.atan2(4, 5)",
+    () => util.testExpression`Math.atan2(4, 5)`,
+    util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+);
+
+util.testEachVersion(
+    "Math.pow(3, 5)",
+    () => util.testExpression`Math.pow(3, 5)`,
+    util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+);


### PR DESCRIPTION
Officially, 5.3 has deprecated `math.pow`, to be replaced by the `^` operator, see: https://www.lua.org/manual/5.3/manual.html#8.2