### PR TITLE
Correctly place class member preceding instances in the constructor always

### DIFF
--- a/src/transformation/visitors/class/members/constructor.ts
+++ b/src/transformation/visitors/class/members/constructor.ts
@@ -2,7 +2,6 @@ import * as ts from "typescript";
 import * as lua from "../../../../LuaAST";
 import { TransformationContext } from "../../../context";
 import { createSelfIdentifier } from "../../../utils/lua-ast";
-import { transformInPrecedingStatementScope } from "../../../utils/preceding-statements";
 import { popScope, pushScope, ScopeType } from "../../../utils/scope";
 import { transformFunctionBodyContent, transformFunctionBodyHeader, transformParameters } from "../../function";
 import { transformIdentifier } from "../../identifier";
@@ -44,9 +43,7 @@ export function transformConstructorDeclaration(
     // Check for field declarations in constructor
     const constructorFieldsDeclarations = statement.parameters.filter(p => p.modifiers !== undefined);
 
-    const [fieldsPrecedingStatements, classInstanceFields] = transformInPrecedingStatementScope(context, () =>
-        transformClassInstanceFields(context, instanceFields)
-    );
+    const classInstanceFields = transformClassInstanceFields(context, instanceFields);
 
     // If there are field initializers and the first statement is a super call,
     // move super call between default assignments and initializers
@@ -81,7 +78,6 @@ export function transformConstructorDeclaration(
         // else { TypeScript error: A parameter property may not be declared using a binding pattern }
     }
 
-    bodyWithFieldInitializers.push(...fieldsPrecedingStatements);
     bodyWithFieldInitializers.push(...classInstanceFields);
 
     bodyWithFieldInitializers.push(...body);

--- a/test/unit/precedingStatements.spec.ts
+++ b/test/unit/precedingStatements.spec.ts
@@ -635,3 +635,14 @@ test("class member initializers", () => {
         return [inst.myField, inst.foo];
     `.expectToMatchJsResult();
 });
+
+test("class member initializers in extended class", () => {
+    util.testFunction`
+        class A {}
+        class MyClass extends A {
+            myField = false ?? true;
+        }
+        const inst = new MyClass();
+        return inst.myField;
+    `.expectToMatchJsResult();
+});


### PR DESCRIPTION
In case of extended classes without defined constructor, the constructor transformation path is avoided. Unwrapping the preceding statements in transformClassInstanceFields correctly places the preceding statements in all situations.