### PR TITLE
Fix module resolution exploding

### DIFF
--- a/src/transpilation/resolve.ts
+++ b/src/transpilation/resolve.ts
@@ -161,7 +161,7 @@ function resolveFileDependencies(file: ProcessedFile, context: ResolutionContext
         dependencies.push(...resolvedDependency.resolvedFiles);
         diagnostics.push(...resolvedDependency.diagnostics);
     }
-    return { resolvedFiles: dependencies, diagnostics };
+    return { resolvedFiles: deduplicateResolvedFiles(dependencies), diagnostics };
 }
 
 function resolveDependency(
@@ -174,7 +174,7 @@ function resolveDependency(
 
     const fileDirectory = path.dirname(requiringFile.fileName);
     if (options.tstlVerbose) {
-        console.log(`Resolving "${dependency}" from ${normalizeSlashes(fileDirectory)}`);
+        console.log(`Resolving "${dependency}" from ${normalizeSlashes(requiringFile.fileName)}`);
     }
 
     // Check if the import is relative

--- a/test/transpile/__snapshots__/project.spec.ts.snap
+++ b/test/transpile/__snapshots__/project.spec.ts.snap
@@ -11,7 +11,7 @@ Array [
   "Constructing emit plan",
   "Resolving dependencies for <cwd>/test/transpile/project/otherFile.ts",
   "Resolving dependencies for <cwd>/test/transpile/project/index.ts",
-  "Resolving \\"./otherFile\\" from <cwd>/test/transpile/project",
+  "Resolving \\"./otherFile\\" from <cwd>/test/transpile/project/index.ts",
   "Resolved ./otherFile to <cwd>/test/transpile/project/otherFile.ts",
   "Emitting output",
   "Emitting <cwd>/test/transpile/project/otherFile.lua",


### PR DESCRIPTION
Apparently I forgot to de-duplicate resolved files in one crucial point, causing file dependency lists to grow to 100k+ dependencies.

Thanks to @Zamiell for reporting.

Fixes #1219 