### PR TITLE
Error when using null or undefined in array literal

### DIFF
--- a/src/transformation/utils/diagnostics.ts
+++ b/src/transformation/utils/diagnostics.ts
@@ -155,3 +155,7 @@ export const unsupportedBuiltinOptionalCall = createErrorDiagnosticFactory(
 export const unsupportedOptionalCompileMembersOnly = createErrorDiagnosticFactory(
     "Optional calls are not supported on enums marked with @compileMembersOnly."
 );
+
+export const undefinedInArrayLiteral = createErrorDiagnosticFactory(
+    "Array literals may not contain undefined or null."
+);

--- a/src/transformation/visitors/literal.ts
+++ b/src/transformation/visitors/literal.ts
@@ -229,7 +229,11 @@ function checkForUndefinedOrNullInArrayLiteral(array: ts.ArrayLiteralExpression,
 }
 
 function isUndefinedOrNull(node: ts.Node) {
-    return node.kind === ts.SyntaxKind.UndefinedKeyword || node.kind === ts.SyntaxKind.NullKeyword || (ts.isIdentifier(node) && node.text === "undefined");
+    return (
+        node.kind === ts.SyntaxKind.UndefinedKeyword ||
+        node.kind === ts.SyntaxKind.NullKeyword ||
+        (ts.isIdentifier(node) && node.text === "undefined")
+    );
 }
 
 export const literalVisitors: Visitors = {

--- a/src/transformation/visitors/literal.ts
+++ b/src/transformation/visitors/literal.ts
@@ -2,7 +2,11 @@ import * as ts from "typescript";
 import * as lua from "../../LuaAST";
 import { assertNever } from "../../utils";
 import { FunctionVisitor, TransformationContext, Visitors } from "../context";
-import { invalidMultiFunctionUse, unsupportedAccessorInObjectLiteral } from "../utils/diagnostics";
+import {
+    invalidMultiFunctionUse,
+    undefinedInArrayLiteral,
+    unsupportedAccessorInObjectLiteral,
+} from "../utils/diagnostics";
 import { createExportedIdentifier, getSymbolExportScope } from "../utils/export";
 import { LuaLibFeature, transformLuaLibFunction } from "../utils/lualib";
 import { createSafeName, hasUnsafeIdentifierName, hasUnsafeSymbolName } from "../utils/safe-names";
@@ -196,6 +200,9 @@ const transformObjectLiteralExpression: FunctionVisitor<ts.ObjectLiteralExpressi
 };
 
 const transformArrayLiteralExpression: FunctionVisitor<ts.ArrayLiteralExpression> = (expression, context) => {
+    // Disallow using undefined/null in array literals
+    checkForUndefinedOrNullInArrayLiteral(expression, context);
+
     const filteredElements = expression.elements.map(e =>
         ts.isOmittedExpression(e) ? ts.factory.createIdentifier("undefined") : e
     );
@@ -203,6 +210,27 @@ const transformArrayLiteralExpression: FunctionVisitor<ts.ArrayLiteralExpression
 
     return lua.createTableExpression(values, expression);
 };
+
+function checkForUndefinedOrNullInArrayLiteral(array: ts.ArrayLiteralExpression, context: TransformationContext) {
+    // Look for last non-nil element in literal
+    let lastNonUndefinedIndex = array.elements.length - 1;
+    for (; lastNonUndefinedIndex >= 0; lastNonUndefinedIndex--) {
+        if (!isUndefinedOrNull(array.elements[lastNonUndefinedIndex])) {
+            break;
+        }
+    }
+
+    // Add diagnostics for non-trailing nil elements in array literal
+    for (let i = 0; i < array.elements.length; i++) {
+        if (i < lastNonUndefinedIndex && isUndefinedOrNull(array.elements[i])) {
+            context.diagnostics.push(undefinedInArrayLiteral(array.elements[i]));
+        }
+    }
+}
+
+function isUndefinedOrNull(node: ts.Node) {
+    return node.kind === ts.SyntaxKind.UndefinedKeyword || node.kind === ts.SyntaxKind.NullKeyword || (ts.isIdentifier(node) && node.text === "undefined");
+}
 
 export const literalVisitors: Visitors = {
     [ts.SyntaxKind.NullKeyword]: node => lua.createNilLiteral(node),


### PR DESCRIPTION
Array literals containing `null` or `undefined` will lead to possibly broken Lua.

For instance:
```ts
const mytuple = [1, undefined, 3];
```

Will translate into:
```lua
local mytuple = {1, nil, 3}; -- Stops after first nil, this ends up being {1}
```

Added a warning to prevent users from doing this. Using null or undefined at the end of an array literal is still allowed.

Closes #1216 