### PR TITLE
Add warning diagnostic when using condition variable that will never be false

### DIFF
--- a/src/transformation/utils/diagnostics.ts
+++ b/src/transformation/utils/diagnostics.ts
@@ -140,6 +140,10 @@ export const annotationDeprecated = createWarningDiagnosticFactory(
         `See https://typescripttolua.github.io/docs/advanced/compiler-annotations#${kind.toLowerCase()} for more information.`
 );
 
+export const truthyOnlyConditionalValue = createWarningDiagnosticFactory(
+    "Numbers and strings will always evaluate to true in Lua. Explicitly check the value with ===."
+);
+
 export const notAllowedOptionalAssignment = createErrorDiagnosticFactory(
     "The left-hand side of an assignment expression may not be an optional property access."
 );

--- a/src/transformation/visitors/loops/do-while.ts
+++ b/src/transformation/visitors/loops/do-while.ts
@@ -2,9 +2,13 @@ import * as ts from "typescript";
 import * as lua from "../../../LuaAST";
 import { FunctionVisitor } from "../../context";
 import { transformInPrecedingStatementScope } from "../../utils/preceding-statements";
+import { checkOnlyTruthyCondition } from "../conditional";
 import { invertCondition, transformLoopBody } from "./utils";
 
 export const transformWhileStatement: FunctionVisitor<ts.WhileStatement> = (statement, context) => {
+    // Check if we need to add diagnostic about Lua truthiness
+    checkOnlyTruthyCondition(statement.expression, context);
+
     const body = transformLoopBody(context, statement);
 
     let [conditionPrecedingStatements, condition] = transformInPrecedingStatementScope(context, () =>
@@ -37,6 +41,9 @@ export const transformWhileStatement: FunctionVisitor<ts.WhileStatement> = (stat
 };
 
 export const transformDoStatement: FunctionVisitor<ts.DoStatement> = (statement, context) => {
+    // Check if we need to add diagnostic about Lua truthiness
+    checkOnlyTruthyCondition(statement.expression, context);
+
     const body = lua.createDoStatement(transformLoopBody(context, statement));
 
     let [conditionPrecedingStatements, condition] = transformInPrecedingStatementScope(context, () =>

--- a/test/unit/conditionals.spec.ts
+++ b/test/unit/conditionals.spec.ts
@@ -1,4 +1,5 @@
 import * as tstl from "../../src";
+import { truthyOnlyConditionalValue } from "../../src/transformation/utils/diagnostics";
 import * as util from "../util";
 
 test.each([0, 1])("if (%p)", inp => {
@@ -112,3 +113,45 @@ test.each([false, true, null])("Ternary conditional with generic whenTrue branch
         })
         .expectToMatchJsResult();
 });
+
+test.each(["string", "number", "string | number"])(
+    "Warning when using if statement that cannot evaluate to false undefined or null (%p)",
+    type => {
+        util.testFunction`
+            if (condition) {}
+        `
+            .setTsHeader(`declare var condition: ${type};`)
+            .expectToHaveDiagnostics([truthyOnlyConditionalValue.code]);
+    }
+);
+
+test.each(["string", "number", "string | number"])(
+    "Warning when using while statement that cannot evaluate to false undefined or null (%p)",
+    type => {
+        util.testFunction`
+            while (condition) {}
+        `
+            .setTsHeader(`declare var condition: ${type};`)
+            .expectToHaveDiagnostics([truthyOnlyConditionalValue.code]);
+    }
+);
+
+test.each(["string", "number", "string | number"])(
+    "Warning when using do while statement that cannot evaluate to false undefined or null (%p)",
+    type => {
+        util.testFunction`
+            do {} while (condition)
+        `
+            .setTsHeader(`declare var condition: ${type};`)
+            .expectToHaveDiagnostics([truthyOnlyConditionalValue.code]);
+    }
+);
+
+test.each(["string", "number", "string | number"])(
+    "Warning when using ternary that cannot evaluate to false undefined or null (%p)",
+    type => {
+        util.testExpression`condition ? 1 : 0`
+            .setTsHeader(`declare var condition: ${type};`)
+            .expectToHaveDiagnostics([truthyOnlyConditionalValue.code]);
+    }
+);


### PR DESCRIPTION
Adds a warning diagnostic when using a type in a conditional which cannot be falsy in Lua (exception being `true`, that is still allowed).

Closes #1212 