### PR TITLE
Function apply without arguments should not lead to exception

### DIFF
--- a/src/transformation/builtins/function.ts
+++ b/src/transformation/builtins/function.ts
@@ -23,11 +23,8 @@ export function transformFunctionPrototypeCall(
     const expressionName = expression.name.text;
     switch (expressionName) {
         case "apply":
-            return lua.createCallExpression(
-                caller,
-                [params[0], createUnpackCall(context, params[1], node.arguments[1])],
-                node
-            );
+            const nonContextArgs = params.length > 1 ? [createUnpackCall(context, params[1], node.arguments[1])] : [];
+            return lua.createCallExpression(caller, [params[0], ...nonContextArgs], node);
         case "bind":
             return transformLuaLibFunction(context, LuaLibFeature.FunctionBind, node, caller, ...params);
         case "call":

--- a/test/unit/functions/functions.spec.ts
+++ b/test/unit/functions/functions.spec.ts
@@ -173,6 +173,14 @@ test("Function apply", () => {
     `.expectToMatchJsResult();
 });
 
+// Fix #1226: https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1226
+test("function apply without arguments should not lead to exception", () => {
+    util.testFunction`
+        const f = function (this: number) { return this + 3; }
+        return f.apply(4);
+    `.expectToMatchJsResult();
+});
+
 test("Function call", () => {
     util.testFunction`
         const abc = function (this: { a: number }, a: string) { return this.a + a; }


### PR DESCRIPTION
Seems we never bothered to check `.apply()` without second argument (argument array)

Fixes #1226 