### PR TITLE
Allow configuring output file extension in config

### DIFF
--- a/src/CompilerOptions.ts
+++ b/src/CompilerOptions.ts
@@ -23,6 +23,7 @@ export interface LuaPluginImport {
 
 export type CompilerOptions = OmitIndexSignature<ts.CompilerOptions> & {
     buildMode?: BuildMode;
+    extension?: string;
     luaBundle?: string;
     luaBundleEntry?: string;
     luaTarget?: LuaTarget;

--- a/src/cli/parse.ts
+++ b/src/cli/parse.ts
@@ -31,6 +31,11 @@ export const optionDeclarations: CommandLineOption[] = [
         choices: Object.values(BuildMode),
     },
     {
+        name: "extension",
+        description: 'File extension for the resulting Lua files. Defaults to ".lua"',
+        type: "string",
+    },
+    {
         name: "luaBundle",
         description: "The name of the lua file to bundle output lua to. Requires luaBundleEntry.",
         type: "string",

--- a/src/transpilation/transpiler.ts
+++ b/src/transpilation/transpiler.ts
@@ -127,8 +127,11 @@ export function getEmitPathRelativeToOutDir(fileName: string, program: ts.Progra
         emitPathSplits[0] = "lua_modules";
     }
 
-    // Make extension lua
-    emitPathSplits[emitPathSplits.length - 1] = trimExtension(emitPathSplits[emitPathSplits.length - 1]) + ".lua";
+    // Set extension
+    const extension = ((program.getCompilerOptions() as CompilerOptions).extension ?? "lua").trim();
+    const trimmedExtension = extension.startsWith(".") ? extension.substring(1) : extension;
+    emitPathSplits[emitPathSplits.length - 1] =
+        trimExtension(emitPathSplits[emitPathSplits.length - 1]) + "." + trimmedExtension;
 
     return path.join(...emitPathSplits);
 }

--- a/test/cli/parse.spec.ts
+++ b/test/cli/parse.spec.ts
@@ -123,6 +123,9 @@ describe("command line", () => {
 
             ["luaBundle", "foo", { luaBundle: "foo" }],
             ["luaBundleEntry", "bar", { luaBundleEntry: "bar" }],
+
+            ["extension", ".lua", { extension: ".lua" }],
+            ["extension", "scar", { extension: "scar" }],
         ])("--%s %s", (optionName, value, expected) => {
             const result = tstl.parseCommandLine([`--${optionName}`, value]);
 

--- a/test/transpile/paths.spec.ts
+++ b/test/transpile/paths.spec.ts
@@ -113,6 +113,38 @@ describe("getEmitPath", () => {
         expect(fileNames).toHaveLength(1);
         expect(fileNames).toContain(path.join(cwd, "out1", "out2", "bundle.lua"));
     });
+
+    test.each([".scar", "scar"])("uses config extension (%p)", extension => {
+        const { transpiledFiles } = util.testModule``
+            .setMainFileName("main.ts")
+            .addExtraFile("dir/extra.ts", "")
+            .setOptions({ extension })
+            .expectToHaveNoDiagnostics()
+            .getLuaResult();
+
+        const fileNames = transpiledFiles.map(f => f.outPath);
+        expect(fileNames).toContain("main.scar");
+        expect(fileNames).toContain(path.join("dir", "extra.scar"));
+    });
+
+    test("bundle with different extension", () => {
+        const { transpiledFiles } = util.testModule``
+            .setMainFileName("src/main.ts")
+            .addExtraFile("src/extra.ts", "")
+            .setOptions({
+                configFilePath,
+                rootDir: "src",
+                outDir: "out1",
+                luaBundle: "out2/bundle.scar",
+                luaBundleEntry: "src/main.ts",
+            })
+            .expectToHaveNoDiagnostics()
+            .getLuaResult();
+
+        const fileNames = transpiledFiles.map(f => f.outPath);
+        expect(fileNames).toHaveLength(1);
+        expect(fileNames).toContain(path.join(cwd, "out1", "out2", "bundle.scar"));
+    });
 });
 
 function normalize(path: string) {


### PR DESCRIPTION
Got a request from a modding environment that does not use .lua but instead .scar files (with Lua content). Since there is no good way of changing extension otherwise, besides using some kind of post-build step or custom file watcher, I added it as a tsconfig option.