### PR TITLE
Fix prototype call check for nullable types

### DIFF
--- a/src/transformation/builtins/index.ts
+++ b/src/transformation/builtins/index.ts
@@ -9,6 +9,7 @@ import {
     hasStandardLibrarySignature,
     isArrayType,
     isFunctionType,
+    isNullableType,
     isNumberType,
     isStandardLibraryType,
     isStringType,
@@ -115,22 +116,34 @@ export function transformBuiltinCallExpression(
         }
     }
 
-    if (isStringType(context, ownerType) && hasStandardLibrarySignature(context, node)) {
+    const isStringFunction =
+        isStringType(context, ownerType) ||
+        (expression.questionDotToken && isNullableType(context, ownerType, isStringType));
+    if (isStringFunction && hasStandardLibrarySignature(context, node)) {
         if (isOptionalCall) return unsupportedOptionalCall();
         return transformStringPrototypeCall(context, node);
     }
 
-    if (isNumberType(context, ownerType) && hasStandardLibrarySignature(context, node)) {
+    const isNumberFunction =
+        isNumberType(context, ownerType) ||
+        (expression.questionDotToken && isNullableType(context, ownerType, isNumberType));
+    if (isNumberFunction && hasStandardLibrarySignature(context, node)) {
         if (isOptionalCall) return unsupportedOptionalCall();
         return transformNumberPrototypeCall(context, node);
     }
 
-    if (isArrayType(context, ownerType) && hasStandardLibrarySignature(context, node)) {
+    const isArrayFunction =
+        isArrayType(context, ownerType) ||
+        (expression.questionDotToken && isNullableType(context, ownerType, isArrayType));
+    if (isArrayFunction && hasStandardLibrarySignature(context, node)) {
         if (isOptionalCall) return unsupportedOptionalCall();
         return transformArrayPrototypeCall(context, node);
     }
 
-    if (isFunctionType(ownerType) && hasStandardLibrarySignature(context, node)) {
+    const isFunctionFunction =
+        isFunctionType(ownerType) ||
+        (expression.questionDotToken && isNullableType(context, ownerType, (_, t) => isFunctionType(t)));
+    if (isFunctionFunction && hasStandardLibrarySignature(context, node)) {
         if (isOptionalCall) return unsupportedOptionalCall();
         return transformFunctionPrototypeCall(context, node);
     }

--- a/src/transformation/utils/typescript/types.ts
+++ b/src/transformation/utils/typescript/types.ts
@@ -60,12 +60,27 @@ export function typeCanSatisfy(
     return false;
 }
 
+export function isNullishType(context: TransformationContext, type: ts.Type): boolean {
+    return isTypeWithFlags(context, type, ts.TypeFlags.Undefined | ts.TypeFlags.Null | ts.TypeFlags.VoidLike);
+}
+
 export function isStringType(context: TransformationContext, type: ts.Type): boolean {
     return isTypeWithFlags(context, type, ts.TypeFlags.String | ts.TypeFlags.StringLike | ts.TypeFlags.StringLiteral);
 }
 
 export function isNumberType(context: TransformationContext, type: ts.Type): boolean {
     return isTypeWithFlags(context, type, ts.TypeFlags.Number | ts.TypeFlags.NumberLike | ts.TypeFlags.NumberLiteral);
+}
+
+export function isNullableType(
+    context: TransformationContext,
+    type: ts.Type,
+    isType: (c: TransformationContext, t: ts.Type) => boolean
+): boolean {
+    return (
+        typeCanSatisfy(context, type, t => isType(context, t)) &&
+        typeAlwaysSatisfies(context, type, t => isType(context, t) || isNullishType(context, t))
+    );
 }
 
 function isExplicitArrayType(context: TransformationContext, type: ts.Type): boolean {

--- a/test/unit/builtins/array.spec.ts
+++ b/test/unit/builtins/array.spec.ts
@@ -700,3 +700,15 @@ test.each([
 ])("trailing undefined or null are allowed in array literal (%p)", literal => {
     util.testExpression(literal).expectToHaveNoDiagnostics();
 });
+
+// Issue #1218: https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1218
+test.each(["[1, 2, 3]", "undefined"])("prototype call on nullable array (%p)", value => {
+    util.testFunction`
+        function find(arr?: number[]) {
+            return arr?.indexOf(2);
+        }
+        return find(${value});
+    `
+        .setOptions({ strictNullChecks: true })
+        .expectToMatchJsResult();
+});

--- a/test/unit/builtins/numbers.spec.ts
+++ b/test/unit/builtins/numbers.spec.ts
@@ -143,3 +143,15 @@ test.each([
 ])("parseInt with base and trailing text (%p)", ({ numberString, base }) => {
     util.testExpression`parseInt("${numberString}", ${base})`.expectToMatchJsResult();
 });
+
+// Issue #1218: https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1218
+test.each(["42", "undefined"])("prototype call on nullable number (%p)", value => {
+    util.testFunction`
+        function toString(n?: number) {
+            return n?.toString();
+        }
+        return toString(${value});
+    `
+        .setOptions({ strictNullChecks: true })
+        .expectToMatchJsResult();
+});

--- a/test/unit/builtins/string.spec.ts
+++ b/test/unit/builtins/string.spec.ts
@@ -367,3 +367,15 @@ test("string intersected method", () => {
         return ({ abc: () => "a" } as Vector).abc();
     `.expectToMatchJsResult();
 });
+
+// Issue #1218: https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1218
+test.each(['"foo"', "undefined"])("prototype call on nullable string (%p)", value => {
+    util.testFunction`
+        function toUpper(str?: string) {
+            return str?.toUpperCase();
+        }
+        return toUpper(${value});
+    `
+        .setOptions({ strictNullChecks: true })
+        .expectToMatchJsResult();
+});

--- a/test/unit/builtins/string.spec.ts
+++ b/test/unit/builtins/string.spec.ts
@@ -379,3 +379,18 @@ test.each(['"foo"', "undefined"])("prototype call on nullable string (%p)", valu
         .setOptions({ strictNullChecks: true })
         .expectToMatchJsResult();
 });
+
+// Issue #1218: https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1218
+test.each(["string | undefined", "string | null", "null | string", "null | undefined | string"])(
+    "prototype call on nullable string type (%p)",
+    type => {
+        util.testFunction`
+        function toUpper(str: ${type}) {
+            return str?.toUpperCase();
+        }
+        return toUpper("foo");
+    `
+            .setOptions({ strictNullChecks: true })
+            .expectToMatchJsResult();
+    }
+);

--- a/test/unit/functions/functions.spec.ts
+++ b/test/unit/functions/functions.spec.ts
@@ -181,6 +181,18 @@ test("function apply without arguments should not lead to exception", () => {
     `.expectToMatchJsResult();
 });
 
+// Issue #1218: https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1218
+test.each(["() => 4", "undefined"])("prototype call on nullable function (%p)", value => {
+    util.testFunction`
+        function call(f?: () => number) {
+            return f?.apply(3);
+        }
+        return call(${value});
+    `
+        .setOptions({ strictNullChecks: true })
+        .expectToMatchJsResult();
+});
+
 test("Function call", () => {
     util.testFunction`
         const abc = function (this: { a: number }, a: string) { return this.a + a; }


### PR DESCRIPTION
Turns out that when we check for built-in prototype methods (like `string.prototype.substring` for example), we were not taking optional chaining into account. Therefore `strOrUndefined?.substring()` would lead to invalid Lua. This PR fixes the check for all prototype calls we detect, so they also work in case of optional chaining.

Fixes #1218 