### PR TITLE
Implement Array.from and Array.of

### DIFF
--- a/src/LuaLib.ts
+++ b/src/LuaLib.ts
@@ -10,6 +10,7 @@ export enum LuaLibFeature {
     ArrayForEach = "ArrayForEach",
     ArrayFind = "ArrayFind",
     ArrayFindIndex = "ArrayFindIndex",
+    ArrayFrom = "ArrayFrom",
     ArrayIncludes = "ArrayIncludes",
     ArrayIndexOf = "ArrayIndexOf",
     ArrayIsArray = "ArrayIsArray",

--- a/src/lualib/ArrayFrom.ts
+++ b/src/lualib/ArrayFrom.ts
@@ -1,0 +1,36 @@
+/** @noSelfInFile */
+
+import { __TS__Iterator } from "./Iterator";
+
+function arrayLikeStep(this: ArrayLike<unknown>, index: number): LuaMultiReturn<[number, unknown] | []> {
+    index += 1;
+    if (index > this.length) return $multi();
+    return $multi(index, this[index]);
+}
+
+const arrayLikeIterator: (
+    this: void,
+    arr: ArrayLike<unknown> | Iterable<unknown>
+) => LuaIterable<LuaMultiReturn<[number, unknown]>> = (arr => {
+    if (typeof arr.length === "number") return $multi(arrayLikeStep, arr, 0);
+    return __TS__Iterator(arr);
+}) as any;
+
+export function __TS__ArrayFrom(
+    this: void,
+    arrayLike: ArrayLike<unknown> | Iterable<unknown>,
+    mapFn?: (this: unknown, element: unknown, index: number) => unknown,
+    thisArg?: unknown
+): unknown[] {
+    const result = [];
+    if (mapFn === undefined) {
+        for (const [, v] of arrayLikeIterator(arrayLike)) {
+            result.push(v);
+        }
+    } else {
+        for (const [i, v] of arrayLikeIterator(arrayLike)) {
+            result.push(mapFn.call(thisArg, v, i - 1));
+        }
+    }
+    return result;
+}

--- a/src/lualib/tsconfig.json
+++ b/src/lualib/tsconfig.json
@@ -13,5 +13,6 @@
         "luaLibImport": "none",
         "noHeader": true,
         "luaPlugins": [{ "name": "../../dist/lualib-build/plugin.js" }]
-    }
+    },
+    "include": [".", "../../language-extensions/index.d.ts"]
 }

--- a/src/transformation/builtins/array.ts
+++ b/src/transformation/builtins/array.ts
@@ -5,19 +5,24 @@ import { unsupportedProperty } from "../utils/diagnostics";
 import { LuaLibFeature, transformLuaLibFunction } from "../utils/lualib";
 import { PropertyCallExpression, transformArguments, transformCallAndArguments } from "../visitors/call";
 import { isStringType, isNumberType } from "../utils/typescript";
+import { wrapInTable } from "../utils/lua-ast";
 
 export function transformArrayConstructorCall(
     context: TransformationContext,
     node: PropertyCallExpression
-): lua.CallExpression | undefined {
+): lua.Expression | undefined {
     const expression = node.expression;
     const signature = context.checker.getResolvedSignature(node);
     const params = transformArguments(context, node.arguments, signature);
 
     const expressionName = expression.name.text;
     switch (expressionName) {
+        case "from":
+            return transformLuaLibFunction(context, LuaLibFeature.ArrayFrom, node, ...params);
         case "isArray":
             return transformLuaLibFunction(context, LuaLibFeature.ArrayIsArray, node, ...params);
+        case "of":
+            return wrapInTable(...params);
         default:
             context.diagnostics.push(unsupportedProperty(expression.name, "Array", expressionName));
     }

--- a/test/unit/builtins/array.spec.ts
+++ b/test/unit/builtins/array.spec.ts
@@ -671,6 +671,20 @@ test("Array.isArray returns true for empty objects", () => {
     util.testExpression`Array.isArray({})`.expectToEqual(true);
 });
 
+test.each([
+    "[1, 2, 3]",
+    "(new Set([1, 2, 3])).values()",
+    "[1, 2, 3], value => value * 2",
+    "{ length: 3 }, (_, index) => index + 1",
+])("Array.from(%p)", valueString => {
+    util.testExpression`Array.from(${valueString})`.expectToMatchJsResult();
+});
+
+// Array.of
+test.each(["1, 2, 3", "", "...[1, 2, 3], 4, 5, 6"])("Array.of(%p)", valueString => {
+    util.testExpression`Array.of(${valueString})`.expectToMatchJsResult();
+});
+
 // Test fix for https://github.com/TypeScriptToLua/TypeScriptToLua/issues/738
 test("array.prototype.concat issue #738", () => {
     util.testExpression`([] as any[]).concat(13, 323, {x: 3}, [2, 3])`.expectToMatchJsResult();


### PR DESCRIPTION
Closes #1183, alternative to #1235.

This allows constructs like `Array.from({ length: 3 }, (_, index) => index * 2)` (which works in js).

Array.of simply transforms into a table expression.