### PR TITLE
Resolve node_modules symlinks as node_modules paths

### DIFF
--- a/src/transpilation/resolve.ts
+++ b/src/transpilation/resolve.ts
@@ -14,6 +14,7 @@ const resolver = resolve.ResolverFactory.createResolver({
     enforceExtension: true, // Resolved file must be a lua file
     fileSystem: { ...new resolve.CachedInputFileSystem(fs) },
     useSyncFileSystemCalls: true,
+    symlinks: false, // Do not resolve symlinks to their original paths (that breaks node_modules detection)
 });
 
 interface ResolutionResult {


### PR DESCRIPTION
So apparently the resolver by default resolves symlinks to their original paths. This breaks how we handle node_modules (emit lua to lua_modules), because we can no longer tell the file came from node_modules.

Some examples where this could be annoying:

- Locally testing npm packages you use `npm link` to link one local package into the node_modules directory of another
- Using [npm workspaces](https://docs.npmjs.com/cli/v7/using-npm/workspaces) to split a workspace into multiple packages, symlinked to each other.

I think this change should fix these use cases without breaking others, we can just try it out and see if it has any unexpected side effects.