### PR TITLE
Add new option to bypass 5.1 try/catch in async/await precaution

### DIFF
--- a/src/CompilerOptions.ts
+++ b/src/CompilerOptions.ts
@@ -21,7 +21,7 @@ export interface LuaPluginImport {
     [option: string]: any;
 }
 
-export type CompilerOptions = OmitIndexSignature<ts.CompilerOptions> & {
+export interface TypeScriptToLuaOptions {
     buildMode?: BuildMode;
     extension?: string;
     luaBundle?: string;
@@ -35,8 +35,13 @@ export type CompilerOptions = OmitIndexSignature<ts.CompilerOptions> & {
     plugins?: Array<ts.PluginImport | TransformerImport>;
     sourceMapTraceback?: boolean;
     tstlVerbose?: boolean;
-    [option: string]: any;
-};
+    lua51AllowTryCatchInAsyncAwait?: boolean;
+}
+
+export type CompilerOptions = OmitIndexSignature<ts.CompilerOptions> &
+    TypeScriptToLuaOptions & {
+        [option: string]: any;
+    };
 
 export enum LuaLibImportKind {
     None = "none",

--- a/src/cli/parse.ts
+++ b/src/cli/parse.ts
@@ -88,6 +88,11 @@ export const optionDeclarations: CommandLineOption[] = [
         description: "An array of paths that tstl should not resolve and keep as-is.",
         type: "array",
     },
+    {
+        name: "lua51AllowTryCatchInAsyncAwait",
+        description: "Always allow try/catch in async/await functions for Lua 5.1.",
+        type: "boolean",
+    },
 ];
 
 export function updateParsedConfigFile(parsedConfigFile: ts.ParsedCommandLine): ParsedCommandLine {

--- a/src/transformation/utils/diagnostics.ts
+++ b/src/transformation/utils/diagnostics.ts
@@ -1,5 +1,5 @@
 import * as ts from "typescript";
-import { LuaTarget } from "../../CompilerOptions";
+import { LuaTarget, TypeScriptToLuaOptions } from "../../CompilerOptions";
 import { createSerialDiagnosticFactory } from "../../utils";
 import { AnnotationKind } from "./annotations";
 
@@ -84,10 +84,21 @@ export const unsupportedRightShiftOperator = createErrorDiagnosticFactory(
     "Right shift operator is not supported for target Lua 5.3. Use `>>>` instead."
 );
 
+type NonUniversalTarget = Exclude<LuaTarget, LuaTarget.Universal>;
+
 const getLuaTargetName = (version: LuaTarget) => (version === LuaTarget.LuaJIT ? "LuaJIT" : `Lua ${version}`);
 export const unsupportedForTarget = createErrorDiagnosticFactory(
-    (functionality: string, version: Exclude<LuaTarget, LuaTarget.Universal>) =>
+    (functionality: string, version: NonUniversalTarget) =>
         `${functionality} is/are not supported for target ${getLuaTargetName(version)}.`
+);
+
+export const unsupportedForTargetButOverrideAvailable = createErrorDiagnosticFactory(
+    (functionality: string, version: NonUniversalTarget, optionName: keyof TypeScriptToLuaOptions) =>
+        `As a precaution, ${functionality} is/are not supported for target ${getLuaTargetName(
+            version
+        )} due to language features/limitations. ` +
+        `However "--${optionName}" can be used to bypass this precaution. ` +
+        "See https://typescripttolua.github.io/docs/configuration for more information."
 );
 
 export const unsupportedProperty = createErrorDiagnosticFactory(

--- a/test/unit/builtins/async-await.spec.ts
+++ b/test/unit/builtins/async-await.spec.ts
@@ -1,5 +1,6 @@
 import { ModuleKind, ScriptTarget } from "typescript";
 import { LuaTarget } from "../../../src";
+import { unsupportedForTargetButOverrideAvailable } from "../../../src/transformation/utils/diagnostics";
 import { awaitMustBeInAsyncFunction, unsupportedForTarget } from "../../../src/transformation/utils/diagnostics";
 import * as util from "../../util";
 
@@ -540,7 +541,8 @@ describe("try/catch in async function", () => {
         // Cannot execute LuaJIT with test runner
         {
             ...util.expectEachVersionExceptJit(builder => builder.expectToEqual({ result: 4 })),
-            [LuaTarget.Lua51]: builder => builder.expectToHaveDiagnostics([unsupportedForTarget.code]),
+            [LuaTarget.Lua51]: builder =>
+                builder.expectToHaveDiagnostics([unsupportedForTargetButOverrideAvailable.code]),
         }
     );
 
@@ -563,7 +565,8 @@ describe("try/catch in async function", () => {
             ...util.expectEachVersionExceptJit(builder =>
                 builder.expectToEqual({ reason: "an error occurred in the async function: test error" })
             ),
-            [LuaTarget.Lua51]: builder => builder.expectToHaveDiagnostics([unsupportedForTarget.code]),
+            [LuaTarget.Lua51]: builder =>
+                builder.expectToHaveDiagnostics([unsupportedForTargetButOverrideAvailable.code]),
         }
     );
 
@@ -590,7 +593,8 @@ describe("try/catch in async function", () => {
             ...util.expectEachVersionExceptJit(builder =>
                 builder.expectToEqual({ reason: "an error occurred in the async function: test error" })
             ),
-            [LuaTarget.Lua51]: builder => builder.expectToHaveDiagnostics([unsupportedForTarget.code]),
+            [LuaTarget.Lua51]: builder =>
+                builder.expectToHaveDiagnostics([unsupportedForTargetButOverrideAvailable.code]),
         }
     );
 });

--- a/test/unit/builtins/async-await.spec.ts
+++ b/test/unit/builtins/async-await.spec.ts
@@ -1,7 +1,7 @@
 import { ModuleKind, ScriptTarget } from "typescript";
 import { LuaTarget } from "../../../src";
 import { unsupportedForTargetButOverrideAvailable } from "../../../src/transformation/utils/diagnostics";
-import { awaitMustBeInAsyncFunction, unsupportedForTarget } from "../../../src/transformation/utils/diagnostics";
+import { awaitMustBeInAsyncFunction } from "../../../src/transformation/utils/diagnostics";
 import * as util from "../../util";
 
 const promiseTestLib = `


### PR DESCRIPTION
Closes #1158

Adds a very specific option to allow TSTL to proceed with transforming try/catch in async/await functions 

`lua51AllowTryCatchInAsyncAwait` (boolean) (false by default)

I figured `lua51` in the name to come first because this only has an effect on Lua 5.1 and isn't needed in any other targets

I can add more to this PR if needed just wanted to get an idea if this is the kind of solution expected 🤔 

Also planning to add some more details to the wiki about what specifically in the language we're looking for so that someone can figure out if this is a switch they should enable