### PR TITLE
Support for import expressions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5084,9 +5084,9 @@
             }
         },
         "node_modules/minimist": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
             "dev": true
         },
         "node_modules/ms": {
@@ -10320,9 +10320,9 @@
             }
         },
         "minimist": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
             "dev": true
         },
         "ms": {

--- a/src/transformation/builtins/promise.ts
+++ b/src/transformation/builtins/promise.ts
@@ -44,7 +44,7 @@ export function transformPromiseConstructorCall(
     }
 }
 
-function createStaticPromiseFunctionAccessor(functionName: string, node: ts.Node) {
+export function createStaticPromiseFunctionAccessor(functionName: string, node: ts.Node) {
     return lua.createTableIndexExpression(
         lua.createIdentifier("__TS__Promise"),
         lua.createStringLiteral(functionName),

--- a/src/transformation/visitors/call.ts
+++ b/src/transformation/visitors/call.ts
@@ -15,6 +15,7 @@ import { moveToPrecedingTemp, transformExpressionList } from "./expression-list"
 import { transformInPrecedingStatementScope } from "../utils/preceding-statements";
 import { getOptionalContinuationData, transformOptionalChain } from "./optional-chaining";
 import { transformLanguageExtensionCallExpression } from "./language-extensions";
+import { transformImportExpression } from "./modules/import";
 
 export type PropertyCallExpression = ts.CallExpression & { expression: ts.PropertyAccessExpression };
 
@@ -210,6 +211,10 @@ function transformElementCall(context: TransformationContext, node: ts.CallExpre
 }
 
 export const transformCallExpression: FunctionVisitor<ts.CallExpression> = (node, context) => {
+    if (node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+        return transformImportExpression(node, context);
+    }
+
     if (ts.isOptionalChain(node)) {
         return transformOptionalChain(context, node);
     }

--- a/test/cli/run.ts
+++ b/test/cli/run.ts
@@ -1,7 +1,7 @@
 import { ChildProcess, fork } from "child_process";
 import * as path from "path";
 
-jest.setTimeout(20000);
+jest.setTimeout(30000);
 
 const cliPath = path.join(__dirname, "../../src/tstl.ts");
 

--- a/test/unit/modules/modules.spec.ts
+++ b/test/unit/modules/modules.spec.ts
@@ -280,3 +280,14 @@ test("namespace export with unsafe Lua name", () => {
         .addExtraFile("module.ts", moduleFile)
         .expectToMatchJsResult();
 });
+
+test("import expression", () => {
+    util.testModule`
+        let result;
+        import("./module").then(m => { result = m.foo(); });
+        export { result };
+    `
+        .addExtraFile("module.ts", 'export function foo() { return "foo"; }')
+        .setOptions({ module: ts.ModuleKind.ESNext })
+        .expectToMatchJsResult();
+});


### PR DESCRIPTION
Translates `import(<path>)` to `Promise.resolve(require(<path>))`.

Closes #1251 