### PR TITLE
fix: debug.traceback of loadstring get unknown file #1259

### DIFF
--- a/src/lualib/SourceMapTraceBack.ts
+++ b/src/lualib/SourceMapTraceBack.ts
@@ -59,9 +59,7 @@ export function __TS__SourceMapTraceBack(this: void, fileName: string, sourceMap
 
                 return `${file}:${line}`;
             };
-            [result] = string.gsub(result, '(%[string "[^"]+"%]):(%d+)', (file, line) =>
-                stringReplacer(file, line)
-            );
+            [result] = string.gsub(result, '(%[string "[^"]+"%]):(%d+)', (file, line) => stringReplacer(file, line));
 
             return result;
         }) as typeof debug.traceback;

--- a/src/lualib/SourceMapTraceBack.ts
+++ b/src/lualib/SourceMapTraceBack.ts
@@ -43,8 +43,24 @@ export function __TS__SourceMapTraceBack(this: void, fileName: string, sourceMap
             let [result] = string.gsub(trace, "(%S+)%.lua:(%d+)", (file, line) =>
                 replacer(`${file}.lua`, `${file}.ts`, line)
             );
+
+            const stringReplacer = (file: string, line: string) => {
+                const fileSourceMap: SourceMap = globalThis.__TS__sourcemap[file];
+                if (fileSourceMap && fileSourceMap[line]) {
+                    const chunkName = string.match(file, '%[string "([^"]+)"%]')[0];
+                    const [sourceName] = string.gsub(chunkName, ".lua$", ".ts");
+                    const data = fileSourceMap[line];
+                    if (typeof data === "number") {
+                        return `${sourceName}:${data}`;
+                    }
+
+                    return `${data.file}:${data.line}`;
+                }
+
+                return `${file}:${line}`;
+            };
             [result] = string.gsub(result, '(%[string "[^"]+"%]):(%d+)', (file, line) =>
-                replacer(file, "unknown", line)
+                stringReplacer(file, line)
             );
 
             return result;

--- a/test/unit/printer/sourcemaps.spec.ts
+++ b/test/unit/printer/sourcemaps.spec.ts
@@ -1,5 +1,6 @@
 import { SourceMapConsumer } from "source-map";
 import * as tstl from "../../../src";
+import { LuaTarget } from "../../../src";
 import { couldNotResolveRequire } from "../../../src/transpilation/diagnostics";
 import * as util from "../../util";
 import { lineAndColumnOf } from "./utils";
@@ -325,4 +326,29 @@ test("Inline sourcemaps", () => {
         file.lua.match(/--# sourceMappingURL=data:application\/json;base64,([A-Za-z0-9+/=]+)/) ?? [];
     const inlineSourceMap = Buffer.from(inlineSourceMapMatch, "base64").toString();
     expect(inlineSourceMap).toBe(file.luaSourceMap);
+});
+
+test("loadstring sourceMapTraceback gives traceback", () => {
+    const strCodeBuilder = util.testModule`
+        function bar() {
+            const trace = (debug.traceback as (this: void)=>string)();
+            return trace;
+        }
+        return bar();
+    `.setOptions({ sourceMapTraceback: true, luaTarget: LuaTarget.Lua51 });
+
+    const strCode = strCodeBuilder.getMainLuaCodeChunk();
+    const file = `
+        const luaCode: string = \`${strCode}\`;
+        return (loadstring as (this: void, string: string, chunkname?: string) => LuaMultiReturn<[() => any] | [undefined, string]>)
+            (luaCode, "foo.lua")()
+    `;
+    const builder = util.testModule`
+        return (require as (this: void, modname: string) => any)("foo");
+    `
+        .addExtraFile("foo.ts", file)
+        .setOptions({ sourceMapTraceback: true, luaTarget: LuaTarget.Lua51 });
+
+    const traceback = builder.getLuaExecutionResult();
+    expect(traceback).toContain("foo.ts");
 });


### PR DESCRIPTION
Assume the chunkname is the lua path, and replace the traceback substring [string "xx/xx.lua"]:22 to xx/xx.ts:10