### PR TITLE
Apply JSDoc Comments to Lua code

### DIFF
--- a/src/transformation/utils/lua-ast.ts
+++ b/src/transformation/utils/lua-ast.ts
@@ -233,7 +233,7 @@ function applyJSDocComments(
     // By default, TSTL will display comments immediately next to the "--" characters. We can make
     // the comments look better if we separate them by a space (similar to what Prettier does in
     // JavaScript/TypeScript).
-    const docCommentWithSpace = docComment.map((line) => ` ${line}`);
+    const docCommentWithSpace = docComment.map(line => ` ${line}`);
 
     if (declaration && assignment) {
         declaration.leadingComments = docCommentWithSpace;
@@ -244,10 +244,7 @@ function applyJSDocComments(
     }
 }
 
-function extractJSDocCommentFromTSNode(
-    context: TransformationContext,
-    tsOriginal: ts.Node | undefined,
-) {
+function extractJSDocCommentFromTSNode(context: TransformationContext, tsOriginal: ts.Node | undefined) {
     if (tsOriginal === undefined) {
         return undefined;
     }

--- a/src/transformation/utils/lua-ast.ts
+++ b/src/transformation/utils/lua-ast.ts
@@ -225,7 +225,7 @@ function applyJSDocComments(
     declaration: lua.VariableDeclarationStatement | undefined,
     assignment: lua.AssignmentStatement | undefined
 ) {
-    const docComment = extractJSDocCommentFromTSNode(context, tsOriginal);
+    const docComment = getJSDocCommentFromTSNode(context, tsOriginal);
     if (docComment === undefined) {
         return;
     }
@@ -244,7 +244,7 @@ function applyJSDocComments(
     }
 }
 
-function extractJSDocCommentFromTSNode(context: TransformationContext, tsOriginal: ts.Node | undefined) {
+function getJSDocCommentFromTSNode(context: TransformationContext, tsOriginal: ts.Node | undefined) {
     if (tsOriginal === undefined) {
         return undefined;
     }

--- a/src/transformation/utils/lua-ast.ts
+++ b/src/transformation/utils/lua-ast.ts
@@ -300,7 +300,7 @@ function getJSDocCommentFromTSNode(
     // We want to JSDoc comments to map on to LDoc comments:
     // https://stevedonovan.github.io/ldoc/manual/doc.md.html
     // LDoc comments require that the first line starts with three hyphens.
-    // Thus, need to add one or more hyphens to the first line.
+    // Thus, need to add a hyphen to the first line.
     const firstLine = lines[0];
     if (firstLine.startsWith(" @")) {
         lines.unshift("-");

--- a/src/transformation/utils/lua-ast.ts
+++ b/src/transformation/utils/lua-ast.ts
@@ -225,6 +225,8 @@ function applyJSDocComments(
     declaration: lua.VariableDeclarationStatement | undefined,
     assignment: lua.AssignmentStatement | undefined
 ) {
+    // Respect the vanilla TypeScript option of "removeComments":
+    // https://www.typescriptlang.org/tsconfig#removeComments
     if (context.options.removeComments) {
         return;
     }

--- a/src/transformation/utils/lua-ast.ts
+++ b/src/transformation/utils/lua-ast.ts
@@ -225,6 +225,10 @@ function applyJSDocComments(
     declaration: lua.VariableDeclarationStatement | undefined,
     assignment: lua.AssignmentStatement | undefined
 ) {
+    if (context.options.removeComments) {
+        return;
+    }
+
     const docComment = getJSDocCommentFromTSNode(context, tsOriginal);
     if (docComment === undefined) {
         return;

--- a/test/unit/__snapshots__/comments.spec.ts.snap
+++ b/test/unit/__snapshots__/comments.spec.ts.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`JSDoc is copied on a function: code 1`] = `
+"-- This is a function comment.
+-- It has multiple lines.
+function foo(self)
+end"
+`;
+
+exports[`JSDoc is copied on a function: diagnostics 1`] = `""`;
+
+exports[`JSDoc is copied on a variable: code 1`] = `
+"-- This is a variable comment.
+-- It has multiple lines.
+foo = 123"
+`;
+
+exports[`JSDoc is copied on a variable: diagnostics 1`] = `""`;

--- a/test/unit/__snapshots__/comments.spec.ts.snap
+++ b/test/unit/__snapshots__/comments.spec.ts.snap
@@ -1,18 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`JSDoc is copied on a function: code 1`] = `
-"-- This is a function comment.
+exports[`JSDoc is copied on a function with tags: code 1`] = `
+"--- This is a function comment.
 -- It has multiple lines.
-function foo(self)
+-- 
+-- @param arg1 This is the first argument.
+-- @param arg2 This is the second argument.
+-- @returns A very powerful string.
+function foo(self, arg1, arg2)
+    return \\"bar\\"
 end"
 `;
 
-exports[`JSDoc is copied on a function: diagnostics 1`] = `""`;
+exports[`JSDoc is copied on a function with tags: diagnostics 1`] = `""`;
 
 exports[`JSDoc is copied on a variable: code 1`] = `
-"-- This is a variable comment.
--- It has multiple lines.
+"--- This is a variable comment.
 foo = 123"
 `;
 
 exports[`JSDoc is copied on a variable: diagnostics 1`] = `""`;
+
+exports[`Multi-line JSDoc with one block is copied on a function: code 1`] = `
+"--- This is a function comment.
+-- It has more than one line.
+function foo(self)
+end"
+`;
+
+exports[`Multi-line JSDoc with one block is copied on a function: diagnostics 1`] = `""`;
+
+exports[`Multi-line JSDoc with two blocks is copied on a function: code 1`] = `
+"--- This is a function comment.
+-- It has more than one line.
+-- 
+-- It also has more than one block.
+function foo(self)
+end"
+`;
+
+exports[`Multi-line JSDoc with two blocks is copied on a function: diagnostics 1`] = `""`;
+
+exports[`Single-line JSDoc is copied on a function: code 1`] = `
+"--- This is a function comment.
+function foo(self)
+end"
+`;
+
+exports[`Single-line JSDoc is copied on a function: diagnostics 1`] = `""`;

--- a/test/unit/__snapshots__/optionalChaining.spec.ts.snap
+++ b/test/unit/__snapshots__/optionalChaining.spec.ts.snap
@@ -32,9 +32,17 @@ exports[`Unsupported optional chains Builtin prototype method: diagnostics 1`] =
 exports[`Unsupported optional chains Compile members only: code 1`] = `
 "local ____exports = {}
 function ____exports.__main(self)
+    ---
+    -- @compileMembersOnly
     local A = 0
+    ---
+    -- @compileMembersOnly
     local B = 2
+    ---
+    -- @compileMembersOnly
     local C = 3
+    ---
+    -- @compileMembersOnly
     local D = \\"D\\"
     local ____TestEnum_B_0 = TestEnum
     if ____TestEnum_B_0 ~= nil then

--- a/test/unit/annotations/__snapshots__/customConstructor.spec.ts.snap
+++ b/test/unit/annotations/__snapshots__/customConstructor.spec.ts.snap
@@ -6,6 +6,8 @@ local __TS__Class = ____lualib.__TS__Class
 local __TS__New = ____lualib.__TS__New
 local ____exports = {}
 function ____exports.__main(self)
+    ---
+    -- @customConstructor
     local Point2D = __TS__Class()
     Point2D.name = \\"Point2D\\"
     function Point2D.prototype.____constructor(self)

--- a/test/unit/annotations/__snapshots__/deprecated.spec.ts.snap
+++ b/test/unit/annotations/__snapshots__/deprecated.spec.ts.snap
@@ -42,6 +42,8 @@ exports[`extension removed: code 1`] = `
 "local ____lualib = require(\\"lualib_bundle\\")
 local __TS__Class = ____lualib.__TS__Class
 local __TS__ClassExtends = ____lualib.__TS__ClassExtends
+---
+-- @extension
 B = __TS__Class()
 B.name = \\"B\\"
 __TS__ClassExtends(B, A)"
@@ -51,6 +53,8 @@ exports[`extension removed: code 2`] = `
 "local ____lualib = require(\\"lualib_bundle\\")
 local __TS__Class = ____lualib.__TS__Class
 local __TS__ClassExtends = ____lualib.__TS__ClassExtends
+---
+-- @metaExtension
 B = __TS__Class()
 B.name = \\"B\\"
 __TS__ClassExtends(B, A)"
@@ -108,6 +112,8 @@ exports[`pureAbstract removed: diagnostics 1`] = `"main.ts(4,22): error TSTL: '@
 exports[`tuplereturn lambda: code 1`] = `
 "local ____exports = {}
 function ____exports.__main(self)
+    ---
+    -- @tupleReturn
     local function f()
         return {3, 4}
     end
@@ -120,6 +126,8 @@ exports[`tuplereturn lambda: diagnostics 1`] = `"main.ts(2,39): error TSTL: '@tu
 exports[`tuplereturn removed on function declaration: code 1`] = `
 "local ____exports = {}
 function ____exports.__main(self)
+    ---
+    -- @tupleReturn
     local function tuple(self)
         return {3, 5, 1}
     end
@@ -132,6 +140,8 @@ exports[`tuplereturn removed on function declaration: diagnostics 1`] = `"main.t
 exports[`tuplereturn removed: code 1`] = `
 "local ____exports = {}
 function ____exports.__main(self)
+    ---
+    -- @tupleReturn
     local function tuple(self)
         return {3, 5, 1}
     end

--- a/test/unit/annotations/deprecated.spec.ts
+++ b/test/unit/annotations/deprecated.spec.ts
@@ -4,14 +4,14 @@ import * as util from "../../util";
 test.each(["extension", "metaExtension"])("extension removed", extensionType => {
     util.testModule`
         declare class A {}
-        /** @${extensionType} **/
+        /** @${extensionType} */
         class B extends A {}
     `.expectDiagnosticsToMatchSnapshot([annotationRemoved.code]);
 });
 
 test("phantom removed", () => {
     util.testModule`
-        /** @phantom **/
+        /** @phantom */
         namespace A {
             function nsMember() {}
         }

--- a/test/unit/comments.spec.ts
+++ b/test/unit/comments.spec.ts
@@ -7,7 +7,7 @@ test("JSDoc is copied on a function", () => {
          * It has multiple lines.
          */
         function foo() {}
-    `.expectToHaveNoDiagnostics();
+    `.expectToHaveNoDiagnostics().expectDiagnosticsToMatchSnapshot();
 
     const transpiledFile = builder.getLuaResult().transpiledFiles[0];
     expect(transpiledFile).toBeDefined();
@@ -23,7 +23,7 @@ test("JSDoc is copied on a variable", () => {
          * It has multiple lines.
          */
         const foo = 123;
-    `.expectToHaveNoDiagnostics();
+    `.expectToHaveNoDiagnostics().expectDiagnosticsToMatchSnapshot();
 
     const transpiledFile = builder.getLuaResult().transpiledFiles[0];
     expect(transpiledFile).toBeDefined();

--- a/test/unit/comments.spec.ts
+++ b/test/unit/comments.spec.ts
@@ -7,7 +7,9 @@ test("JSDoc is copied on a function", () => {
          * It has multiple lines.
          */
         function foo() {}
-    `.expectToHaveNoDiagnostics().expectDiagnosticsToMatchSnapshot();
+    `
+        .expectToHaveNoDiagnostics()
+        .expectDiagnosticsToMatchSnapshot();
 
     const transpiledFile = builder.getLuaResult().transpiledFiles[0];
     expect(transpiledFile).toBeDefined();
@@ -23,7 +25,9 @@ test("JSDoc is copied on a variable", () => {
          * It has multiple lines.
          */
         const foo = 123;
-    `.expectToHaveNoDiagnostics().expectDiagnosticsToMatchSnapshot();
+    `
+        .expectToHaveNoDiagnostics()
+        .expectDiagnosticsToMatchSnapshot();
 
     const transpiledFile = builder.getLuaResult().transpiledFiles[0];
     expect(transpiledFile).toBeDefined();

--- a/test/unit/comments.spec.ts
+++ b/test/unit/comments.spec.ts
@@ -1,0 +1,19 @@
+import * as util from "../util";
+
+test("JSDoc is copied", () => {
+    const builder = util.testModule`
+        /**
+         * LOL
+         */
+        function foo() {}
+        // POOP
+    `
+        .expectToHaveNoDiagnostics();
+
+    const transpiledFile = builder.getLuaResult().transpiledFiles[0];
+    util.assert(transpiledFile !== undefined);
+    const { lua } =  transpiledFile;
+    util.assert(lua !== undefined);
+    console.log(lua);
+    expect(lua).toContain("LOL");
+});

--- a/test/unit/comments.spec.ts
+++ b/test/unit/comments.spec.ts
@@ -7,12 +7,11 @@ test("JSDoc is copied on a function", () => {
          * It has multiple lines.
          */
         function foo() {}
-    `
-        .expectToHaveNoDiagnostics();
+    `.expectToHaveNoDiagnostics();
 
     const transpiledFile = builder.getLuaResult().transpiledFiles[0];
     util.assert(transpiledFile !== undefined);
-    const { lua } =  transpiledFile;
+    const { lua } = transpiledFile;
     util.assert(lua !== undefined);
     expect(lua).toContain("This is a function comment.");
 });
@@ -24,12 +23,11 @@ test("JSDoc is copied on a variable", () => {
          * It has multiple lines.
          */
         const foo = 123;
-    `
-        .expectToHaveNoDiagnostics();
+    `.expectToHaveNoDiagnostics();
 
     const transpiledFile = builder.getLuaResult().transpiledFiles[0];
     util.assert(transpiledFile !== undefined);
-    const { lua } =  transpiledFile;
+    const { lua } = transpiledFile;
     util.assert(lua !== undefined);
     expect(lua).toContain("This is a variable comment.");
 });

--- a/test/unit/comments.spec.ts
+++ b/test/unit/comments.spec.ts
@@ -1,11 +1,8 @@
 import * as util from "../util";
 
-test("JSDoc is copied on a function", () => {
+test("Single-line JSDoc is copied on a function", () => {
     const builder = util.testModule`
-        /**
-         * This is a function comment.
-         * It has multiple lines.
-         */
+        /** This is a function comment. */
         function foo() {}
     `
         .expectToHaveNoDiagnostics()
@@ -18,12 +15,73 @@ test("JSDoc is copied on a function", () => {
     expect(lua).toContain("This is a function comment.");
 });
 
-test("JSDoc is copied on a variable", () => {
+test("Multi-line JSDoc with one block is copied on a function", () => {
     const builder = util.testModule`
         /**
-         * This is a variable comment.
-         * It has multiple lines.
+         * This is a function comment.
+         * It has more than one line.
          */
+        function foo() {}
+    `
+        .expectToHaveNoDiagnostics()
+        .expectDiagnosticsToMatchSnapshot();
+
+    const transpiledFile = builder.getLuaResult().transpiledFiles[0];
+    expect(transpiledFile).toBeDefined();
+    const { lua } = transpiledFile;
+    expect(lua).toBeDefined();
+    expect(lua).toContain("It has more than one line.");
+});
+
+test("Multi-line JSDoc with two blocks is copied on a function", () => {
+    const builder = util.testModule`
+        /**
+         * This is a function comment.
+         * It has more than one line.
+         *
+         * It also has more than one block.
+         */
+        function foo() {}
+    `
+        .expectToHaveNoDiagnostics()
+        .expectDiagnosticsToMatchSnapshot();
+
+    const transpiledFile = builder.getLuaResult().transpiledFiles[0];
+    expect(transpiledFile).toBeDefined();
+    const { lua } = transpiledFile;
+    expect(lua).toBeDefined();
+    expect(lua).toContain("It also has more than one block.");
+});
+
+test("JSDoc is copied on a function with tags", () => {
+    const builder = util.testModule`
+        /**
+         * This is a function comment.
+         * It has multiple lines.
+         *
+         * @param arg1 This is the first argument.
+         * @param arg2 This is the second argument.
+         * @returns A very powerful string.
+         */
+        function foo(arg1: boolean, arg2: number): string {
+            return "bar";
+        }
+    `
+        .expectToHaveNoDiagnostics()
+        .expectDiagnosticsToMatchSnapshot();
+
+    const transpiledFile = builder.getLuaResult().transpiledFiles[0];
+    expect(transpiledFile).toBeDefined();
+    const { lua } = transpiledFile;
+    expect(lua).toBeDefined();
+    expect(lua).toContain("This is the first argument.");
+    expect(lua).toContain("This is the second argument.");
+    expect(lua).toContain("A very powerful string.");
+});
+
+test("JSDoc is copied on a variable", () => {
+    const builder = util.testModule`
+        /** This is a variable comment. */
         const foo = 123;
     `
         .expectToHaveNoDiagnostics()

--- a/test/unit/comments.spec.ts
+++ b/test/unit/comments.spec.ts
@@ -1,12 +1,12 @@
 import * as util from "../util";
 
-test("JSDoc is copied", () => {
+test("JSDoc is copied on a function", () => {
     const builder = util.testModule`
         /**
-         * LOL
+         * This is a function comment.
+         * It has multiple lines.
          */
         function foo() {}
-        // POOP
     `
         .expectToHaveNoDiagnostics();
 
@@ -15,5 +15,23 @@ test("JSDoc is copied", () => {
     const { lua } =  transpiledFile;
     util.assert(lua !== undefined);
     console.log(lua);
-    expect(lua).toContain("LOL");
+    expect(lua).toContain("This is a function comment.");
+});
+
+test("JSDoc is copied on a variable", () => {
+    const builder = util.testModule`
+        /**
+         * This is a variable comment.
+         * It has multiple lines.
+         */
+        const foo = 123;
+    `
+        .expectToHaveNoDiagnostics();
+
+    const transpiledFile = builder.getLuaResult().transpiledFiles[0];
+    util.assert(transpiledFile !== undefined);
+    const { lua } =  transpiledFile;
+    util.assert(lua !== undefined);
+    console.log(lua);
+    expect(lua).toContain("This is a variable comment.");
 });

--- a/test/unit/comments.spec.ts
+++ b/test/unit/comments.spec.ts
@@ -14,7 +14,6 @@ test("JSDoc is copied on a function", () => {
     util.assert(transpiledFile !== undefined);
     const { lua } =  transpiledFile;
     util.assert(lua !== undefined);
-    console.log(lua);
     expect(lua).toContain("This is a function comment.");
 });
 
@@ -32,6 +31,5 @@ test("JSDoc is copied on a variable", () => {
     util.assert(transpiledFile !== undefined);
     const { lua } =  transpiledFile;
     util.assert(lua !== undefined);
-    console.log(lua);
     expect(lua).toContain("This is a variable comment.");
 });

--- a/test/unit/comments.spec.ts
+++ b/test/unit/comments.spec.ts
@@ -10,9 +10,9 @@ test("JSDoc is copied on a function", () => {
     `.expectToHaveNoDiagnostics();
 
     const transpiledFile = builder.getLuaResult().transpiledFiles[0];
-    util.assert(transpiledFile !== undefined);
+    expect(transpiledFile).toBeDefined();
     const { lua } = transpiledFile;
-    util.assert(lua !== undefined);
+    expect(lua).toBeDefined();
     expect(lua).toContain("This is a function comment.");
 });
 
@@ -26,8 +26,8 @@ test("JSDoc is copied on a variable", () => {
     `.expectToHaveNoDiagnostics();
 
     const transpiledFile = builder.getLuaResult().transpiledFiles[0];
-    util.assert(transpiledFile !== undefined);
+    expect(transpiledFile).toBeDefined();
     const { lua } = transpiledFile;
-    util.assert(lua !== undefined);
+    expect(lua).toBeDefined();
     expect(lua).toContain("This is a variable comment.");
 });


### PR DESCRIPTION
Fixes #815, sort-of-but-not-really.

According to [this StackOverlow page](https://stackoverflow.com/questions/47429792/is-it-possible-to-get-comments-as-nodes-in-the-ast-using-the-typescript-compiler), it is not possible to get single-line comments in the AST. However, it is possible to extract JSDoc comments that are specifically attached to functions and variables.

So, for this PR, I simply extract JSDoc where I can, and then stick it on the "leadingComments" property that Perry added in 0fba69b06767811f554f21fa8f3d20cb51d5b25c.

This works, and seems good for a first iteration of the feature.

A better solution would be to:
1) Wait for the Lua to be finished generating.
2) Grab every possible comment in the entire TS source file via the method described in the StackOverflow post.
3) Then, massage the comments into the already-generated-Lua.

However, how do we find the correct spot in the generated Lua that corresponds with this spot in the source code? Is that possible?