### PR TITLE
Fix async try

### DIFF
--- a/src/lualib/Await.ts
+++ b/src/lualib/Await.ts
@@ -21,6 +21,7 @@ type ErrorHandler = (this: void, error: unknown) => unknown;
 // eslint-disable-next-line @typescript-eslint/promise-function-async
 export function __TS__AsyncAwaiter(this: void, generator: (this: void) => void) {
     return new Promise((resolve, reject) => {
+        let resolved = false;
         const asyncCoroutine = coroutine.create(generator);
 
         // eslint-disable-next-line @typescript-eslint/promise-function-async
@@ -57,13 +58,14 @@ export function __TS__AsyncAwaiter(this: void, generator: (this: void) => void) 
             }
         }
         function step(result: unknown, errorHandler: ErrorHandler | undefined) {
+            if (resolved) return;
             if (coroutine.status(asyncCoroutine) === "dead") {
                 resolve(result);
             } else {
                 adopt(result).then(fulfilled, rejected(errorHandler));
             }
         }
-        const [success, errorOrErrorHandler, resultOrError] = coroutine.resume(asyncCoroutine);
+        const [success, errorOrErrorHandler, resultOrError] = coroutine.resume(asyncCoroutine, (v: unknown) => { resolved = true; adopt(v).then(resolve, reject) });
         if (success) {
             step(resultOrError, errorOrErrorHandler);
         } else {

--- a/src/lualib/Await.ts
+++ b/src/lualib/Await.ts
@@ -16,8 +16,6 @@
 
 import { __TS__Promise } from "./Promise";
 
-type ErrorHandler = (this: void, error: unknown) => unknown;
-
 // eslint-disable-next-line @typescript-eslint/promise-function-async
 export function __TS__AsyncAwaiter(this: void, generator: (this: void) => void) {
     return new Promise((resolve, reject) => {
@@ -29,51 +27,33 @@ export function __TS__AsyncAwaiter(this: void, generator: (this: void) => void) 
             return value instanceof __TS__Promise ? value : Promise.resolve(value);
         }
         function fulfilled(value: unknown) {
-            const [success, errorOrErrorHandler, resultOrError] = coroutine.resume(asyncCoroutine, value);
+            const [success, resultOrError] = coroutine.resume(asyncCoroutine, value);
             if (success) {
-                step(resultOrError, errorOrErrorHandler);
+                step(resultOrError);
             } else {
-                reject(errorOrErrorHandler);
+                reject(resultOrError);
             }
         }
-        function rejected(handler: ErrorHandler | undefined) {
-            if (handler) {
-                return (value: unknown) => {
-                    const [success, hasReturnedOrError, returnedValue] = pcall(handler, value);
-                    if (success) {
-                        if (hasReturnedOrError) {
-                            resolve(returnedValue);
-                        } else {
-                            step(hasReturnedOrError, handler);
-                        }
-                    } else {
-                        reject(hasReturnedOrError);
-                    }
-                };
-            } else {
-                // If no catch clause, just reject
-                return value => {
-                    reject(value);
-                };
-            }
-        }
-        function step(result: unknown, errorHandler: ErrorHandler | undefined) {
+        function step(result: unknown) {
             if (resolved) return;
             if (coroutine.status(asyncCoroutine) === "dead") {
                 resolve(result);
             } else {
-                adopt(result).then(fulfilled, rejected(errorHandler));
+                adopt(result).then(fulfilled, reject);
             }
         }
-        const [success, errorOrErrorHandler, resultOrError] = coroutine.resume(asyncCoroutine, (v: unknown) => { resolved = true; adopt(v).then(resolve, reject) });
+        const [success, resultOrError] = coroutine.resume(asyncCoroutine, (v: unknown) => {
+            resolved = true;
+            adopt(v).then(resolve, reject);
+        });
         if (success) {
-            step(resultOrError, errorOrErrorHandler);
+            step(resultOrError);
         } else {
-            reject(errorOrErrorHandler);
+            reject(resultOrError);
         }
     });
 }
 
-export function __TS__Await(this: void, errorHandler: ErrorHandler, thing: unknown) {
-    return coroutine.yield(errorHandler, thing);
+export function __TS__Await(this: void, thing: unknown) {
+    return coroutine.yield(thing);
 }

--- a/src/transformation/visitors/async-await.ts
+++ b/src/transformation/visitors/async-await.ts
@@ -20,13 +20,16 @@ export function isAsyncFunction(declaration: ts.FunctionLikeDeclaration): boolea
     return declaration.modifiers?.some(m => m.kind === ts.SyntaxKind.AsyncKeyword) ?? false;
 }
 
-export function wrapInAsyncAwaiter(context: TransformationContext, statements: lua.Statement[]): lua.CallExpression {
+export function wrapInAsyncAwaiter(
+    context: TransformationContext,
+    statements: lua.Statement[],
+    includeResolveParameter = true
+): lua.CallExpression {
     importLuaLibFeature(context, LuaLibFeature.Await);
 
+    const parameters = includeResolveParameter ? [lua.createIdentifier("____awaiter_resolve")] : [];
+
     return lua.createCallExpression(lua.createIdentifier("__TS__AsyncAwaiter"), [
-        lua.createFunctionExpression(lua.createBlock(statements), [
-            lua.createIdentifier("____awaiter_resolve"),
-            lua.createIdentifier("____awaiter_reject"),
-        ]),
+        lua.createFunctionExpression(lua.createBlock(statements), parameters),
     ]);
 }

--- a/src/transformation/visitors/async-await.ts
+++ b/src/transformation/visitors/async-await.ts
@@ -12,8 +12,7 @@ export const transformAwaitExpression: FunctionVisitor<ts.AwaitExpression> = (no
     }
 
     const expression = context.transformExpression(node.expression);
-    const catchIdentifier = lua.createIdentifier("____catch");
-    return transformLuaLibFunction(context, LuaLibFeature.Await, node, catchIdentifier, expression);
+    return transformLuaLibFunction(context, LuaLibFeature.Await, node, expression);
 };
 
 export function isAsyncFunction(declaration: ts.FunctionLikeDeclaration): boolean {

--- a/src/transformation/visitors/errors.ts
+++ b/src/transformation/visitors/errors.ts
@@ -28,7 +28,7 @@ const transformAsyncTry: FunctionVisitor<ts.TryStatement> = (statement, context)
         return tryBlock.statements;
     }
 
-    const awaiter = wrapInAsyncAwaiter(context, tryBlock.statements);
+    const awaiter = wrapInAsyncAwaiter(context, tryBlock.statements, false);
     const awaiterIdentifier = lua.createIdentifier("____try");
     const awaiterDefinition = lua.createVariableDeclarationStatement(awaiterIdentifier, awaiter);
 
@@ -51,17 +51,16 @@ const transformAsyncTry: FunctionVisitor<ts.TryStatement> = (statement, context)
         const awaiterCatch = lua.createTableIndexExpression(awaiterIdentifier, lua.createStringLiteral("catch"));
         const catchCall = lua.createCallExpression(awaiterCatch, [
             awaiterIdentifier,
-            // catch
             catchFunction
         ]);
 
         const promiseAwait = transformLuaLibFunction(context, LuaLibFeature.Await, statement, lua.createNilLiteral(), catchCall);
-        result.push(lua.createReturnStatement([lua.createNilLiteral(), promiseAwait], statement));
+        result.push(lua.createExpressionStatement(promiseAwait, statement));
     }
     else
     {
         const promiseAwait = transformLuaLibFunction(context, LuaLibFeature.Await, statement, lua.createNilLiteral(), awaiterIdentifier);
-        result.push(lua.createReturnStatement([lua.createNilLiteral(), promiseAwait], statement));
+        result.push(lua.createExpressionStatement(promiseAwait, statement));
     }
 
     return result;

--- a/src/transformation/visitors/function.ts
+++ b/src/transformation/visitors/function.ts
@@ -163,7 +163,7 @@ export function transformFunctionBody(
     scope.node = node;
     let bodyStatements = transformFunctionBodyContent(context, body);
     if (node && isAsyncFunction(node)) {
-        bodyStatements = wrapInAsyncAwaiter(context, bodyStatements);
+        bodyStatements = [lua.createReturnStatement([wrapInAsyncAwaiter(context, bodyStatements)])];
     }
     const headerStatements = transformFunctionBodyHeader(context, scope, parameters, spreadIdentifier);
     popScope(context);

--- a/src/transformation/visitors/return.ts
+++ b/src/transformation/visitors/return.ts
@@ -85,7 +85,7 @@ export function createReturnStatement(
 ): lua.ReturnStatement {
     const results = [...values];
 
-    if (isInTryCatch(context)) {
+    if (isInTryCatch(context) && !isInAsyncFunction(node)) {
         // Bubble up explicit return flag and check if we're inside a try/catch block
         results.unshift(lua.createBooleanLiteral(true));
     } else if (isInAsyncFunction(node)) {

--- a/src/transformation/visitors/return.ts
+++ b/src/transformation/visitors/return.ts
@@ -88,7 +88,7 @@ export function createReturnStatement(
     if (isInTryCatch(context) && !isInAsyncFunction(node)) {
         // Bubble up explicit return flag and check if we're inside a try/catch block
         results.unshift(lua.createBooleanLiteral(true));
-    } else if (isInAsyncFunction(node)) {
+    } else if (isInAsyncFunction(node) && !isInCatch(context)) {
         // Add nil error handler in async function and not in try
         results.unshift(lua.createNilLiteral());
     }
@@ -110,4 +110,20 @@ function isInTryCatch(context: TransformationContext): boolean {
     }
 
     return insideTryCatch;
+}
+
+function isInCatch(context: TransformationContext): boolean {
+        // Check if context is in a try or catch
+        let insideCatch = false;
+        for (const scope of walkScopesUp(context)) {
+            scope.functionReturned = true;
+
+            if (scope.type === ScopeType.Function) {
+                break;
+            }
+
+            insideCatch = insideCatch || scope.type === ScopeType.Catch;
+        }
+
+        return insideCatch;
 }

--- a/test/unit/builtins/async-await.spec.ts
+++ b/test/unit/builtins/async-await.spec.ts
@@ -699,7 +699,7 @@ describe("try/catch in async function", () => {
     });
 
     // https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1272
-    test.only("Awaiting a rejecting promise should halt function execution (#1272)", () => {
+    test("Awaiting a rejecting promise should halt function execution (#1272)", () => {
         util.testModule`
             let rej: (error: any) => void = () => {};
             const foo = () => new Promise((_, reject) => {
@@ -757,7 +757,11 @@ describe("try/catch in async function", () => {
                 try {
                     throw "throw 2"; // Another throw
                 } catch (err) {
-                    return err; // Async function should exit here
+                    try {
+                        await foo();
+                    } catch (err2) {
+                        return \`caught: \${err}, then: \${err2}\`; // Async function should exit here
+                    }
                 }
                 halted = false; // This code should not be called
                 return 10;
@@ -778,7 +782,7 @@ describe("try/catch in async function", () => {
                 caught: "catch err: Error: foo error",
                 succeeded: true,
                 rejected: false,
-                value: "throw 2",
+                value: "caught: throw 2, then: Error: foo error",
             },
         });
     });

--- a/test/unit/builtins/async-await.spec.ts
+++ b/test/unit/builtins/async-await.spec.ts
@@ -648,8 +648,6 @@ describe("try/catch in async function", () => {
             }
 
             receive().then(v => {
-                // @ts-ignore
-                print("then", v);
                 log(v);
             });
 


### PR DESCRIPTION
Fixed functions not correctly halting after await  failed due to rejected promise. Got rid of previous weird rejection handler passing in favor of making Try/Catch blocks their own async blocks where catch is in the `.catch` of the async awaiter.

Fixes #1272 

Example:
```ts
            const run = async () => {
                try {
                    await foo();
                    halted = false;
                } catch (err) {
                    caught = 'catch err: ' + err;
                } finally {
                    finallyCalled = true;
                }
            };
```
Translates to:
```lua
      local function run()
          return __TS__AsyncAwaiter(function(____awaiter_resolve)
              local ____try = __TS__AsyncAwaiter(function()
                  __TS__Await(foo(nil))
                  halted = false
              end)
              ____try.finally(
                  ____try,
                  function()
                      finallyCalled = true
                  end
              )
              __TS__Await(____try.catch(
                  ____try,
                  function(____, err)
                      caught = "catch err: " .. tostring(err)
                  end
              ))
          end)
      end
```