### PR TITLE
Fix methods with non-null operator not being detected as methods

### DIFF
--- a/src/transformation/builtins/math.ts
+++ b/src/transformation/builtins/math.ts
@@ -4,7 +4,7 @@ import * as lua from "../../LuaAST";
 import { TransformationContext } from "../context";
 import { unsupportedProperty } from "../utils/diagnostics";
 import { LuaLibFeature, transformLuaLibFunction } from "../utils/lualib";
-import { PropertyCallExpression, transformArguments } from "../visitors/call";
+import { transformArguments } from "../visitors/call";
 
 export function transformMathProperty(
     context: TransformationContext,
@@ -33,14 +33,14 @@ export function transformMathProperty(
 
 export function transformMathCall(
     context: TransformationContext,
-    node: PropertyCallExpression
+    node: ts.CallExpression,
+    calledMethod: ts.PropertyAccessExpression
 ): lua.Expression | undefined {
-    const expression = node.expression;
     const signature = context.checker.getResolvedSignature(node);
     const params = transformArguments(context, node.arguments, signature);
     const math = lua.createIdentifier("math");
 
-    const expressionName = expression.name.text;
+    const expressionName = calledMethod.name.text;
     switch (expressionName) {
         // Lua 5.3: math.atan(y, x)
         // Otherwise: math.atan2(y, x)
@@ -107,6 +107,6 @@ export function transformMathCall(
         }
 
         default:
-            context.diagnostics.push(unsupportedProperty(expression.name, "Math", expressionName));
+            context.diagnostics.push(unsupportedProperty(calledMethod.name, "Math", expressionName));
     }
 }

--- a/src/transformation/builtins/object.ts
+++ b/src/transformation/builtins/object.ts
@@ -3,56 +3,56 @@ import * as ts from "typescript";
 import { TransformationContext } from "../context";
 import { unsupportedProperty } from "../utils/diagnostics";
 import { LuaLibFeature, transformLuaLibFunction } from "../utils/lualib";
-import { PropertyCallExpression, transformArguments } from "../visitors/call";
+import { transformArguments } from "../visitors/call";
 
 export function transformObjectConstructorCall(
     context: TransformationContext,
-    expression: PropertyCallExpression
+    node: ts.CallExpression,
+    calledMethod: ts.PropertyAccessExpression
 ): lua.Expression | undefined {
-    const method = expression.expression;
-    const args = transformArguments(context, expression.arguments);
-    const methodName = method.name.text;
+    const args = transformArguments(context, node.arguments);
+    const methodName = calledMethod.name.text;
 
     switch (methodName) {
         case "assign":
-            return transformLuaLibFunction(context, LuaLibFeature.ObjectAssign, expression, ...args);
+            return transformLuaLibFunction(context, LuaLibFeature.ObjectAssign, node, ...args);
         case "defineProperty":
-            return transformLuaLibFunction(context, LuaLibFeature.ObjectDefineProperty, expression, ...args);
+            return transformLuaLibFunction(context, LuaLibFeature.ObjectDefineProperty, node, ...args);
         case "entries":
-            return transformLuaLibFunction(context, LuaLibFeature.ObjectEntries, expression, ...args);
+            return transformLuaLibFunction(context, LuaLibFeature.ObjectEntries, node, ...args);
         case "fromEntries":
-            return transformLuaLibFunction(context, LuaLibFeature.ObjectFromEntries, expression, ...args);
+            return transformLuaLibFunction(context, LuaLibFeature.ObjectFromEntries, node, ...args);
         case "getOwnPropertyDescriptor":
-            return transformLuaLibFunction(context, LuaLibFeature.ObjectGetOwnPropertyDescriptor, expression, ...args);
+            return transformLuaLibFunction(context, LuaLibFeature.ObjectGetOwnPropertyDescriptor, node, ...args);
         case "getOwnPropertyDescriptors":
-            return transformLuaLibFunction(context, LuaLibFeature.ObjectGetOwnPropertyDescriptors, expression, ...args);
+            return transformLuaLibFunction(context, LuaLibFeature.ObjectGetOwnPropertyDescriptors, node, ...args);
         case "keys":
-            return transformLuaLibFunction(context, LuaLibFeature.ObjectKeys, expression, ...args);
+            return transformLuaLibFunction(context, LuaLibFeature.ObjectKeys, node, ...args);
         case "values":
-            return transformLuaLibFunction(context, LuaLibFeature.ObjectValues, expression, ...args);
+            return transformLuaLibFunction(context, LuaLibFeature.ObjectValues, node, ...args);
         default:
-            context.diagnostics.push(unsupportedProperty(method.name, "Object", methodName));
+            context.diagnostics.push(unsupportedProperty(calledMethod.name, "Object", methodName));
     }
 }
 
 export function transformObjectPrototypeCall(
     context: TransformationContext,
     node: ts.CallExpression,
-    expression: ts.PropertyAccessExpression
+    calledMethod: ts.PropertyAccessExpression
 ): lua.Expression | undefined {
     const signature = context.checker.getResolvedSignature(node);
 
-    const name = expression.name.text;
+    const name = calledMethod.name.text;
     switch (name) {
         case "toString":
             const toStringIdentifier = lua.createIdentifier("tostring");
             return lua.createCallExpression(
                 toStringIdentifier,
-                [context.transformExpression(expression.expression)],
+                [context.transformExpression(calledMethod.expression)],
                 node
             );
         case "hasOwnProperty":
-            const expr = context.transformExpression(expression.expression);
+            const expr = context.transformExpression(calledMethod.expression);
             const parameters = transformArguments(context, node.arguments, signature);
             const rawGetIdentifier = lua.createIdentifier("rawget");
             const rawGetCall = lua.createCallExpression(rawGetIdentifier, [expr, ...parameters]);

--- a/src/transformation/builtins/string.ts
+++ b/src/transformation/builtins/string.ts
@@ -4,7 +4,7 @@ import { TransformationContext } from "../context";
 import { unsupportedProperty } from "../utils/diagnostics";
 import { addToNumericExpression, createNaN, getNumberLiteralValue, wrapInTable } from "../utils/lua-ast";
 import { LuaLibFeature, transformLuaLibFunction } from "../utils/lualib";
-import { PropertyCallExpression, transformArguments, transformCallAndArguments } from "../visitors/call";
+import { transformArguments, transformCallAndArguments } from "../visitors/call";
 
 function createStringCall(methodName: string, tsOriginal: ts.Node, ...params: lua.Expression[]): lua.CallExpression {
     const stringIdentifier = lua.createIdentifier("string");
@@ -17,13 +17,13 @@ function createStringCall(methodName: string, tsOriginal: ts.Node, ...params: lu
 
 export function transformStringPrototypeCall(
     context: TransformationContext,
-    node: PropertyCallExpression
+    node: ts.CallExpression,
+    calledMethod: ts.PropertyAccessExpression
 ): lua.Expression | undefined {
-    const expression = node.expression;
     const signature = context.checker.getResolvedSignature(node);
-    const [caller, params] = transformCallAndArguments(context, expression.expression, node.arguments, signature);
+    const [caller, params] = transformCallAndArguments(context, calledMethod.expression, node.arguments, signature);
 
-    const expressionName = expression.name.text;
+    const expressionName = calledMethod.name.text;
     switch (expressionName) {
         case "replace":
             return transformLuaLibFunction(context, LuaLibFeature.StringReplace, node, caller, ...params);
@@ -146,19 +146,19 @@ export function transformStringPrototypeCall(
         case "padEnd":
             return transformLuaLibFunction(context, LuaLibFeature.StringPadEnd, node, caller, ...params);
         default:
-            context.diagnostics.push(unsupportedProperty(expression.name, "string", expressionName));
+            context.diagnostics.push(unsupportedProperty(calledMethod.name, "string", expressionName));
     }
 }
 
 export function transformStringConstructorCall(
     context: TransformationContext,
-    node: PropertyCallExpression
+    node: ts.CallExpression,
+    calledMethod: ts.PropertyAccessExpression
 ): lua.Expression | undefined {
-    const expression = node.expression;
     const signature = context.checker.getResolvedSignature(node);
     const params = transformArguments(context, node.arguments, signature);
 
-    const expressionName = expression.name.text;
+    const expressionName = calledMethod.name.text;
     switch (expressionName) {
         case "fromCharCode":
             return lua.createCallExpression(
@@ -168,7 +168,7 @@ export function transformStringConstructorCall(
             );
 
         default:
-            context.diagnostics.push(unsupportedProperty(expression.name, "String", expressionName));
+            context.diagnostics.push(unsupportedProperty(calledMethod.name, "String", expressionName));
     }
 }
 

--- a/src/transformation/visitors/call.ts
+++ b/src/transformation/visitors/call.ts
@@ -126,7 +126,7 @@ export function transformContextualCallExpression(
     if (ts.isOptionalChain(node)) {
         return transformOptionalChain(context, node);
     }
-    const left = ts.isCallExpression(node) ? node.expression : node.tag;
+    const left = ts.isCallExpression(node) ? getCalledExpression(node) : node.tag;
 
     let [argPrecedingStatements, transformedArguments] = transformInPrecedingStatementScope(context, () =>
         transformArguments(context, args, signature)
@@ -176,10 +176,14 @@ export function transformContextualCallExpression(
     }
 }
 
-function transformPropertyCall(context: TransformationContext, node: PropertyCallExpression): lua.Expression {
+function transformPropertyCall(
+    context: TransformationContext,
+    node: ts.CallExpression,
+    calledExpression: ts.PropertyAccessExpression
+): lua.Expression {
     const signature = context.checker.getResolvedSignature(node);
 
-    if (node.expression.expression.kind === ts.SyntaxKind.SuperKeyword) {
+    if (calledExpression.expression.kind === ts.SyntaxKind.SuperKeyword) {
         // Super calls take the format of super.call(self,...)
         const parameters = transformArguments(context, node.arguments, signature, ts.factory.createThis());
         return lua.createCallExpression(context.transformExpression(node.expression), parameters);
@@ -211,7 +215,9 @@ function transformElementCall(context: TransformationContext, node: ts.CallExpre
 }
 
 export const transformCallExpression: FunctionVisitor<ts.CallExpression> = (node, context) => {
-    if (node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+    const calledExpression = getCalledExpression(node);
+
+    if (calledExpression.kind === ts.SyntaxKind.ImportKeyword) {
         return transformImportExpression(node, context);
     }
 
@@ -219,8 +225,8 @@ export const transformCallExpression: FunctionVisitor<ts.CallExpression> = (node
         return transformOptionalChain(context, node);
     }
 
-    const optionalContinuation = ts.isIdentifier(node.expression)
-        ? getOptionalContinuationData(node.expression)
+    const optionalContinuation = ts.isIdentifier(calledExpression)
+        ? getOptionalContinuationData(calledExpression)
         : undefined;
     const wrapResultInTable = isMultiReturnCall(context, node) && shouldMultiReturnCallBeWrapped(context, node);
 
@@ -236,18 +242,18 @@ export const transformCallExpression: FunctionVisitor<ts.CallExpression> = (node
         return wrapResultInTable ? wrapInTable(builtinOrExtensionResult) : builtinOrExtensionResult;
     }
 
-    if (ts.isPropertyAccessExpression(node.expression)) {
-        const ownerType = context.checker.getTypeAtLocation(node.expression.expression);
+    if (ts.isPropertyAccessExpression(calledExpression)) {
+        const ownerType = context.checker.getTypeAtLocation(calledExpression.expression);
         const annotations = getTypeAnnotations(ownerType);
         if (annotations.has(AnnotationKind.LuaTable)) {
             context.diagnostics.push(annotationRemoved(node, AnnotationKind.LuaTable));
         }
 
-        const result = transformPropertyCall(context, node as PropertyCallExpression);
+        const result = transformPropertyCall(context, node, calledExpression);
         return wrapResultInTable ? wrapInTable(result) : result;
     }
 
-    if (ts.isElementAccessExpression(node.expression)) {
+    if (ts.isElementAccessExpression(calledExpression)) {
         const result = transformElementCall(context, node);
         return wrapResultInTable ? wrapInTable(result) : result;
     }
@@ -255,7 +261,7 @@ export const transformCallExpression: FunctionVisitor<ts.CallExpression> = (node
     const signature = context.checker.getResolvedSignature(node);
 
     // Handle super calls properly
-    if (node.expression.kind === ts.SyntaxKind.SuperKeyword) {
+    if (calledExpression.kind === ts.SyntaxKind.SuperKeyword) {
         const parameters = transformArguments(context, node.arguments, signature, ts.factory.createThis());
 
         return lua.createCallExpression(
@@ -274,14 +280,14 @@ export const transformCallExpression: FunctionVisitor<ts.CallExpression> = (node
     const isContextualCall =
         !signatureDeclaration || getDeclarationContextType(context, signatureDeclaration) !== ContextType.Void;
     if (!isContextualCall) {
-        [callPath, parameters] = transformCallAndArguments(context, node.expression, node.arguments, signature);
+        [callPath, parameters] = transformCallAndArguments(context, calledExpression, node.arguments, signature);
     } else {
         // if is optionalContinuation, context will be handled by transformOptionalChain.
         const useGlobalContext = !context.isStrict && optionalContinuation === undefined;
         const callContext = useGlobalContext ? ts.factory.createIdentifier("_G") : ts.factory.createNull();
         [callPath, parameters] = transformCallAndArguments(
             context,
-            node.expression,
+            calledExpression,
             node.arguments,
             signature,
             callContext
@@ -294,3 +300,11 @@ export const transformCallExpression: FunctionVisitor<ts.CallExpression> = (node
     }
     return wrapResultInTable ? wrapInTable(callExpression) : callExpression;
 };
+
+function getCalledExpression(node: ts.CallExpression): ts.Expression {
+    function unwrapExpression(expression: ts.Expression): ts.Expression {
+        expression = ts.skipOuterExpressions(expression);
+        return ts.isNonNullExpression(expression) ? unwrapExpression(expression.expression) : expression;
+    }
+    return unwrapExpression(node.expression);
+}

--- a/src/transformation/visitors/call.ts
+++ b/src/transformation/visitors/call.ts
@@ -17,8 +17,6 @@ import { getOptionalContinuationData, transformOptionalChain } from "./optional-
 import { transformLanguageExtensionCallExpression } from "./language-extensions";
 import { transformImportExpression } from "./modules/import";
 
-export type PropertyCallExpression = ts.CallExpression & { expression: ts.PropertyAccessExpression };
-
 export function validateArguments(
     context: TransformationContext,
     params: readonly ts.Expression[],
@@ -179,11 +177,11 @@ export function transformContextualCallExpression(
 function transformPropertyCall(
     context: TransformationContext,
     node: ts.CallExpression,
-    calledExpression: ts.PropertyAccessExpression
+    calledMethod: ts.PropertyAccessExpression
 ): lua.Expression {
     const signature = context.checker.getResolvedSignature(node);
 
-    if (calledExpression.expression.kind === ts.SyntaxKind.SuperKeyword) {
+    if (calledMethod.expression.kind === ts.SyntaxKind.SuperKeyword) {
         // Super calls take the format of super.call(self,...)
         const parameters = transformArguments(context, node.arguments, signature, ts.factory.createThis());
         return lua.createCallExpression(context.transformExpression(node.expression), parameters);
@@ -301,7 +299,7 @@ export const transformCallExpression: FunctionVisitor<ts.CallExpression> = (node
     return wrapResultInTable ? wrapInTable(callExpression) : callExpression;
 };
 
-function getCalledExpression(node: ts.CallExpression): ts.Expression {
+export function getCalledExpression(node: ts.CallExpression): ts.Expression {
     function unwrapExpression(expression: ts.Expression): ts.Expression {
         expression = ts.skipOuterExpressions(expression);
         return ts.isNonNullExpression(expression) ? unwrapExpression(expression.expression) : expression;

--- a/test/unit/functions/functions.spec.ts
+++ b/test/unit/functions/functions.spec.ts
@@ -268,6 +268,14 @@ test("Object method declaration", () => {
     `.expectToMatchJsResult();
 });
 
+// https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1266
+test("Object method declaration used with non-null operator (#1266)", () => {
+    util.testFunction`
+        let o = { v: 4, m(i: number): number { return this.v * i; } };
+        return o.m!(3);
+    `.expectToMatchJsResult();
+});
+
 test.each([
     { args: ["bar"], expected: "foobar" },
     { args: ["baz", "bar"], expected: "bazbar" },


### PR DESCRIPTION
`obj.method!()` was not being detected as method call because `obj.method!` is not a property access expression. Fixed it by unwrapping the called expression when handling call expressions.

Fixes #1266 