### PR TITLE
Fixed a bug where call expressions would get an incorrect context parameter

### DIFF
--- a/src/transformation/visitors/call.ts
+++ b/src/transformation/visitors/call.ts
@@ -288,7 +288,8 @@ export const transformCallExpression: FunctionVisitor<ts.CallExpression> = (node
             calledExpression,
             node.arguments,
             signature,
-            callContext
+            // Only pass context if noImplicitSelf is not configured
+            context.options.noImplicitSelf ? undefined : callContext
         );
     }
 

--- a/test/unit/jsx.spec.ts
+++ b/test/unit/jsx.spec.ts
@@ -288,6 +288,18 @@ describe("jsx", () => {
             .addExtraFile("myJsx.ts", customJsxLib)
             .expectToMatchJsResult();
     });
+    test("custom JSX factory with noImplicitSelf", () => {
+        testJsx`
+            return <a><b>c</b></a>
+        `
+            .setTsHeader(
+                `function createElement(tag: string | Function, props: { [key: string]: string | boolean }, ...children: any[]) {
+                return { tag, children };
+            }`
+            )
+            .setOptions({ jsxFactory: "createElement", noImplicitSelf: true })
+            .expectToMatchJsResult();
+    });
     test("custom fragment factory", () => {
         testJsx`
             return <><b>c</b></>


### PR DESCRIPTION
Fixes #1262 