### PR TITLE
Reduce use of temp variables

### DIFF
--- a/src/transformation/visitors/expression-list.ts
+++ b/src/transformation/visitors/expression-list.ts
@@ -11,7 +11,12 @@ export function shouldMoveToTemp(context: TransformationContext, expression: lua
     return (
         !lua.isLiteral(expression) &&
         !(lua.isIdentifier(expression) && expression.symbolId === tempSymbolId) && // Treat generated temps as consts
-        !(tsOriginal && (isConstIdentifier(context, tsOriginal) || isOptionalContinuation(tsOriginal)))
+        !(
+            tsOriginal &&
+            (isConstIdentifier(context, tsOriginal) ||
+                isOptionalContinuation(tsOriginal) ||
+                tsOriginal.kind === ts.SyntaxKind.ThisKeyword)
+        )
     );
 }
 

--- a/src/transformation/visitors/variable-declaration.ts
+++ b/src/transformation/visitors/variable-declaration.ts
@@ -167,9 +167,7 @@ export function transformBindingVariableDeclaration(
 
     if (ts.isObjectBindingPattern(bindingPattern) || bindingPattern.elements.some(isComplexBindingElement)) {
         let table: lua.Expression;
-        if (initializer !== undefined && ts.isIdentifier(initializer)) {
-            table = transformIdentifier(context, initializer);
-        } else if (initializer) {
+        if (initializer) {
             // Contain the expression in a temporary variable
             let expression = context.transformExpression(initializer);
             if (isMultiReturnCall(context, initializer)) {

--- a/src/transformation/visitors/variable-declaration.ts
+++ b/src/transformation/visitors/variable-declaration.ts
@@ -12,6 +12,7 @@ import { createCallableTable, isFunctionTypeWithProperties } from "./function";
 import { transformIdentifier } from "./identifier";
 import { isMultiReturnCall } from "./language-extensions/multi";
 import { transformPropertyName } from "./literal";
+import { moveToPrecedingTemp } from "./expression-list";
 
 export function transformArrayBindingElement(
     context: TransformationContext,
@@ -38,7 +39,7 @@ export function transformArrayBindingElement(
 export function transformBindingPattern(
     context: TransformationContext,
     pattern: ts.BindingPattern,
-    table: lua.Identifier,
+    table: lua.Expression,
     propertyAccessStack: ts.PropertyName[] = []
 ): lua.Statement[] {
     const result: lua.Statement[] = [];
@@ -165,21 +166,22 @@ export function transformBindingVariableDeclaration(
         ts.isBindingElement(e) && (!ts.isIdentifier(e.name) || e.dotDotDotToken);
 
     if (ts.isObjectBindingPattern(bindingPattern) || bindingPattern.elements.some(isComplexBindingElement)) {
-        let table: lua.Identifier;
+        let table: lua.Expression;
         if (initializer !== undefined && ts.isIdentifier(initializer)) {
             table = transformIdentifier(context, initializer);
-        } else {
+        } else if (initializer) {
             // Contain the expression in a temporary variable
-            if (initializer) {
-                table = context.createTempNameForNode(initializer);
-                let expression = context.transformExpression(initializer);
-                if (isMultiReturnCall(context, initializer)) {
-                    expression = wrapInTable(expression);
-                }
-                statements.push(lua.createVariableDeclarationStatement(table, expression));
-            } else {
-                table = lua.createAnonymousIdentifier();
+            let expression = context.transformExpression(initializer);
+            if (isMultiReturnCall(context, initializer)) {
+                expression = wrapInTable(expression);
             }
+            const [moveStatements, movedExpr] = transformInPrecedingStatementScope(context, () =>
+                moveToPrecedingTemp(context, expression, initializer)
+            );
+            statements.push(...moveStatements);
+            table = movedExpr;
+        } else {
+            table = lua.createAnonymousIdentifier();
         }
         statements.push(...transformBindingPattern(context, bindingPattern, table));
         return statements;

--- a/test/translation/__snapshots__/transformation.spec.ts.snap
+++ b/test/translation/__snapshots__/transformation.spec.ts.snap
@@ -269,7 +269,8 @@ value1 = obj.value1
 value2 = obj.value2
 obj2 = {value3 = 1, value4 = 2}
 value3 = obj2.value3
-value4 = obj2.value4
+local ____obj2_0 = obj2
+value4 = ____obj2_0.value4
 function fun1(self)
 end
 fun2 = function()

--- a/test/unit/destructuring.spec.ts
+++ b/test/unit/destructuring.spec.ts
@@ -74,6 +74,28 @@ test.each(testCases)("in variable declaration (%p)", ({ binding, value }) => {
     `.expectToMatchJsResult();
 });
 
+test.each(testCases)("in variable declaration from const variable (%p)", ({ binding, value }) => {
+    util.testFunction`
+        let ${allBindings};
+        {
+            const v: any = ${value};
+            const ${binding} = v;
+            return { ${allBindings} };
+        }
+   `.expectToMatchJsResult();
+});
+
+test.each(testCases)("in variable declaration from this (%p)", ({ binding, value }) => {
+    util.testFunction`
+        let ${allBindings};
+        function test(this: any) {
+            const ${binding} = this;
+            return { ${allBindings} };
+        }
+        return test.call(${value});
+    `.expectToMatchJsResult();
+});
+
 test.each(testCases)("in exported variable declaration (%p)", ({ binding, value }) => {
     util.testModule`
         export const ${binding} = ${value};
@@ -98,6 +120,28 @@ test.each(assignmentTestCases)("in assignment expression (%p)", ({ binding, valu
         const obj = { prop: false };
         const expressionResult = (${binding} = ${value});
         return { ${allBindings}, obj, expressionResult };
+    `.expectToMatchJsResult();
+});
+
+test.each(assignmentTestCases)("in assignment expression from const variable (%p)", ({ binding, value }) => {
+    util.testFunction`
+        let ${allBindings};
+        const obj = { prop: false };
+        const v: any = ${value};
+        const expressionResult = (${binding} = v);
+        return { ${allBindings}, expressionResult };
+    `.expectToMatchJsResult();
+});
+
+test.each(assignmentTestCases)("in assignment expression from this (%p)", ({ binding, value }) => {
+    util.testFunction`
+        let ${allBindings};
+        const obj = { prop: false };
+        function test(this: any) {
+            const expressionResult = (${binding} = this);
+            return { ${allBindings}, obj, expressionResult };
+        }
+        return test.call(${value});
     `.expectToMatchJsResult();
 });
 

--- a/test/unit/language-extensions/__snapshots__/multi.spec.ts.snap
+++ b/test/unit/language-extensions/__snapshots__/multi.spec.ts.snap
@@ -61,7 +61,7 @@ end"
 
 exports[`invalid $multi call (const [a = 0] = $multi()): diagnostics 1`] = `"main.ts(2,25): error TSTL: The $multi function must be called in a return statement."`;
 
-exports[`invalid $multi call (const {} = $multi();): code 1`] = `"local _____24multi_result_0 = {{____(_G)}}"`;
+exports[`invalid $multi call (const {} = $multi();): code 1`] = `"local ____temp_0 = {{____(_G)}}"`;
 
 exports[`invalid $multi call (const {} = $multi();): diagnostics 1`] = `"main.ts(2,20): error TSTL: The $multi function must be called in a return statement."`;
 
@@ -219,10 +219,10 @@ local function multi(self, ...)
     return ...
 end
 local a
-local _____24multi_result_0 = {____(nil, 1)}
-a = _____24multi_result_0[1]
+local ____temp_0 = {____(nil, 1)}
+a = ____temp_0[1]
 ____exports.a = a
-if _____24multi_result_0 then
+if ____temp_0 then
     a = a + 1
     ____exports.a = a
 end


### PR DESCRIPTION
This reduces the use of temp variables by using `moveToPrecedingTemp` instead of always using a temp. This was done for some cases of assigment and in destructuring declarations.

Additionally, the `this` keyword (which is read-only) is no longer moved to a temp variable.