### PR TITLE
Fix call context

### DIFF
--- a/src/typescript-internal.d.ts
+++ b/src/typescript-internal.d.ts
@@ -28,6 +28,8 @@ declare module "typescript" {
 
     function transformJsx(context: TransformationContext): (x: SourceFile) => SourceFile;
 
+    function nodeIsSynthesized(range: TextRange): boolean;
+
     export type OuterExpression =
         | ParenthesizedExpression
         | TypeAssertion

--- a/test/unit/functions/noImplicitSelfOption.spec.ts
+++ b/test/unit/functions/noImplicitSelfOption.spec.ts
@@ -67,3 +67,17 @@ test("generates declaration files with @noSelfInFile", () => {
         .ignoreDiagnostics([couldNotResolveRequire.code]) // no foo implementation in the project to create foo.lua
         .expectToHaveNoDiagnostics();
 });
+
+// https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1292
+test("explicit this parameter respected over noImplicitSelf", () => {
+    util.testModule`
+        function foo(this: unknown, arg: any) {
+            return {self: this, arg};
+        }
+        export const result = foo(1);
+    `
+        .setOptions({
+            noImplicitSelf: true,
+        })
+        .expectToMatchJsResult();
+});

--- a/test/unit/functions/noSelfAnnotation.spec.ts
+++ b/test/unit/functions/noSelfAnnotation.spec.ts
@@ -51,3 +51,14 @@ test("@noSelf on parent namespace declaration removes context argument", () => {
         MyNamespace.myMethod();
     `.expectLuaToMatchSnapshot();
 });
+
+// additional coverage for https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1292
+test("explicit this parameter respected over @noSelf", () => {
+    util.testModule`
+        /** @noSelfInFile */
+        function foo(this: unknown, arg: any) {
+            return {self: this, arg};
+        }
+        export const result = foo(1);
+    `.expectToMatchJsResult();
+});


### PR DESCRIPTION
Fixes #1292, which was broken by #1282 

To still keep #1262, I couldn't find an elegant way to detect jsx createElement calls specifically. Instead I found a condition that tells if a call is _probably_ jsx createElement (see changes in call.ts).

Maybe the best thing to do is to actually revert #1282, and document that the `this` parameter is _always_ required for jsx `createElement`.