### PR TITLE
Fix chained promise resolves not correctly passing value

### DIFF
--- a/src/LuaPrinter.ts
+++ b/src/LuaPrinter.ts
@@ -241,6 +241,7 @@ export class LuaPrinter {
             // Inline lualib features
             sourceChunks.push("-- Lua Library inline imports\n");
             sourceChunks.push(loadInlineLualibFeatures(file.luaLibFeatures, this.emitHost));
+            sourceChunks.push("-- End of Lua Library inline imports\n");
         }
 
         if (this.options.sourceMapTraceback && !isBundleEnabled(this.options)) {

--- a/src/lualib/Promise.ts
+++ b/src/lualib/Promise.ts
@@ -85,7 +85,7 @@ export class __TS__Promise<T> implements Promise<T> {
             }
         } else {
             // We always want to resolve our child promise if this promise is resolved, even if we have no handler
-            this.fulfilledCallbacks.push(() => resolve(undefined));
+            this.fulfilledCallbacks.push(v => resolve(v));
         }
 
         if (onRejected) {
@@ -96,6 +96,9 @@ export class __TS__Promise<T> implements Promise<T> {
                 // If promise already rejected, immediately call callback
                 internalCallback(this.rejectionReason);
             }
+        } else {
+            // We always want to reject our child promise if this promise is rejected, even if we have no handler
+            this.rejectedCallbacks.push(err => reject(err));
         }
 
         if (isFulfilled) {

--- a/test/unit/builtins/promise.spec.ts
+++ b/test/unit/builtins/promise.spec.ts
@@ -523,6 +523,34 @@ test("chained then throws", () => {
         ]);
 });
 
+test("empty then resolves", () => {
+    util.testFunction`
+    const { promise, resolve } = defer<string>();
+
+    promise.then().then(v => { log("then2", v) });
+
+    resolve("mydata");
+
+    return allLogs;
+    `
+        .setTsHeader(promiseTestLib)
+        .expectToEqual(["then2", "mydata"]);
+});
+
+test("empty then rejects", () => {
+    util.testFunction`
+    const { promise, reject } = defer<string>();
+
+    promise.then().catch(err => { log("catch", err) });
+
+    reject("my error");
+
+    return allLogs;
+    `
+        .setTsHeader(promiseTestLib)
+        .expectToEqual(["catch", "my error"]);
+});
+
 test("catch on rejected promise immediately calls callback", () => {
     util.testFunction`
         Promise.reject("already rejected").catch(reason => { log(reason); });
@@ -592,7 +620,7 @@ describe("finally behaves same as then/catch", () => {
                 log("final code");
             })
             .catch(reason => {
-                log("handling error", data);
+                log("handling error", reason);
                 log("final code");
             });
     `;


### PR DESCRIPTION
This happens when one or both of the then() callbacks are undefined.