### PR TITLE
Support arrays in CLI arguments

### DIFF
--- a/src/cli/diagnostics.ts
+++ b/src/cli/diagnostics.ts
@@ -33,6 +33,11 @@ export const compilerOptionRequiresAValueOfType = createCommandLineError(
     (name: string, type: string) => `Compiler option '${name}' requires a value of type ${type}.`
 );
 
+export const compilerOptionCouldNotParseJson = createCommandLineError(
+    5025,
+    (name: string, error: string) => `Compiler option '${name}' failed to parse the given JSON value: '${error}'.`
+);
+
 export const optionProjectCannotBeMixedWithSourceFilesOnACommandLine = createCommandLineError(
     5042,
     () => "Option 'project' cannot be mixed with source files on a command line."

--- a/src/cli/parse.ts
+++ b/src/cli/parse.ts
@@ -232,11 +232,9 @@ function readValue(option: CommandLineOption, value: unknown, isFromCli: boolean
             }
 
             if (isFromCli && typeof value === "string") {
-                const array = value.split(",");
-
                 if (option.type === "array-of-objects") {
                     try {
-                        const objects = array.map(s => JSON.parse(s));
+                        const objects = JSON.parse(value);
                         return { value: objects };
                     } catch (e) {
                         if (!(e instanceof SyntaxError)) throw e;
@@ -248,6 +246,7 @@ function readValue(option: CommandLineOption, value: unknown, isFromCli: boolean
                     }
                 }
 
+                const array = value.split(",");
                 return { value: array };
             }
 

--- a/test/cli/parse.spec.ts
+++ b/test/cli/parse.spec.ts
@@ -132,8 +132,8 @@ describe("command line", () => {
             ["extension", ".lua", { extension: ".lua" }],
             ["extension", "scar", { extension: "scar" }],
 
-            ["luaPlugins", '{ "name": "a" }', { luaPlugins: [{ name: "a" }] }],
-            ["luaPlugins", '{ "name": "a" },{ "name": "b" }', { luaPlugins: [{ name: "a" }, { name: "b" }] }],
+            ["luaPlugins", '[{ "name": "a" }]', { luaPlugins: [{ name: "a" }] }],
+            ["luaPlugins", '[{ "name": "a" },{ "name": "b" }]', { luaPlugins: [{ name: "a" }, { name: "b" }] }],
 
             ["noResolvePaths", "path1", { noResolvePaths: ["path1"] }],
             ["noResolvePaths", "path1,path2", { noResolvePaths: ["path1", "path2"] }],

--- a/test/cli/parse.spec.ts
+++ b/test/cli/parse.spec.ts
@@ -57,6 +57,12 @@ describe("command line", () => {
 
             expect(result.errors).toHaveDiagnostics();
         });
+
+        test("should error on invalid value", () => {
+            const result = tstl.parseCommandLine(["--luaPlugins", "{"]);
+
+            expect(result.errors).toHaveDiagnostics();
+        });
     });
 
     describe("boolean options", () => {
@@ -126,6 +132,10 @@ describe("command line", () => {
             ["extension", ".lua", { extension: ".lua" }],
             ["extension", "scar", { extension: "scar" }],
 
+            ["luaPlugins", '{ "name": "a" }', { luaPlugins: [{ name: "a" }] }],
+            ["luaPlugins", '{ "name": "a" },{ "name": "b" }', { luaPlugins: [{ name: "a" }, { name: "b" }] }],
+
+            ["noResolvePaths", "path1", { noResolvePaths: ["path1"] }],
             ["noResolvePaths", "path1,path2", { noResolvePaths: ["path1", "path2"] }],
         ])("--%s %s", (optionName, value, expected) => {
             const result = tstl.parseCommandLine([`--${optionName}`, value]);

--- a/test/cli/parse.spec.ts
+++ b/test/cli/parse.spec.ts
@@ -125,6 +125,8 @@ describe("command line", () => {
 
             ["extension", ".lua", { extension: ".lua" }],
             ["extension", "scar", { extension: "scar" }],
+
+            ["noResolvePaths", "path1,path2", { noResolvePaths: ["path1", "path2"] }],
         ])("--%s %s", (optionName, value, expected) => {
             const result = tstl.parseCommandLine([`--${optionName}`, value]);
 

--- a/test/cli/parse.spec.ts
+++ b/test/cli/parse.spec.ts
@@ -57,9 +57,11 @@ describe("command line", () => {
 
             expect(result.errors).toHaveDiagnostics();
         });
+    });
 
-        test("should error on invalid value", () => {
-            const result = tstl.parseCommandLine(["--luaPlugins", "{"]);
+    describe("array-of-objects options", () => {
+        test.each([["{"], ["{}"], ["0"], ["''"]])("should error on invalid value (%s)", value => {
+            const result = tstl.parseCommandLine(["--luaPlugins", value]);
 
             expect(result.errors).toHaveDiagnostics();
         });


### PR DESCRIPTION
Closes #1267

Allows TSTL to receive arrays for its parameters via the CLI from a comma separated value

```
tstl -p tsconfig.json --noResolvePaths patha,pathb
```

Let me know if there's some other edge cases I may be missing

Edit:
Also supporting arrays of objects parameters (only effects `luaPlugins`) by parsing a JSON array instead of a comma separated string

```
tstl -p tsconfig.json --luaPlugins '[{ "name": "my-plugin" }]'
```