### PR TITLE
Get preEmit diagnostics from TypeScript before transforming

### DIFF
--- a/src/transpilation/index.ts
+++ b/src/transpilation/index.ts
@@ -19,11 +19,9 @@ export function transpileFiles(
     writeFile?: ts.WriteFileCallback
 ): EmitResult {
     const program = ts.createProgram(rootNames, options);
+    const preEmitDiagnostics = ts.getPreEmitDiagnostics(program);
     const { diagnostics: transpileDiagnostics, emitSkipped } = new Transpiler().emit({ program, writeFile });
-    const diagnostics = ts.sortAndDeduplicateDiagnostics([
-        ...ts.getPreEmitDiagnostics(program),
-        ...transpileDiagnostics,
-    ]);
+    const diagnostics = ts.sortAndDeduplicateDiagnostics([...preEmitDiagnostics, ...transpileDiagnostics]);
 
     return { diagnostics: [...diagnostics], emitSkipped };
 }
@@ -98,12 +96,10 @@ export function transpileVirtualProject(
     options: CompilerOptions = {}
 ): TranspileVirtualProjectResult {
     const program = createVirtualProgram(files, options);
+    const preEmitDiagnostics = ts.getPreEmitDiagnostics(program);
     const collector = createEmitOutputCollector();
     const { diagnostics: transpileDiagnostics } = new Transpiler().emit({ program, writeFile: collector.writeFile });
-    const diagnostics = ts.sortAndDeduplicateDiagnostics([
-        ...ts.getPreEmitDiagnostics(program),
-        ...transpileDiagnostics,
-    ]);
+    const diagnostics = ts.sortAndDeduplicateDiagnostics([...preEmitDiagnostics, ...transpileDiagnostics]);
 
     return { diagnostics: [...diagnostics], transpiledFiles: collector.files };
 }

--- a/src/tstl.ts
+++ b/src/tstl.ts
@@ -102,12 +102,11 @@ function performCompilation(
         configFileParsingDiagnostics,
     });
 
+    const preEmitDiagnostics = ts.getPreEmitDiagnostics(program);
+
     const { diagnostics: transpileDiagnostics, emitSkipped } = new tstl.Transpiler().emit({ program });
 
-    const diagnostics = ts.sortAndDeduplicateDiagnostics([
-        ...ts.getPreEmitDiagnostics(program),
-        ...transpileDiagnostics,
-    ]);
+    const diagnostics = ts.sortAndDeduplicateDiagnostics([...preEmitDiagnostics, ...transpileDiagnostics]);
 
     diagnostics.forEach(reportDiagnostic);
     const exitCode =

--- a/test/unit/comments.spec.ts
+++ b/test/unit/comments.spec.ts
@@ -93,3 +93,23 @@ test("JSDoc is copied on a variable", () => {
     expect(lua).toBeDefined();
     expect(lua).toContain("This is a variable comment.");
 });
+
+// https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1299
+test("tsdoc comment does not cause a diagnostic (#1299)", () => {
+    util.testModule`
+        interface LuaBootstrap {
+            /**
+             * @remarks
+             *
+             * Links can point to a URL: {@link https://github.com/microsoft/tsdoc}
+             */
+            on_init(f: (() => void) ): void
+        }
+
+        const script : LuaBootstrap = {
+            on_init: (x) => x()
+        }
+
+        script.on_init(() => {})
+    `.expectToHaveNoDiagnostics();
+});

--- a/test/util.ts
+++ b/test/util.ts
@@ -223,6 +223,7 @@ export abstract class TestBuilder {
     @memoize
     public getLuaResult(): tstl.TranspileVirtualProjectResult {
         const program = this.getProgram();
+        const preEmitDiagnostics = ts.getPreEmitDiagnostics(program);
         const collector = createEmitOutputCollector();
         const { diagnostics: transpileDiagnostics } = new tstl.Transpiler({ emitHost: this.getEmitHost() }).emit({
             program,
@@ -230,10 +231,7 @@ export abstract class TestBuilder {
             writeFile: collector.writeFile,
         });
 
-        const diagnostics = ts.sortAndDeduplicateDiagnostics([
-            ...ts.getPreEmitDiagnostics(program),
-            ...transpileDiagnostics,
-        ]);
+        const diagnostics = ts.sortAndDeduplicateDiagnostics([...preEmitDiagnostics, ...transpileDiagnostics]);
 
         return { diagnostics: [...diagnostics], transpiledFiles: collector.files };
     }


### PR DESCRIPTION
Apparently some of the actions we do while transforming can affect the state of the TS type checker, resulting in extra (nonsense) diagnostics being returned when calling getPreEmitDiagnostics. 

To fix, we get the preEmitDiagnostics from TS before we transform, avoiding those diagnostics.

Fixes #1299, #1058