### PR TITLE
Fixes for Optimize PR

### DIFF
--- a/src/transformation/builtins/function.ts
+++ b/src/transformation/builtins/function.ts
@@ -4,9 +4,9 @@ import * as lua from "../../LuaAST";
 import { TransformationContext } from "../context";
 import { unsupportedForTarget, unsupportedProperty, unsupportedSelfFunctionConversion } from "../utils/diagnostics";
 import { ContextType, getFunctionContextType } from "../utils/function-context";
-import { createUnpackCall } from "../utils/lua-ast";
 import { LuaLibFeature, transformLuaLibFunction } from "../utils/lualib";
 import { transformCallAndArguments } from "../visitors/call";
+import { createUnpackCall } from "../utils/lua-ast";
 
 export function transformFunctionPrototypeCall(
     context: TransformationContext,

--- a/src/transformation/builtins/index.ts
+++ b/src/transformation/builtins/index.ts
@@ -145,6 +145,8 @@ function tryTransformBuiltinPropertyCall(
         case "ReadonlyArray":
             return transformArrayPrototypeCall(context, node, calledMethod);
         case "Function":
+        case "CallableFunction":
+        case "NewableFunction":
             return transformFunctionPrototypeCall(context, node, calledMethod);
     }
 }

--- a/src/transformation/utils/language-extensions.ts
+++ b/src/transformation/utils/language-extensions.ts
@@ -76,7 +76,11 @@ function getPropertyValue(context: TransformationContext, type: ts.Type, propert
 }
 
 export function getExtensionKindForNode(context: TransformationContext, node: ts.Node): ExtensionKind | undefined {
-    const type = context.checker.getTypeAtLocation(node);
+    const originalNode = ts.getOriginalNode(node);
+    let type = context.checker.getTypeAtLocation(originalNode);
+    if (ts.isOptionalChain(originalNode)) {
+        type = context.checker.getNonNullableType(type);
+    }
     return getExtensionKindForType(context, type);
 }
 

--- a/src/transformation/utils/language-extensions.ts
+++ b/src/transformation/utils/language-extensions.ts
@@ -63,8 +63,8 @@ export function getExtensionKindForType(context: TransformationContext, type: ts
 }
 
 const excludedTypeFlags: ts.TypeFlags =
-    ((1 << 18) - 1) & // All flags from Any...Never
-    ts.TypeFlags.Index &
+    ((1 << 18) - 1) | // All flags from Any...Never
+    ts.TypeFlags.Index |
     ts.TypeFlags.NonPrimitive;
 
 function getPropertyValue(context: TransformationContext, type: ts.Type, propertyName: string): string | undefined {

--- a/test/unit/functions/functions.spec.ts
+++ b/test/unit/functions/functions.spec.ts
@@ -159,24 +159,31 @@ test("Class static dot method with parameter", () => {
     `.expectToMatchJsResult();
 });
 
-test("Function bind", () => {
+const functionTypeDeclarations = [
+    ["arrow", ": (...args: any) => any"],
+    ["call signature", ": { (...args: any): any; }"],
+    ["generic", ": Function"],
+    ["inferred", ""],
+];
+
+test.each(functionTypeDeclarations)("Function bind (%s)", (_, type) => {
     util.testFunction`
-        const abc = function (this: { a: number }, a: string, b: string) { return this.a + a + b; }
+        const abc${type} = function (this: { a: number }, a: string, b: string) { return this.a + a + b; }
         return abc.bind({ a: 4 }, "b")("c");
     `.expectToMatchJsResult();
 });
 
-test("Function apply", () => {
+test.each(functionTypeDeclarations)("Function apply (%s)", (_, type) => {
     util.testFunction`
-        const abc = function (this: { a: number }, a: string) { return this.a + a; }
+        const abc${type} = function (this: { a: number }, a: string) { return this.a + a; }
         return abc.apply({ a: 4 }, ["b"]);
     `.expectToMatchJsResult();
 });
 
 // Fix #1226: https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1226
-test("function apply without arguments should not lead to exception", () => {
+test.each(functionTypeDeclarations)("function apply without arguments should not lead to exception (%s)", (_, type) => {
     util.testFunction`
-        const f = function (this: number) { return this + 3; }
+        const f${type} = function (this: number) { return this + 3; }
         return f.apply(4);
     `.expectToMatchJsResult();
 });
@@ -193,9 +200,9 @@ test.each(["() => 4", "undefined"])("prototype call on nullable function (%p)", 
         .expectToMatchJsResult();
 });
 
-test("Function call", () => {
+test.each(functionTypeDeclarations)("Function call (%s)", (_, type) => {
     util.testFunction`
-        const abc = function (this: { a: number }, a: string) { return this.a + a; }
+        const abc${type} = function (this: { a: number }, a: string) { return this.a + a; }
         return abc.call({ a: 4 }, "b");
     `.expectToMatchJsResult();
 });

--- a/test/unit/language-extensions/table.spec.ts
+++ b/test/unit/language-extensions/table.spec.ts
@@ -424,3 +424,22 @@ describe("LuaTable extension interface", () => {
             .expectToEqual({ foo: 1, bar: 3, baz: 5 });
     });
 });
+
+test.each([
+    [undefined, undefined],
+    ["new LuaSet()", true],
+])("call on optional table with strictNullChecks (%s)", (value, expected) => {
+    util.testFunction`
+        function getFoo(): LuaSet<string> | undefined {
+            return ${value}
+        }
+        const foo = getFoo()
+        foo?.add("foo")
+        return foo?.has("foo")
+    `
+        .setOptions({
+            strictNullChecks: true,
+        })
+        .withLanguageExtensions()
+        .expectToEqual(expected);
+});


### PR DESCRIPTION
Fixes the following things that were broken with the last PR:

Fixes `function.apply(...)` and similar calls, when the function is declared using an explicit arrow-function type (`const foo: (args)=>ret`). 

Fixes an optimization with language-extensions detection (broken as in didn't actually optimize, not wrong behavior). Another 6% `transpile` time speedup.

Fixes optional chaining breaking language extensions. This wasn't caught in the tests previously before because strictNullChecks needs to be on.
