### PR TITLE
Fix import expression

### DIFF
--- a/src/transformation/visitors/modules/import.ts
+++ b/src/transformation/visitors/modules/import.ts
@@ -167,6 +167,7 @@ export const transformImportEqualsDeclaration: FunctionVisitor<ts.ImportEqualsDe
 export const transformImportExpression: FunctionVisitor<ts.CallExpression> = (node, context) => {
     importLuaLibFeature(context, LuaLibFeature.Promise);
 
-    const importPath = node.arguments.map(a => context.transformExpression(a));
-    return lua.createCallExpression(createStaticPromiseFunctionAccessor("resolve", node), importPath, node);
+    const moduleRequire =
+        node.arguments.length > 0 ? createModuleRequire(context, node.arguments[0], node) : lua.createNilLiteral();
+    return lua.createCallExpression(createStaticPromiseFunctionAccessor("resolve", node), [moduleRequire], node);
 };

--- a/src/transpilation/resolve.ts
+++ b/src/transpilation/resolve.ts
@@ -260,7 +260,7 @@ function isBuildModeLibrary(program: ts.Program) {
 function findRequiredPaths(code: string): string[] {
     // Find all require("<path>") paths in a lua code string
     const paths: string[] = [];
-    const pattern = /(^|\s|;|=)require\("(.+?)"\)/g;
+    const pattern = /(^|\s|;|=|\()require\("(.+?)"\)/g;
     // eslint-disable-next-line @typescript-eslint/ban-types
     let match: RegExpExecArray | null;
     while ((match = pattern.exec(code))) {
@@ -277,7 +277,7 @@ function replaceRequireInCode(file: ProcessedFile, originalRequire: string, newR
     const escapedRequire = originalRequire.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
 
     file.code = file.code.replace(
-        new RegExp(`(^|\\s|;|=)require\\("${escapedRequire}"\\)`),
+        new RegExp(`(^|\\s|;|=|\\()require\\("${escapedRequire}"\\)`),
         `$1require("${requirePath}")`
     );
 }

--- a/test/unit/modules/modules.spec.ts
+++ b/test/unit/modules/modules.spec.ts
@@ -289,5 +289,6 @@ test("import expression", () => {
     `
         .addExtraFile("module.ts", 'export function foo() { return "foo"; }')
         .setOptions({ module: ts.ModuleKind.ESNext })
+        .expectToEqual({ result: "foo" })
         .expectToMatchJsResult();
 });

--- a/test/unit/modules/modules.spec.ts
+++ b/test/unit/modules/modules.spec.ts
@@ -289,6 +289,5 @@ test("import expression", () => {
     `
         .addExtraFile("module.ts", 'export function foo() { return "foo"; }')
         .setOptions({ module: ts.ModuleKind.ESNext })
-        .expectToEqual({ result: "foo" })
-        .expectToMatchJsResult();
+        .expectToEqual({ result: "foo" });
 });


### PR DESCRIPTION
Turns out
```ts
const abc = import "def";
```
Was actually translated to:
```
local abc = Promise.resolve("def")
```
But instead it should be:
```
local abc = Promise.resolve(require("def"))
```