### PR TITLE
Exception trying to read symbol from undefined type

### DIFF
--- a/src/transformation/builtins/index.ts
+++ b/src/transformation/builtins/index.ts
@@ -4,13 +4,7 @@ import { TransformationContext } from "../context";
 import { createNaN } from "../utils/lua-ast";
 import { importLuaLibFeature, LuaLibFeature } from "../utils/lualib";
 import { getIdentifierSymbolId } from "../utils/symbols";
-import {
-    isStandardLibraryType,
-    isStandardLibraryDeclaration,
-    isStringType,
-    isArrayType,
-    isFunctionType,
-} from "../utils/typescript";
+import { isStandardLibraryType, isStringType, isArrayType, isFunctionType } from "../utils/typescript";
 import { getCalledExpression } from "../visitors/call";
 import { transformArrayConstructorCall, transformArrayProperty, transformArrayPrototypeCall } from "./array";
 import { transformConsoleCall } from "./console";
@@ -85,9 +79,7 @@ function tryTransformBuiltinGlobalMethodCall(
     calledMethod: ts.PropertyAccessExpression
 ) {
     const ownerType = context.checker.getTypeAtLocation(calledMethod.expression);
-    if (!isStandardLibraryType(context, ownerType, undefined)) return;
-
-    const ownerSymbol = ownerType.symbol;
+    const ownerSymbol = tryGetStandardLibrarySymbolOfType(context, ownerType);
     if (!ownerSymbol || ownerSymbol.parent) return;
 
     let result: lua.Expression | undefined;
@@ -129,11 +121,9 @@ function tryTransformBuiltinPropertyCall(
     node: ts.CallExpression,
     calledMethod: ts.PropertyAccessExpression
 ) {
-    const signatureDeclaration = context.checker.getResolvedSignature(node)?.declaration;
-    if (!signatureDeclaration || !isStandardLibraryDeclaration(context, signatureDeclaration)) return;
-
-    const callSymbol = context.checker.getTypeAtLocation(signatureDeclaration).symbol;
-    if (!callSymbol) return; // Should not be required but can apparently happen, see #1325
+    const functionType = context.checker.getTypeAtLocation(node.expression);
+    const callSymbol = tryGetStandardLibrarySymbolOfType(context, functionType);
+    if (!callSymbol) return;
     const ownerSymbol = callSymbol.parent;
     if (!ownerSymbol || ownerSymbol.parent) return;
 
@@ -217,4 +207,17 @@ export function checkForLuaLibType(context: TransformationContext, type: ts.Type
     if (builtinErrorTypeNames.has(name)) {
         importLuaLibFeature(context, LuaLibFeature.Error);
     }
+}
+
+function tryGetStandardLibrarySymbolOfType(context: TransformationContext, type: ts.Type): ts.Symbol | undefined {
+    if (type.isUnionOrIntersection()) {
+        for (const subType of type.types) {
+            const symbol = tryGetStandardLibrarySymbolOfType(context, subType);
+            if (symbol) return symbol;
+        }
+    } else if (isStandardLibraryType(context, type, undefined)) {
+        return type.symbol;
+    }
+
+    return undefined;
 }

--- a/src/transformation/builtins/index.ts
+++ b/src/transformation/builtins/index.ts
@@ -133,7 +133,7 @@ function tryTransformBuiltinPropertyCall(
     if (!signatureDeclaration || !isStandardLibraryDeclaration(context, signatureDeclaration)) return;
 
     const callSymbol = context.checker.getTypeAtLocation(signatureDeclaration).symbol;
-    if (!callSymbol) return;
+    if (!callSymbol) return; // Should not be required but can apparently happen, see #1325
     const ownerSymbol = callSymbol.parent;
     if (!ownerSymbol || ownerSymbol.parent) return;
 

--- a/src/transformation/builtins/index.ts
+++ b/src/transformation/builtins/index.ts
@@ -133,6 +133,7 @@ function tryTransformBuiltinPropertyCall(
     if (!signatureDeclaration || !isStandardLibraryDeclaration(context, signatureDeclaration)) return;
 
     const callSymbol = context.checker.getTypeAtLocation(signatureDeclaration).symbol;
+    if (!callSymbol) return;
     const ownerSymbol = callSymbol.parent;
     if (!ownerSymbol || ownerSymbol.parent) return;
 

--- a/test/unit/functions/functions.spec.ts
+++ b/test/unit/functions/functions.spec.ts
@@ -512,3 +512,15 @@ test("top-level function declaration is global", () => {
         .addExtraFile("a.ts", 'function foo() { return "foo" }')
         .expectToEqual({ result: "foo" });
 });
+
+// https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1325
+test("call expression should not throw (#1325)", () => {
+    util.testModule`
+        function test<T>(iterator:Iterator<T>) {
+            iterator.return();
+        }
+    `
+        .setOptions({ target: 99 })
+        .expectToHaveNoDiagnostics()
+        .debug();
+});

--- a/test/unit/functions/functions.spec.ts
+++ b/test/unit/functions/functions.spec.ts
@@ -1,3 +1,4 @@
+import * as ts from "typescript";
 import * as tstl from "../../../src";
 import * as util from "../../util";
 import { unsupportedForTarget } from "../../../src/transformation/utils/diagnostics";
@@ -517,10 +518,10 @@ test("top-level function declaration is global", () => {
 test("call expression should not throw (#1325)", () => {
     util.testModule`
         function test<T>(iterator:Iterator<T>) {
-            iterator.return();
+            iterator.return?.();
         }
     `
-        .setOptions({ target: 99 })
-        .expectToHaveNoDiagnostics()
-        .debug();
+        // Note: does not reproduce without strict=true
+        .setOptions({ target: ts.ScriptTarget.ESNext, strict: true })
+        .expectToHaveNoDiagnostics();
 });


### PR DESCRIPTION
Seems problem is that if you set strict=true, TS inserts a bunch of undefined types, and if you try to call something that is possibly undefined (should be disallowed by TS, but we also try to transform incorrect code), this symbol could be undefined causing an exception.

Fixes #1325 