### PR TITLE
Allow $multi to be cast to any

### DIFF
--- a/src/transformation/visitors/language-extensions/multi.ts
+++ b/src/transformation/visitors/language-extensions/multi.ts
@@ -14,7 +14,11 @@ export function isMultiReturnType(type: ts.Type): boolean {
 }
 
 export function canBeMultiReturnType(type: ts.Type): boolean {
-    return isMultiReturnType(type) || (type.isUnion() && type.types.some(t => canBeMultiReturnType(t)));
+    return (
+        (type.flags & ts.TypeFlags.Any) !== 0 ||
+        isMultiReturnType(type) ||
+        (type.isUnion() && type.types.some(t => canBeMultiReturnType(t)))
+    );
 }
 
 export function isMultiFunctionCall(context: TransformationContext, expression: ts.CallExpression): boolean {

--- a/test/unit/language-extensions/multi.spec.ts
+++ b/test/unit/language-extensions/multi.spec.ts
@@ -184,6 +184,36 @@ test("forward $multi call in ArrowFunction body", () => {
         .expectToEqual([1, 2]);
 });
 
+test("$multi call in function typed as any", () => {
+    util.testFunction`
+        function foo(): any { return $multi(1, 2); }
+        return foo()
+    `
+        .withLanguageExtensions()
+        .expectToHaveNoDiagnostics()
+        .expectToEqual(1);
+});
+
+test("$multi call cast to any", () => {
+    util.testFunction`
+        function foo() { return $multi(1, 2) as any; }
+        return foo()
+    `
+        .withLanguageExtensions()
+        .expectToHaveNoDiagnostics()
+        .expectToEqual(1);
+});
+
+test("$multi call cast to MultiReturn type", () => {
+    util.testFunction`
+        function foo() { return $multi(1, 2) as unknown as LuaMultiReturn<number[]>; }
+        return foo()
+    `
+        .withLanguageExtensions()
+        .expectToHaveNoDiagnostics()
+        .expectToEqual(1);
+});
+
 test.each(["0", "i"])("allow LuaMultiReturn numeric access (%s)", expression => {
     util.testFunction`
         ${multiFunction}


### PR DESCRIPTION
`any` exists to turn off the type-checker; This PR allows `$multi()` calls to be casted to `any`/returned in functions typed as `any`. This allows getting around current limitations with multi-return, e.g. in custom lua iterators with state