### PR TITLE
Support typescript 4.7 instantiation expressions

### DIFF
--- a/src/transformation/visitors/typescript.ts
+++ b/src/transformation/visitors/typescript.ts
@@ -20,6 +20,7 @@ export const typescriptVisitors: Visitors = {
     [ts.SyntaxKind.InterfaceDeclaration]: () => undefined,
 
     [ts.SyntaxKind.NonNullExpression]: (node, context) => context.transformExpression(node.expression),
+    [ts.SyntaxKind.ExpressionWithTypeArguments]: (node, context) => context.transformExpression(node.expression),
     [ts.SyntaxKind.AsExpression]: transformAssertionExpression,
     [ts.SyntaxKind.TypeAssertionExpression]: transformAssertionExpression,
     [ts.SyntaxKind.NotEmittedStatement]: () => undefined,

--- a/test/unit/expressions.spec.ts
+++ b/test/unit/expressions.spec.ts
@@ -153,6 +153,14 @@ test("Non-null expression", () => {
     `.expectToMatchJsResult();
 });
 
+test("Typescript 4.7 instantiation expression", () => {
+    util.testFunction`
+        function foo<T>(x: T): T { return x; }
+        const bar = foo<number>;
+        return bar(3);
+    `.expectToMatchJsResult();
+});
+
 test.each([
     '"foobar"',
     "17",


### PR DESCRIPTION
This adds support for Instantiation expressions, introduced in typescript 4.7:
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#instantiation-expressions