### PR TITLE
Update VS Code development container configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,6 +7,6 @@
         "editorconfig.editorconfig",
         "esbenp.prettier-vscode"
     ],
-    "postCreateCommand": "npm ci --legacy-peer-deps",
+    "postCreateCommand": "npm ci",
     "remoteUser": "node"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,14 +1,12 @@
 {
     "name": "TypeScriptToLua",
-    "image": "mcr.microsoft.com/vscode/devcontainers/javascript-node:14",
-    "settings": {
-        "terminal.integrated.shell.linux": "/bin/bash"
-    },
+    "image": "mcr.microsoft.com/vscode/devcontainers/javascript-node:18",
     "extensions": [
         "typescript-to-lua.vscode-typescript-to-lua",
         "dbaeumer.vscode-eslint",
         "editorconfig.editorconfig",
         "esbenp.prettier-vscode"
     ],
-    "postCreateCommand": "npm ci"
+    "postCreateCommand": "npm ci --legacy-peer-deps",
+    "remoteUser": "node"
 }


### PR DESCRIPTION
Bump to Node 18, delete the obsolete shell preference, fix npm error with the post-install command, and run as a non-root user.