### PR TITLE
Lua 5.0: Fix bad unpack() call in SparseArraySpread

### DIFF
--- a/src/lualib/5.0/SparseArraySpread.ts
+++ b/src/lualib/5.0/SparseArraySpread.ts
@@ -1,5 +1,6 @@
 import { __TS__SparseArray } from "./SparseArray";
+import { __TS__Unpack } from "./Unpack";
 
 export function __TS__SparseArraySpread<T>(this: void, sparseArray: __TS__SparseArray<T>): LuaMultiReturn<T[]> {
-    return unpack(sparseArray, 1, sparseArray.sparseLength);
+    return __TS__Unpack(sparseArray, 1, sparseArray.sparseLength);
 }

--- a/src/lualib/5.0/Unpack.ts
+++ b/src/lualib/5.0/Unpack.ts
@@ -1,1 +1,16 @@
-export const __TS__Unpack = unpack;
+/** @noSelfInFile */
+
+// We're not interested in emulating all of the behaviors of unpack() from Lua
+// 5.1, just the ones needed by other parts of lualib.
+export function __TS__Unpack<T>(list: T[], i: number, j?: number): LuaMultiReturn<T[]> {
+    if (i === 1 && j === undefined) {
+        return unpack(list);
+    } else {
+        j ??= list.length;
+        const slice: T[] = [];
+        for (let n = i; n <= j; n++) {
+            slice[n - i] = list[n - 1]; // We don't want to add 1 to the index into list.
+        }
+        return $multi(...slice);
+    }
+}

--- a/src/lualib/declarations/tstl.d.ts
+++ b/src/lualib/declarations/tstl.d.ts
@@ -18,9 +18,6 @@ interface LuaClassInstance extends LuaMetatable<any> {
     constructor: LuaClass;
 }
 
-// Declare unpack for versions that have it instead of table.unpack
-declare const unpack: typeof table.unpack | undefined;
-
 // Declare math atan2 for versions that have it instead of math.atan
 declare namespace math {
     const atan2: typeof atan;

--- a/src/lualib/declarations/universal/unpack.d.ts
+++ b/src/lualib/declarations/universal/unpack.d.ts
@@ -1,0 +1,4 @@
+/** @noSelfInFile */
+
+// Declare unpack for versions that have it instead of table.unpack
+declare const unpack: typeof table.unpack | undefined;


### PR DESCRIPTION
For the 5.0 target, we are currently transpiling the SparseArraySpread lualib feature as:

```lua
local function __TS__SparseArraySpread(sparseArray)
    return unpack(nil, sparseArray, 1, sparseArray.sparseLength)
end
```

The `nil` argument causes runtime errors and should not be there; unpack() takes 3 arguments. Or, rather, it does in all versions of Lua except 5.0, which does _not_ support the optional i and j arguments that specify the start and end of the unpacked slice.

So we need to add a polyfill that supports i and j, and also convinces the type checker that it's okay to call unpack() without a leading `nil`.