### PR TITLE
Add support for Typescript 4.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,13 +37,13 @@
                 "prettier": "^2.3.2",
                 "ts-jest": "^28.0.8",
                 "ts-node": "^10.9.1",
-                "typescript": "~4.8.2"
+                "typescript": "~4.9.3"
             },
             "engines": {
                 "node": ">=16.10.0"
             },
             "peerDependencies": {
-                "typescript": "~4.8.2"
+                "typescript": "~4.9.3"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -7302,9 +7302,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.8.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-            "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+            "version": "4.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
+            "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -13033,9 +13033,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "4.8.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
-            "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+            "version": "4.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
+            "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
             "dev": true
         },
         "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "node": ">=16.10.0"
     },
     "peerDependencies": {
-        "typescript": "~4.8.2"
+        "typescript": "~4.9.3"
     },
     "dependencies": {
         "@typescript-to-lua/language-extensions": "1.0.0",
@@ -70,6 +70,6 @@
         "prettier": "^2.3.2",
         "ts-jest": "^28.0.8",
         "ts-node": "^10.9.1",
-        "typescript": "~4.8.2"
+        "typescript": "~4.9.3"
     }
 }

--- a/src/LuaAST.ts
+++ b/src/LuaAST.ts
@@ -145,19 +145,19 @@ export interface Node extends TextRange {
 
 export function createNode(kind: SyntaxKind, tsOriginal?: ts.Node): Node {
     if (tsOriginal === undefined) {
-        return {kind, flags: NodeFlags.None};
+        return { kind, flags: NodeFlags.None };
     }
 
     const sourcePosition = getSourcePosition(tsOriginal);
     if (sourcePosition) {
-        return {kind, line: sourcePosition.line, column: sourcePosition.column, flags: NodeFlags.None};
+        return { kind, line: sourcePosition.line, column: sourcePosition.column, flags: NodeFlags.None };
     } else {
-        return {kind, flags: NodeFlags.None};
+        return { kind, flags: NodeFlags.None };
     }
 }
 
 export function cloneNode<T extends Node>(node: T): T {
-    return {...node};
+    return { ...node };
 }
 
 export function setNodePosition<T extends Node>(node: T, position: TextRange): T {
@@ -186,17 +186,17 @@ function getSourcePosition(sourceNode: ts.Node): TextRange | undefined {
     const parseTreeNode = ts.getParseTreeNode(sourceNode) ?? sourceNode;
     const sourceFile = parseTreeNode.getSourceFile();
     if (sourceFile !== undefined && parseTreeNode.pos >= 0) {
-        const {line, character} = ts.getLineAndCharacterOfPosition(
+        const { line, character } = ts.getLineAndCharacterOfPosition(
             sourceFile,
             parseTreeNode.pos + parseTreeNode.getLeadingTriviaWidth()
         );
 
-        return {line, column: character};
+        return { line, column: character };
     }
 }
 
 export function getOriginalPos(node: Node): TextRange {
-    return {line: node.line, column: node.column};
+    return { line: node.line, column: node.column };
 }
 
 export function setNodeFlags<T extends Node>(node: T, flags: NodeFlags): T {

--- a/src/LuaAST.ts
+++ b/src/LuaAST.ts
@@ -145,19 +145,19 @@ export interface Node extends TextRange {
 
 export function createNode(kind: SyntaxKind, tsOriginal?: ts.Node): Node {
     if (tsOriginal === undefined) {
-        return { kind, flags: NodeFlags.None };
+        return {kind, flags: NodeFlags.None};
     }
 
     const sourcePosition = getSourcePosition(tsOriginal);
     if (sourcePosition) {
-        return { kind, line: sourcePosition.line, column: sourcePosition.column, flags: NodeFlags.None };
+        return {kind, line: sourcePosition.line, column: sourcePosition.column, flags: NodeFlags.None};
     } else {
-        return { kind, flags: NodeFlags.None };
+        return {kind, flags: NodeFlags.None};
     }
 }
 
 export function cloneNode<T extends Node>(node: T): T {
-    return { ...node };
+    return {...node};
 }
 
 export function setNodePosition<T extends Node>(node: T, position: TextRange): T {
@@ -186,17 +186,17 @@ function getSourcePosition(sourceNode: ts.Node): TextRange | undefined {
     const parseTreeNode = ts.getParseTreeNode(sourceNode) ?? sourceNode;
     const sourceFile = parseTreeNode.getSourceFile();
     if (sourceFile !== undefined && parseTreeNode.pos >= 0) {
-        const { line, character } = ts.getLineAndCharacterOfPosition(
+        const {line, character} = ts.getLineAndCharacterOfPosition(
             sourceFile,
             parseTreeNode.pos + parseTreeNode.getLeadingTriviaWidth()
         );
 
-        return { line, column: character };
+        return {line, column: character};
     }
 }
 
 export function getOriginalPos(node: Node): TextRange {
-    return { line: node.line, column: node.column };
+    return {line: node.line, column: node.column};
 }
 
 export function setNodeFlags<T extends Node>(node: T, flags: NodeFlags): T {
@@ -816,6 +816,7 @@ export function createTableIndexExpression(
 }
 
 export type AssignmentLeftHandSideExpression = Identifier | TableIndexExpression;
+
 export function isAssignmentLeftHandSideExpression(node: Node): node is AssignmentLeftHandSideExpression {
     return isIdentifier(node) || isTableIndexExpression(node);
 }

--- a/src/LuaAST.ts
+++ b/src/LuaAST.ts
@@ -5,7 +5,7 @@
 // because we don't create the AST from text
 
 import * as ts from "typescript";
-import { LuaLibFeature } from "./transformation/utils/lualib";
+import { LuaLibFeature } from "./LuaLib";
 import { castArray } from "./utils";
 
 export enum SyntaxKind {

--- a/src/LuaPrinter.ts
+++ b/src/LuaPrinter.ts
@@ -1,12 +1,12 @@
 import * as path from "path";
-import {Mapping, SourceMapGenerator, SourceNode} from "source-map";
+import { Mapping, SourceMapGenerator, SourceNode } from "source-map";
 import * as ts from "typescript";
-import {CompilerOptions, isBundleEnabled, LuaLibImportKind, LuaTarget} from "./CompilerOptions";
+import { CompilerOptions, isBundleEnabled, LuaLibImportKind, LuaTarget } from "./CompilerOptions";
 import * as lua from "./LuaAST";
-import {loadImportedLualibFeatures, loadInlineLualibFeatures, LuaLibFeature} from "./LuaLib";
-import {isValidLuaIdentifier, shouldAllowUnicode} from "./transformation/utils/safe-names";
-import {EmitHost, getEmitPath} from "./transpilation";
-import {intersperse, normalizeSlashes} from "./utils";
+import { loadImportedLualibFeatures, loadInlineLualibFeatures, LuaLibFeature } from "./LuaLib";
+import { isValidLuaIdentifier, shouldAllowUnicode } from "./transformation/utils/safe-names";
+import { EmitHost, getEmitPath } from "./transpilation";
+import { intersperse, normalizeSlashes } from "./utils";
 
 // https://www.lua.org/pil/2.4.html
 // https://www.ecma-international.org/ecma-262/10.0/index.html#table-34
@@ -179,7 +179,7 @@ export class LuaPrinter {
 
         const sourceRoot = this.options.sourceRoot
             ? // According to spec, sourceRoot is simply prepended to the source name, so the slash should be included
-            `${this.options.sourceRoot.replace(/[\\/]+$/, "")}/`
+              `${this.options.sourceRoot.replace(/[\\/]+$/, "")}/`
             : "";
         const rootSourceNode = this.printFile(file);
         const sourceMap = this.buildSourceMap(sourceRoot, rootSourceNode);
@@ -195,7 +195,7 @@ export class LuaPrinter {
             code = code.replace(LuaPrinter.sourceMapTracebackPlaceholder, stackTraceOverride);
         }
 
-        return {code, sourceMap: sourceMap.toString(), sourceMapNode: rootSourceNode};
+        return { code, sourceMap: sourceMap.toString(), sourceMapNode: rootSourceNode };
     }
 
     private printInlineSourceMap(sourceMap: SourceMapGenerator): string {
@@ -272,7 +272,7 @@ export class LuaPrinter {
     }
 
     protected createSourceNode(node: lua.Node, chunks: SourceChunk | SourceChunk[], name?: string): SourceNode {
-        const {line, column} = lua.getOriginalPos(node);
+        const { line, column } = lua.getOriginalPos(node);
 
         return line !== undefined && column !== undefined
             ? new SourceNode(line + 1, column, this.relativeSourcePath, chunks, name)
@@ -892,8 +892,8 @@ export class LuaPrinter {
             if (isNewMapping(sourceNode)) {
                 currentMapping = {
                     source: sourceNode.source,
-                    original: {line: sourceNode.line, column: sourceNode.column},
-                    generated: {line: generatedLine, column: generatedColumn},
+                    original: { line: sourceNode.line, column: sourceNode.column },
+                    generated: { line: generatedLine, column: generatedColumn },
                     name: sourceNode.name,
                 };
                 map.addMapping(currentMapping);

--- a/src/LuaPrinter.ts
+++ b/src/LuaPrinter.ts
@@ -1,12 +1,12 @@
 import * as path from "path";
-import { Mapping, SourceMapGenerator, SourceNode } from "source-map";
+import {Mapping, SourceMapGenerator, SourceNode} from "source-map";
 import * as ts from "typescript";
-import { CompilerOptions, isBundleEnabled, LuaLibImportKind, LuaTarget } from "./CompilerOptions";
+import {CompilerOptions, isBundleEnabled, LuaLibImportKind, LuaTarget} from "./CompilerOptions";
 import * as lua from "./LuaAST";
-import { loadInlineLualibFeatures, LuaLibFeature, loadImportedLualibFeatures } from "./LuaLib";
-import { isValidLuaIdentifier, shouldAllowUnicode } from "./transformation/utils/safe-names";
-import { EmitHost, getEmitPath } from "./transpilation";
-import { intersperse, normalizeSlashes } from "./utils";
+import {loadImportedLualibFeatures, loadInlineLualibFeatures, LuaLibFeature} from "./LuaLib";
+import {isValidLuaIdentifier, shouldAllowUnicode} from "./transformation/utils/safe-names";
+import {EmitHost, getEmitPath} from "./transpilation";
+import {intersperse, normalizeSlashes} from "./utils";
 
 // https://www.lua.org/pil/2.4.html
 // https://www.ecma-international.org/ecma-262/10.0/index.html#table-34
@@ -179,7 +179,7 @@ export class LuaPrinter {
 
         const sourceRoot = this.options.sourceRoot
             ? // According to spec, sourceRoot is simply prepended to the source name, so the slash should be included
-              `${this.options.sourceRoot.replace(/[\\/]+$/, "")}/`
+            `${this.options.sourceRoot.replace(/[\\/]+$/, "")}/`
             : "";
         const rootSourceNode = this.printFile(file);
         const sourceMap = this.buildSourceMap(sourceRoot, rootSourceNode);
@@ -195,7 +195,7 @@ export class LuaPrinter {
             code = code.replace(LuaPrinter.sourceMapTracebackPlaceholder, stackTraceOverride);
         }
 
-        return { code, sourceMap: sourceMap.toString(), sourceMapNode: rootSourceNode };
+        return {code, sourceMap: sourceMap.toString(), sourceMapNode: rootSourceNode};
     }
 
     private printInlineSourceMap(sourceMap: SourceMapGenerator): string {
@@ -272,7 +272,7 @@ export class LuaPrinter {
     }
 
     protected createSourceNode(node: lua.Node, chunks: SourceChunk | SourceChunk[], name?: string): SourceNode {
-        const { line, column } = lua.getOriginalPos(node);
+        const {line, column} = lua.getOriginalPos(node);
 
         return line !== undefined && column !== undefined
             ? new SourceNode(line + 1, column, this.relativeSourcePath, chunks, name)
@@ -892,16 +892,16 @@ export class LuaPrinter {
             if (isNewMapping(sourceNode)) {
                 currentMapping = {
                     source: sourceNode.source,
-                    original: { line: sourceNode.line, column: sourceNode.column },
-                    generated: { line: generatedLine, column: generatedColumn },
+                    original: {line: sourceNode.line, column: sourceNode.column},
+                    generated: {line: generatedLine, column: generatedColumn},
                     name: sourceNode.name,
                 };
                 map.addMapping(currentMapping);
             }
 
-            for (const chunk of sourceNode.children) {
+            for (const chunk of sourceNode.children as SourceChunk[]) {
                 if (typeof chunk === "string") {
-                    const lines = (chunk as string).split("\n");
+                    const lines = chunk.split("\n");
                     if (lines.length > 1) {
                         generatedLine += lines.length - 1;
                         generatedColumn = 0;

--- a/src/cli/parse.ts
+++ b/src/cli/parse.ts
@@ -147,7 +147,7 @@ function updateParsedCommandLine(parsedCommandLine: ts.ParsedCommandLine, args: 
         if (!args[i].startsWith("-")) continue;
 
         const isShorthand = !args[i].startsWith("--");
-        const argumentName = args[i].substr(isShorthand ? 1 : 2);
+        const argumentName = args[i].substring(isShorthand ? 1 : 2);
         const option = optionDeclarations.find(option => {
             if (option.name.toLowerCase() === argumentName.toLowerCase()) return true;
             if (isShorthand && option.aliases) {

--- a/src/lualib/ParseInt.ts
+++ b/src/lualib/ParseInt.ts
@@ -10,8 +10,8 @@ export function __TS__ParseInt(this: void, numberString: string, base?: number):
         if (hexMatch) {
             base = 16;
             numberString = __TS__Match(hexMatch, "-")[0]
-                ? "-" + numberString.substr(hexMatch.length)
-                : numberString.substr(hexMatch.length);
+                ? "-" + numberString.substring(hexMatch.length)
+                : numberString.substring(hexMatch.length);
         }
     }
 
@@ -22,7 +22,7 @@ export function __TS__ParseInt(this: void, numberString: string, base?: number):
 
     // Calculate string match pattern to use
     const allowedDigits =
-        base <= 10 ? parseIntBasePattern.substring(0, base) : parseIntBasePattern.substr(0, 10 + 2 * (base - 10));
+        base <= 10 ? parseIntBasePattern.substring(0, base) : parseIntBasePattern.substring(0, 10 + 2 * (base - 10));
     const pattern = `^%s*(-?[${allowedDigits}]*)`;
 
     // Try to parse with Lua tonumber

--- a/src/lualib/SetDescriptor.ts
+++ b/src/lualib/SetDescriptor.ts
@@ -1,4 +1,4 @@
-import {__TS__CloneDescriptor} from "./CloneDescriptor";
+import { __TS__CloneDescriptor } from "./CloneDescriptor";
 
 function descriptorIndex(this: any, key: string): void {
     const value = rawget(this, key);

--- a/src/lualib/SetDescriptor.ts
+++ b/src/lualib/SetDescriptor.ts
@@ -1,4 +1,4 @@
-import { __TS__CloneDescriptor } from "./CloneDescriptor";
+import {__TS__CloneDescriptor} from "./CloneDescriptor";
 
 function descriptorIndex(this: any, key: string): void {
     const value = rawget(this, key);
@@ -73,8 +73,7 @@ export function __TS__SetDescriptor(
     if (value !== undefined) rawset(target, key, undefined);
 
     if (!rawget(metatable, "_descriptors")) metatable._descriptors = {};
-    const descriptor = __TS__CloneDescriptor(desc);
-    metatable._descriptors[key] = descriptor;
+    metatable._descriptors[key] = __TS__CloneDescriptor(desc);
     metatable.__index = descriptorIndex;
     metatable.__newindex = descriptorNewIndex;
 }

--- a/src/transformation/context/context.ts
+++ b/src/transformation/context/context.ts
@@ -65,7 +65,10 @@ export class TransformationContext {
     /** @internal */
     public transformNodeRaw(node: ts.Node, isExpression?: boolean) {
         // TODO: Move to visitors?
-        if (ts.canHaveModifiers(node) && node.modifiers?.some(modifier => modifier.kind === ts.SyntaxKind.DeclareKeyword)) {
+        if (
+            ts.canHaveModifiers(node) &&
+            node.modifiers?.some(modifier => modifier.kind === ts.SyntaxKind.DeclareKeyword)
+        ) {
             return [];
         }
 

--- a/src/transformation/context/context.ts
+++ b/src/transformation/context/context.ts
@@ -65,7 +65,7 @@ export class TransformationContext {
     /** @internal */
     public transformNodeRaw(node: ts.Node, isExpression?: boolean) {
         // TODO: Move to visitors?
-        if (node.modifiers?.some(modifier => modifier.kind === ts.SyntaxKind.DeclareKeyword)) {
+        if (ts.canHaveModifiers(node) && node.modifiers?.some(modifier => modifier.kind === ts.SyntaxKind.DeclareKeyword)) {
             return [];
         }
 

--- a/src/transformation/context/visitors.ts
+++ b/src/transformation/context/visitors.ts
@@ -1,7 +1,7 @@
 import * as ts from "typescript";
 import * as lua from "../../LuaAST";
-import { OneToManyVisitorResult } from "../utils/lua-ast";
-import { TransformationContext } from "./context";
+import {OneToManyVisitorResult} from "../utils/lua-ast";
+import {TransformationContext} from "./context";
 
 interface NodesBySyntaxKind {
     // Copied from is* type guards, with JSDoc and TypeNodes removed
@@ -61,6 +61,7 @@ interface NodesBySyntaxKind {
     [ts.SyntaxKind.AsExpression]: ts.AsExpression;
     [ts.SyntaxKind.NonNullExpression]: ts.NonNullExpression;
     [ts.SyntaxKind.MetaProperty]: ts.MetaProperty;
+    [ts.SyntaxKind.SatisfiesExpression]: ts.SatisfiesExpression;
     [ts.SyntaxKind.TemplateSpan]: ts.TemplateSpan;
     [ts.SyntaxKind.SemicolonClassElement]: ts.SemicolonClassElement;
     [ts.SyntaxKind.Block]: ts.Block;
@@ -141,13 +142,14 @@ export type StatementLikeNode = ts.Statement;
 export type VisitorResult<T extends ts.Node> = T extends ExpressionLikeNode
     ? lua.Expression
     : T extends StatementLikeNode
-    ? OneToManyVisitorResult<lua.Statement>
-    : T extends ts.SourceFile
-    ? lua.File
-    : OneToManyVisitorResult<lua.Node>;
+        ? OneToManyVisitorResult<lua.Statement>
+        : T extends ts.SourceFile
+            ? lua.File
+            : OneToManyVisitorResult<lua.Node>;
 
 export type Visitor<T extends ts.Node> = FunctionVisitor<T> | ObjectVisitor<T>;
 export type FunctionVisitor<T extends ts.Node> = (node: T, context: TransformationContext) => VisitorResult<T>;
+
 export interface ObjectVisitor<T extends ts.Node> {
     transform: FunctionVisitor<T>;
 

--- a/src/transformation/context/visitors.ts
+++ b/src/transformation/context/visitors.ts
@@ -1,7 +1,7 @@
 import * as ts from "typescript";
 import * as lua from "../../LuaAST";
-import {OneToManyVisitorResult} from "../utils/lua-ast";
-import {TransformationContext} from "./context";
+import { OneToManyVisitorResult } from "../utils/lua-ast";
+import { TransformationContext } from "./context";
 
 interface NodesBySyntaxKind {
     // Copied from is* type guards, with JSDoc and TypeNodes removed
@@ -142,10 +142,10 @@ export type StatementLikeNode = ts.Statement;
 export type VisitorResult<T extends ts.Node> = T extends ExpressionLikeNode
     ? lua.Expression
     : T extends StatementLikeNode
-        ? OneToManyVisitorResult<lua.Statement>
-        : T extends ts.SourceFile
-            ? lua.File
-            : OneToManyVisitorResult<lua.Node>;
+    ? OneToManyVisitorResult<lua.Statement>
+    : T extends ts.SourceFile
+    ? lua.File
+    : OneToManyVisitorResult<lua.Node>;
 
 export type Visitor<T extends ts.Node> = FunctionVisitor<T> | ObjectVisitor<T>;
 export type FunctionVisitor<T extends ts.Node> = (node: T, context: TransformationContext) => VisitorResult<T>;

--- a/src/transformation/utils/diagnostics.ts
+++ b/src/transformation/utils/diagnostics.ts
@@ -1,7 +1,7 @@
 import * as ts from "typescript";
-import { LuaTarget, TypeScriptToLuaOptions } from "../../CompilerOptions";
-import { createSerialDiagnosticFactory } from "../../utils";
-import { AnnotationKind } from "./annotations";
+import {LuaTarget, TypeScriptToLuaOptions} from "../../CompilerOptions";
+import {createSerialDiagnosticFactory} from "../../utils";
+import {AnnotationKind} from "./annotations";
 
 type MessageProvider<TArgs extends any[]> = string | ((...args: TArgs) => string);
 
@@ -119,12 +119,6 @@ export const invalidMultiFunctionReturnType = createErrorDiagnosticFactory(
     "The $multi function cannot be cast to a non-LuaMultiReturn type."
 );
 
-export const invalidMultiTypeToNonArrayLiteral = createErrorDiagnosticFactory("Expected an array literal.");
-
-export const invalidMultiTypeToEmptyPatternOrArrayLiteral = createErrorDiagnosticFactory(
-    "There must be one or more elements specified here."
-);
-
 export const invalidMultiReturnAccess = createErrorDiagnosticFactory(
     "The LuaMultiReturn type can only be accessed via an element access expression of a numeric type."
 );
@@ -132,13 +126,6 @@ export const invalidMultiReturnAccess = createErrorDiagnosticFactory(
 export const invalidCallExtensionUse = createErrorDiagnosticFactory(
     "This function must be called directly and cannot be referred to."
 );
-
-export const annotationRemoved = createErrorDiagnosticFactory(
-    (kind: AnnotationKind) =>
-        `'@${kind}' has been removed and will no longer have any effect.` +
-        `See https://typescripttolua.github.io/docs/advanced/compiler-annotations#${kind.toLowerCase()} for more information.`
-);
-
 export const annotationDeprecated = createWarningDiagnosticFactory(
     (kind: AnnotationKind) =>
         `'@${kind}' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. ` +

--- a/src/transformation/utils/diagnostics.ts
+++ b/src/transformation/utils/diagnostics.ts
@@ -1,7 +1,7 @@
 import * as ts from "typescript";
-import {LuaTarget, TypeScriptToLuaOptions} from "../../CompilerOptions";
-import {createSerialDiagnosticFactory} from "../../utils";
-import {AnnotationKind} from "./annotations";
+import { LuaTarget, TypeScriptToLuaOptions } from "../../CompilerOptions";
+import { createSerialDiagnosticFactory } from "../../utils";
+import { AnnotationKind } from "./annotations";
 
 type MessageProvider<TArgs extends any[]> = string | ((...args: TArgs) => string);
 

--- a/src/transformation/utils/export.ts
+++ b/src/transformation/utils/export.ts
@@ -1,17 +1,17 @@
 import * as ts from "typescript";
 import * as lua from "../../LuaAST";
-import { TransformationContext } from "../context";
-import { createModuleLocalNameIdentifier } from "../visitors/namespace";
-import { createExportsIdentifier } from "./lua-ast";
-import { getSymbolInfo } from "./symbols";
-import { findFirstNodeAbove } from "./typescript";
+import {TransformationContext} from "../context";
+import {createModuleLocalNameIdentifier} from "../visitors/namespace";
+import {createExportsIdentifier} from "./lua-ast";
+import {getSymbolInfo} from "./symbols";
+import {findFirstNodeAbove} from "./typescript";
 
 export function hasDefaultExportModifier(node: ts.Node): boolean {
-    return (node.modifiers ?? []).some(modifier => modifier.kind === ts.SyntaxKind.DefaultKeyword);
+    return ts.canHaveModifiers(node) && node.modifiers?.some(modifier => modifier.kind === ts.SyntaxKind.DefaultKeyword) === true;
 }
 
 export function hasExportModifier(node: ts.Node): boolean {
-    return (node.modifiers ?? []).some(modifier => modifier.kind === ts.SyntaxKind.ExportKeyword);
+    return ts.canHaveModifiers(node) && node.modifiers?.some(modifier => modifier.kind === ts.SyntaxKind.ExportKeyword) === true;
 }
 
 export const createDefaultExportStringLiteral = (original?: ts.Node): lua.StringLiteral =>
@@ -90,7 +90,7 @@ export function getExportedSymbolsFromScope(
     }
 
     // ts.Iterator is not a ES6-compatible iterator, because TypeScript targets ES5
-    const it: Iterable<ts.Symbol> = { [Symbol.iterator]: () => scopeSymbol.exports!.values() };
+    const it: Iterable<ts.Symbol> = {[Symbol.iterator]: () => scopeSymbol.exports!.values()};
     return [...it];
 }
 

--- a/src/transformation/utils/export.ts
+++ b/src/transformation/utils/export.ts
@@ -1,17 +1,23 @@
 import * as ts from "typescript";
 import * as lua from "../../LuaAST";
-import {TransformationContext} from "../context";
-import {createModuleLocalNameIdentifier} from "../visitors/namespace";
-import {createExportsIdentifier} from "./lua-ast";
-import {getSymbolInfo} from "./symbols";
-import {findFirstNodeAbove} from "./typescript";
+import { TransformationContext } from "../context";
+import { createModuleLocalNameIdentifier } from "../visitors/namespace";
+import { createExportsIdentifier } from "./lua-ast";
+import { getSymbolInfo } from "./symbols";
+import { findFirstNodeAbove } from "./typescript";
 
 export function hasDefaultExportModifier(node: ts.Node): boolean {
-    return ts.canHaveModifiers(node) && node.modifiers?.some(modifier => modifier.kind === ts.SyntaxKind.DefaultKeyword) === true;
+    return (
+        ts.canHaveModifiers(node) &&
+        node.modifiers?.some(modifier => modifier.kind === ts.SyntaxKind.DefaultKeyword) === true
+    );
 }
 
 export function hasExportModifier(node: ts.Node): boolean {
-    return ts.canHaveModifiers(node) && node.modifiers?.some(modifier => modifier.kind === ts.SyntaxKind.ExportKeyword) === true;
+    return (
+        ts.canHaveModifiers(node) &&
+        node.modifiers?.some(modifier => modifier.kind === ts.SyntaxKind.ExportKeyword) === true
+    );
 }
 
 export const createDefaultExportStringLiteral = (original?: ts.Node): lua.StringLiteral =>
@@ -90,7 +96,7 @@ export function getExportedSymbolsFromScope(
     }
 
     // ts.Iterator is not a ES6-compatible iterator, because TypeScript targets ES5
-    const it: Iterable<ts.Symbol> = {[Symbol.iterator]: () => scopeSymbol.exports!.values()};
+    const it: Iterable<ts.Symbol> = { [Symbol.iterator]: () => scopeSymbol.exports!.values() };
     return [...it];
 }
 

--- a/src/transformation/visitors/binary-expression/bit.ts
+++ b/src/transformation/visitors/binary-expression/bit.ts
@@ -1,9 +1,9 @@
 import * as ts from "typescript";
-import {LuaTarget} from "../../../CompilerOptions";
+import { LuaTarget } from "../../../CompilerOptions";
 import * as lua from "../../../LuaAST";
-import {assertNever} from "../../../utils";
-import {TransformationContext} from "../../context";
-import {unsupportedForTarget, unsupportedRightShiftOperator} from "../../utils/diagnostics";
+import { assertNever } from "../../../utils";
+import { TransformationContext } from "../../context";
+import { unsupportedForTarget, unsupportedRightShiftOperator } from "../../utils/diagnostics";
 
 export type BitOperator = ts.ShiftOperator | ts.BitwiseOperator;
 export const isBitOperator = (operator: ts.BinaryOperator): operator is BitOperator =>

--- a/src/transformation/visitors/binary-expression/bit.ts
+++ b/src/transformation/visitors/binary-expression/bit.ts
@@ -1,9 +1,9 @@
 import * as ts from "typescript";
-import { LuaTarget } from "../../../CompilerOptions";
+import {LuaTarget} from "../../../CompilerOptions";
 import * as lua from "../../../LuaAST";
-import { assertNever } from "../../../utils";
-import { TransformationContext } from "../../context";
-import { unsupportedForTarget, unsupportedRightShiftOperator } from "../../utils/diagnostics";
+import {assertNever} from "../../../utils";
+import {TransformationContext} from "../../context";
+import {unsupportedForTarget, unsupportedRightShiftOperator} from "../../utils/diagnostics";
 
 export type BitOperator = ts.ShiftOperator | ts.BitwiseOperator;
 export const isBitOperator = (operator: ts.BinaryOperator): operator is BitOperator =>
@@ -49,6 +49,7 @@ function transformBitOperatorToLuaOperator(
             return lua.SyntaxKind.BitwiseLeftShiftOperator;
         case ts.SyntaxKind.GreaterThanGreaterThanToken:
             context.diagnostics.push(unsupportedRightShiftOperator(node));
+            return lua.SyntaxKind.BitwiseRightShiftOperator;
         case ts.SyntaxKind.GreaterThanGreaterThanGreaterThanToken:
             return lua.SyntaxKind.BitwiseRightShiftOperator;
     }
@@ -66,6 +67,7 @@ export function transformBinaryBitOperation(
         case LuaTarget.Lua50:
         case LuaTarget.Lua51:
             context.diagnostics.push(unsupportedForTarget(node, "Bitwise operations", context.luaTarget));
+            return transformBinaryBitLibOperation(node, left, right, operator, "bit");
 
         case LuaTarget.LuaJIT:
             return transformBinaryBitLibOperation(node, left, right, operator, "bit");
@@ -111,6 +113,7 @@ export function transformUnaryBitOperation(
         case LuaTarget.Lua50:
         case LuaTarget.Lua51:
             context.diagnostics.push(unsupportedForTarget(node, "Bitwise operations", context.luaTarget));
+            return transformUnaryBitLibOperation(node, expression, operator, "bit");
 
         case LuaTarget.LuaJIT:
             return transformUnaryBitLibOperation(node, expression, operator, "bit");

--- a/src/transformation/visitors/binary-expression/compound.ts
+++ b/src/transformation/visitors/binary-expression/compound.ts
@@ -3,7 +3,7 @@ import * as lua from "../../../LuaAST";
 import { cast, assertNever } from "../../../utils";
 import { TransformationContext } from "../../context";
 import { transformInPrecedingStatementScope } from "../../utils/preceding-statements";
-import { transformBinaryOperation } from "../binary-expression";
+import { transformBinaryOperation } from "./index";
 import { transformAssignmentWithRightPrecedingStatements } from "./assignments";
 
 function isLuaExpressionWithSideEffect(expression: lua.Expression) {

--- a/src/transformation/visitors/binary-expression/compound.ts
+++ b/src/transformation/visitors/binary-expression/compound.ts
@@ -158,7 +158,7 @@ export function transformCompoundAssignment(
             operatorExpression,
             rightPrecedingStatements
         );
-        return { statements: [tmpDeclaration, ...precedingStatements, ...assignStatements], result: tmpIdentifier };
+        return {statements: [tmpDeclaration, ...precedingStatements, ...assignStatements], result: tmpIdentifier};
     } else {
         if (rightPrecedingStatements.length > 0 && isSetterSkippingCompoundAssignmentOperator(operator)) {
             return {
@@ -183,7 +183,7 @@ export function transformCompoundAssignment(
             operatorExpression,
             precedingStatements
         );
-        return { statements, result: left };
+        return {statements, result: left};
     }
 }
 
@@ -196,7 +196,7 @@ export function transformCompoundAssignmentExpression(
     operator: CompoundAssignmentToken,
     isPostfix: boolean
 ): lua.Expression {
-    const { statements, result } = transformCompoundAssignment(context, expression, lhs, rhs, operator, isPostfix);
+    const {statements, result} = transformCompoundAssignment(context, expression, lhs, rhs, operator, isPostfix);
     context.addPrecedingStatements(statements);
     return result;
 }

--- a/src/transformation/visitors/binary-expression/compound.ts
+++ b/src/transformation/visitors/binary-expression/compound.ts
@@ -158,7 +158,7 @@ export function transformCompoundAssignment(
             operatorExpression,
             rightPrecedingStatements
         );
-        return {statements: [tmpDeclaration, ...precedingStatements, ...assignStatements], result: tmpIdentifier};
+        return { statements: [tmpDeclaration, ...precedingStatements, ...assignStatements], result: tmpIdentifier };
     } else {
         if (rightPrecedingStatements.length > 0 && isSetterSkippingCompoundAssignmentOperator(operator)) {
             return {
@@ -183,7 +183,7 @@ export function transformCompoundAssignment(
             operatorExpression,
             precedingStatements
         );
-        return {statements, result: left};
+        return { statements, result: left };
     }
 }
 
@@ -196,7 +196,7 @@ export function transformCompoundAssignmentExpression(
     operator: CompoundAssignmentToken,
     isPostfix: boolean
 ): lua.Expression {
-    const {statements, result} = transformCompoundAssignment(context, expression, lhs, rhs, operator, isPostfix);
+    const { statements, result } = transformCompoundAssignment(context, expression, lhs, rhs, operator, isPostfix);
     context.addPrecedingStatements(statements);
     return result;
 }

--- a/src/transformation/visitors/class/index.ts
+++ b/src/transformation/visitors/class/index.ts
@@ -116,7 +116,7 @@ function transformClassLikeDeclaration(
         // Generate a constructor if none was defined in a base class
         const constructorResult = transformConstructorDeclaration(
             context,
-            ts.factory.createConstructorDeclaration([], [], [], ts.factory.createBlock([], true)),
+            ts.factory.createConstructorDeclaration([], [], ts.factory.createBlock([], true)),
             localClassName,
             instanceFields,
             classDeclaration

--- a/src/transformation/visitors/class/utils.ts
+++ b/src/transformation/visitors/class/utils.ts
@@ -1,5 +1,5 @@
 import * as ts from "typescript";
-import {TransformationContext} from "../../context";
+import { TransformationContext } from "../../context";
 
 export function isStaticNode(node: ts.HasModifiers): boolean {
     return node.modifiers?.some(m => m.kind === ts.SyntaxKind.StaticKeyword) === true;

--- a/src/transformation/visitors/class/utils.ts
+++ b/src/transformation/visitors/class/utils.ts
@@ -1,12 +1,12 @@
 import * as ts from "typescript";
-import { TransformationContext } from "../../context";
+import {TransformationContext} from "../../context";
 
-export function isStaticNode(node: ts.Node): boolean {
-    return (node.modifiers ?? []).some(m => m.kind === ts.SyntaxKind.StaticKeyword);
+export function isStaticNode(node: ts.HasModifiers): boolean {
+    return node.modifiers?.some(m => m.kind === ts.SyntaxKind.StaticKeyword) === true;
 }
 
 export function getExtendsClause(node: ts.ClassLikeDeclarationBase): ts.HeritageClause | undefined {
-    return (node.heritageClauses ?? []).find(clause => clause.token === ts.SyntaxKind.ExtendsKeyword);
+    return node.heritageClauses?.find(clause => clause.token === ts.SyntaxKind.ExtendsKeyword);
 }
 
 export function getExtendedNode(node: ts.ClassLikeDeclarationBase): ts.ExpressionWithTypeArguments | undefined {

--- a/src/transformation/visitors/template.ts
+++ b/src/transformation/visitors/template.ts
@@ -3,7 +3,7 @@ import * as lua from "../../LuaAST";
 import { FunctionVisitor } from "../context";
 import { ContextType, getDeclarationContextType } from "../utils/function-context";
 import { wrapInToStringForConcat } from "../utils/lua-ast";
-import { isStringType } from "../utils/typescript/types";
+import { isStringType } from "../utils/typescript";
 import { transformArguments, transformContextualCallExpression } from "./call";
 import { transformOrderedExpressions } from "./expression-list";
 

--- a/src/transformation/visitors/typescript.ts
+++ b/src/transformation/visitors/typescript.ts
@@ -1,6 +1,6 @@
 import * as ts from "typescript";
-import {FunctionVisitor, Visitors} from "../context";
-import {validateAssignment} from "../utils/assignment-validation";
+import { FunctionVisitor, Visitors } from "../context";
+import { validateAssignment } from "../utils/assignment-validation";
 
 const transformAssertionExpression: FunctionVisitor<ts.AssertionExpression> = (expression, context) => {
     if (!ts.isConstTypeReference(expression.type)) {

--- a/src/transformation/visitors/typescript.ts
+++ b/src/transformation/visitors/typescript.ts
@@ -1,6 +1,6 @@
 import * as ts from "typescript";
-import { FunctionVisitor, Visitors } from "../context";
-import { validateAssignment } from "../utils/assignment-validation";
+import {FunctionVisitor, Visitors} from "../context";
+import {validateAssignment} from "../utils/assignment-validation";
 
 const transformAssertionExpression: FunctionVisitor<ts.AssertionExpression> = (expression, context) => {
     if (!ts.isConstTypeReference(expression.type)) {
@@ -21,6 +21,7 @@ export const typescriptVisitors: Visitors = {
 
     [ts.SyntaxKind.NonNullExpression]: (node, context) => context.transformExpression(node.expression),
     [ts.SyntaxKind.ExpressionWithTypeArguments]: (node, context) => context.transformExpression(node.expression),
+    [ts.SyntaxKind.SatisfiesExpression]: (node, context) => context.transformExpression(node.expression),
     [ts.SyntaxKind.AsExpression]: transformAssertionExpression,
     [ts.SyntaxKind.TypeAssertionExpression]: transformAssertionExpression,
     [ts.SyntaxKind.NotEmittedStatement]: () => undefined,

--- a/src/transpilation/utils.ts
+++ b/src/transpilation/utils.ts
@@ -40,7 +40,7 @@ export function resolvePlugin(
     kind: string,
     optionName: string,
     basedir: string,
-    query: string,
+    query: unknown,
     importName = "default"
 ): { error?: ts.Diagnostic; result?: unknown } {
     if (typeof query !== "string") {

--- a/src/typescript-internal.d.ts
+++ b/src/typescript-internal.d.ts
@@ -35,8 +35,6 @@ declare module "typescript" {
         parent?: Symbol;
     }
 
-    function getObjectFlags(type: Type): ObjectFlags;
-
     function transformJsx(context: TransformationContext): (x: SourceFile) => SourceFile;
 
     export type OuterExpression =

--- a/test/unit/builtins/numbers.spec.ts
+++ b/test/unit/builtins/numbers.spec.ts
@@ -1,8 +1,6 @@
 import * as util from "../../util";
 
 test.each([
-    "NaN === NaN",
-    "NaN !== NaN",
     "NaN + NaN",
     "NaN - NaN",
     "NaN * NaN",
@@ -119,12 +117,12 @@ test.each(["Infinity", "-Infinity", "   -Infinity"])("parseFloat handles Infinit
 });
 
 test.each([
-    { numberString: "36", base: 8 },
-    { numberString: "-36", base: 8 },
-    { numberString: "100010101101", base: 2 },
-    { numberString: "-100010101101", base: 2 },
-    { numberString: "3F", base: 16 },
-])("parseInt with base (%p)", ({ numberString, base }) => {
+    {numberString: "36", base: 8},
+    {numberString: "-36", base: 8},
+    {numberString: "100010101101", base: 2},
+    {numberString: "-100010101101", base: 2},
+    {numberString: "3F", base: 16},
+])("parseInt with base (%p)", ({numberString, base}) => {
     util.testExpression`parseInt("${numberString}", ${base})`.expectToMatchJsResult();
 });
 
@@ -137,10 +135,10 @@ test.each([1, 37, -100])("parseInt with invalid base (%p)", base => {
 });
 
 test.each([
-    { numberString: "36px", base: 8 },
-    { numberString: "10001010110231", base: 2 },
-    { numberString: "3Fcolor", base: 16 },
-])("parseInt with base and trailing text (%p)", ({ numberString, base }) => {
+    {numberString: "36px", base: 8},
+    {numberString: "10001010110231", base: 2},
+    {numberString: "3Fcolor", base: 16},
+])("parseInt with base and trailing text (%p)", ({numberString, base}) => {
     util.testExpression`parseInt("${numberString}", ${base})`.expectToMatchJsResult();
 });
 
@@ -152,6 +150,6 @@ test.each(["42", "undefined"])("prototype call on nullable number (%p)", value =
         }
         return toString(${value});
     `
-        .setOptions({ strictNullChecks: true })
+        .setOptions({strictNullChecks: true})
         .expectToMatchJsResult();
 });

--- a/test/unit/builtins/numbers.spec.ts
+++ b/test/unit/builtins/numbers.spec.ts
@@ -117,12 +117,12 @@ test.each(["Infinity", "-Infinity", "   -Infinity"])("parseFloat handles Infinit
 });
 
 test.each([
-    {numberString: "36", base: 8},
-    {numberString: "-36", base: 8},
-    {numberString: "100010101101", base: 2},
-    {numberString: "-100010101101", base: 2},
-    {numberString: "3F", base: 16},
-])("parseInt with base (%p)", ({numberString, base}) => {
+    { numberString: "36", base: 8 },
+    { numberString: "-36", base: 8 },
+    { numberString: "100010101101", base: 2 },
+    { numberString: "-100010101101", base: 2 },
+    { numberString: "3F", base: 16 },
+])("parseInt with base (%p)", ({ numberString, base }) => {
     util.testExpression`parseInt("${numberString}", ${base})`.expectToMatchJsResult();
 });
 
@@ -135,10 +135,10 @@ test.each([1, 37, -100])("parseInt with invalid base (%p)", base => {
 });
 
 test.each([
-    {numberString: "36px", base: 8},
-    {numberString: "10001010110231", base: 2},
-    {numberString: "3Fcolor", base: 16},
-])("parseInt with base and trailing text (%p)", ({numberString, base}) => {
+    { numberString: "36px", base: 8 },
+    { numberString: "10001010110231", base: 2 },
+    { numberString: "3Fcolor", base: 16 },
+])("parseInt with base and trailing text (%p)", ({ numberString, base }) => {
     util.testExpression`parseInt("${numberString}", ${base})`.expectToMatchJsResult();
 });
 
@@ -150,6 +150,6 @@ test.each(["42", "undefined"])("prototype call on nullable number (%p)", value =
         }
         return toString(${value});
     `
-        .setOptions({strictNullChecks: true})
+        .setOptions({ strictNullChecks: true })
         .expectToMatchJsResult();
 });

--- a/test/unit/expressions.spec.ts
+++ b/test/unit/expressions.spec.ts
@@ -173,6 +173,13 @@ test("Typescript 4.7 instantiation expression", () => {
     `.expectToMatchJsResult();
 });
 
+test("Typescript 4.9 satisfies expression", () => {
+    util.testFunction`
+        const foo = { a: 1 } satisfies { a: number };
+        return foo.a;
+    `.expectToMatchJsResult();
+})
+
 test.each([
     '"foobar"',
     "17",

--- a/test/unit/expressions.spec.ts
+++ b/test/unit/expressions.spec.ts
@@ -178,7 +178,7 @@ test("Typescript 4.9 satisfies expression", () => {
         const foo = { a: 1 } satisfies { a: number };
         return foo.a;
     `.expectToMatchJsResult();
-})
+});
 
 test.each([
     '"foobar"',


### PR DESCRIPTION
This PR adds support for Typescript 4.9:

- Removed deprecated API usages
- Added support for "satisfies" expressions
- Resolved other potential issues found by code analysis (found when looking for deprecated api usages). This is last commit.