### PR TITLE
Fix Brew missing in PATH

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Lua Install
         run: sudo apt-get install lua5.3 luajit
       - name: Add Brew to Path (Required since Nov 2022)
-        run: eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+        run: eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> $GITHUB_PATH
       - name: Glow Install
         run: brew install glow
       # Checkout master & commit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
     steps:
       - name: Lua Install
         run: sudo apt-get install lua5.3 luajit
+      - name: Add Brew to Path (Required since Nov 2022)
+        run: eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
       - name: Glow Install
         run: brew install glow
       # Checkout master & commit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Lua Install
         run: sudo apt-get install lua5.3 luajit
       - name: Add Brew to Path (Required since Nov 2022)
-        run: eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" >> $GITHUB_PATH
+        run: echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
       - name: Glow Install
         run: brew install glow
       # Checkout master & commit


### PR DESCRIPTION
Seems like the default GitHub Actions Ubuntu image had an update and brew is no longer added to PATH by default.