### PR TITLE
Fix unsafe name default export

### DIFF
--- a/src/transformation/visitors/class/index.ts
+++ b/src/transformation/visitors/class/index.ts
@@ -27,9 +27,9 @@ import { LuaTarget } from "../../../CompilerOptions";
 export const transformClassDeclaration: FunctionVisitor<ts.ClassLikeDeclaration> = (declaration, context) => {
     // If declaration is a default export, transform to export variable assignment instead
     if (hasDefaultExportModifier(declaration)) {
-        const left = createDefaultExportExpression(declaration);
-        const right = transformClassAsExpression(declaration, context);
-        return [lua.createAssignmentStatement(left, right, declaration)];
+        // Class declaration including assignment to ____exports.default are in preceding statements
+        transformClassAsExpression(declaration, context);
+        return [];
     }
 
     const { statements } = transformClassLikeDeclaration(declaration, context);

--- a/src/transformation/visitors/class/index.ts
+++ b/src/transformation/visitors/class/index.ts
@@ -23,13 +23,17 @@ import { createMethodDecoratingExpression, transformMethodDeclaration } from "./
 import { getExtendedNode, getExtendedType, isStaticNode } from "./utils";
 import { createClassSetup } from "./setup";
 import { LuaTarget } from "../../../CompilerOptions";
+import { transformInPrecedingStatementScope } from "../../utils/preceding-statements";
 
 export const transformClassDeclaration: FunctionVisitor<ts.ClassLikeDeclaration> = (declaration, context) => {
     // If declaration is a default export, transform to export variable assignment instead
     if (hasDefaultExportModifier(declaration)) {
         // Class declaration including assignment to ____exports.default are in preceding statements
-        transformClassAsExpression(declaration, context);
-        return [];
+        const [precedingStatements] = transformInPrecedingStatementScope(context, () => {
+            transformClassAsExpression(declaration, context);
+            return [];
+        });
+        return precedingStatements;
     }
 
     const { statements } = transformClassLikeDeclaration(declaration, context);

--- a/test/unit/__snapshots__/identifiers.spec.ts.snap
+++ b/test/unit/__snapshots__/identifiers.spec.ts.snap
@@ -248,6 +248,30 @@ exports[`undeclared identifier must be a valid lua identifier (object literal sh
 
 exports[`undeclared identifier must be a valid lua identifier (object literal shorthand) ("ɥɣɎɌͼƛಠ"): diagnostics 1`] = `"main.ts(2,27): error TSTL: Invalid ambient identifier name 'ɥɣɎɌͼƛಠ'. Ambient identifiers must be valid lua identifiers."`;
 
+exports[`unicode export class 1`] = `
+"local ____lualib = require(\\"lualib_bundle\\")
+local __TS__Class = ____lualib.__TS__Class
+local ____exports = {}
+____exports[\\"你好\\"] = __TS__Class()
+local _____4F60_597D = ____exports[\\"你好\\"]
+_____4F60_597D.name = \\"你好\\"
+function _____4F60_597D.prototype.____constructor(self)
+end
+return ____exports"
+`;
+
+exports[`unicode export default class 1`] = `
+"local ____lualib = require(\\"lualib_bundle\\")
+local __TS__Class = ____lualib.__TS__Class
+local ____exports = {}
+____exports.default = __TS__Class()
+local _____4F60_597D = ____exports.default
+_____4F60_597D.name = \\"你好\\"
+function _____4F60_597D.prototype.____constructor(self)
+end
+return ____exports"
+`;
+
 exports[`unicode identifiers in supporting environments (luajit) destructuring property name ("_̀ः٠‿") 1`] = `
 "local ____exports = {}
 function ____exports.__main(self)

--- a/test/unit/__snapshots__/identifiers.spec.ts.snap
+++ b/test/unit/__snapshots__/identifiers.spec.ts.snap
@@ -248,30 +248,6 @@ exports[`undeclared identifier must be a valid lua identifier (object literal sh
 
 exports[`undeclared identifier must be a valid lua identifier (object literal shorthand) ("ɥɣɎɌͼƛಠ"): diagnostics 1`] = `"main.ts(2,27): error TSTL: Invalid ambient identifier name 'ɥɣɎɌͼƛಠ'. Ambient identifiers must be valid lua identifiers."`;
 
-exports[`unicode export class 1`] = `
-"local ____lualib = require(\\"lualib_bundle\\")
-local __TS__Class = ____lualib.__TS__Class
-local ____exports = {}
-____exports[\\"你好\\"] = __TS__Class()
-local _____4F60_597D = ____exports[\\"你好\\"]
-_____4F60_597D.name = \\"你好\\"
-function _____4F60_597D.prototype.____constructor(self)
-end
-return ____exports"
-`;
-
-exports[`unicode export default class 1`] = `
-"local ____lualib = require(\\"lualib_bundle\\")
-local __TS__Class = ____lualib.__TS__Class
-local ____exports = {}
-____exports.default = __TS__Class()
-local _____4F60_597D = ____exports.default
-_____4F60_597D.name = \\"你好\\"
-function _____4F60_597D.prototype.____constructor(self)
-end
-return ____exports"
-`;
-
 exports[`unicode identifiers in supporting environments (luajit) destructuring property name ("_̀ः٠‿") 1`] = `
 "local ____exports = {}
 function ____exports.__main(self)

--- a/test/unit/identifiers.spec.ts
+++ b/test/unit/identifiers.spec.ts
@@ -287,14 +287,34 @@ describe("unicode identifiers in supporting environments (luajit)", () => {
 
 test("unicode export class", () => {
     util.testModule`
-        export class 你好 {}
-    `.expectLuaToMatchSnapshot();
+        import { 你好 } from "./utfclass";
+        export const result = new 你好().hello();
+    `
+        .addExtraFile(
+            "utfclass.ts",
+            `export class 你好 {
+                hello() {
+                    return "你好";
+                }
+            }`
+        )
+        .expectToEqual({ result: "你好" });
 });
 
 test("unicode export default class", () => {
     util.testModule`
-        export default class 你好 {}
-    `.expectLuaToMatchSnapshot();
+        import c from "./utfclass";
+        export const result = new c().hello();
+    `
+        .addExtraFile(
+            "utfclass.ts",
+            `export default class 你好 {
+                hello() {
+                    return "你好";
+                }
+            }`
+        )
+        .expectToEqual({ result: "你好" });
 });
 
 describe("lua keyword as identifier doesn't interfere with lua's value", () => {

--- a/test/unit/identifiers.spec.ts
+++ b/test/unit/identifiers.spec.ts
@@ -285,6 +285,18 @@ describe("unicode identifiers in supporting environments (luajit)", () => {
     });
 });
 
+test("unicode export class", () => {
+    util.testModule`
+        export class 你好 {}
+    `.expectLuaToMatchSnapshot();
+});
+
+test("unicode export default class", () => {
+    util.testModule`
+        export default class 你好 {}
+    `.expectLuaToMatchSnapshot();
+});
+
 describe("lua keyword as identifier doesn't interfere with lua's value", () => {
     test("variable (nil)", () => {
         util.testFunction`


### PR DESCRIPTION
Default classes turned out to have an extra unnecessary assignment to ____exports.default, which also failed when unsafe unicode names were being used. This removes that.

Fixes #1358 