### PR TITLE
Better require search

### DIFF
--- a/src/transpilation/find-lua-requires.ts
+++ b/src/transpilation/find-lua-requires.ts
@@ -13,7 +13,14 @@ function findRequire(lua: string, offset: number): LuaRequire[] {
 
     while (offset < lua.length) {
         const c = lua[offset];
-        if (c === "r" && (offset === 0 || isWhitespace(lua[offset - 1]) || lua[offset - 1] === "]")) {
+        if (
+            c === "r" &&
+            (offset === 0 ||
+                isWhitespace(lua[offset - 1]) ||
+                lua[offset - 1] === "]" ||
+                lua[offset - 1] === "(" ||
+                lua[offset - 1] === "[")
+        ) {
             const m = matchRequire(lua, offset);
             if (m.matched) {
                 offset = m.match.to + 1;

--- a/src/transpilation/find-lua-requires.ts
+++ b/src/transpilation/find-lua-requires.ts
@@ -1,0 +1,143 @@
+export interface LuaRequire {
+    from: number;
+    to: number;
+    requirePath: string;
+}
+
+export function findLuaRequires(lua: string): LuaRequire[] {
+    return findRequire(lua, 0);
+}
+
+function findRequire(lua: string, offset: number): LuaRequire[] {
+    const result = [];
+
+    while (offset < lua.length) {
+        const c = lua[offset];
+        if (c === "r") {
+            const m = matchRequire(lua, offset);
+            if (m.matched) {
+                offset = m.match.to;
+                result.push(m.match);
+            } else {
+                offset = m.end;
+            }
+        } else if (c === '"' || c === "'") {
+            offset = offset + readString(lua, offset, c).length + 2; // Skip string and surrounding quotes
+        } else if (c === "-" && offset + 1 < lua.length && lua[offset + 1] === "-") {
+            offset = skipComment(lua, offset);
+        }
+        else
+        {
+            offset++;
+        }
+    }
+
+    return result;
+}
+
+type MatchResult<T> = { matched: true; match: T } | { matched: false; end: number };
+
+function matchRequire(lua: string, offset: number): MatchResult<LuaRequire> {
+    const start = offset;
+    for (const c of "require") {
+        if (offset > lua.length) {
+            return { matched: false, end: offset };
+        }
+
+        if (lua[offset] !== c) {
+            return { matched: false, end: offset };
+        }
+        offset++;
+    }
+
+    offset = skipWhitespace(lua, offset);
+
+    if (offset > lua.length || lua[offset] !== "(") {
+        return { matched: false, end: offset };
+    }
+
+    offset++;
+
+    offset = skipWhitespace(lua, offset);
+
+    if (offset > lua.length || (lua[offset] !== '"' && lua[offset] !== "'")) {
+        return { matched: false, end: offset };
+    }
+
+    const requireString = readString(lua, offset, lua[offset]);
+    offset += requireString.length + 2; // Skip string and surrounding quotes
+
+    offset = skipWhitespace(lua, offset);
+
+    if (offset > lua.length || lua[offset] !== ")") {
+        return { matched: false, end: offset };
+    }
+
+    offset++;
+
+    return { matched: true, match: { from: start, to: offset, requirePath: requireString } };
+}
+
+function readString(lua: string, offset: number, delimiter: string): string {
+    expect(lua, offset, delimiter);
+    offset++;
+
+    const start = offset;
+
+    let escaped = false;
+    while (offset < lua.length && (lua[offset] !== delimiter || escaped)) {
+        if (lua[offset] === "\\" && !escaped) {
+            escaped = true;
+        } else {
+            escaped = false;
+        }
+
+        offset++;
+    }
+
+    expect(lua, offset, delimiter);
+
+    return lua.slice(start, offset);
+}
+
+function skipWhitespace(lua: string, offset: number): number {
+    while (
+        offset < lua.length &&
+        (lua[offset] === " " || lua[offset] === "\t" || lua[offset] === "\r" || lua[offset] === "\n")
+    ) {
+        offset++;
+    }
+    return offset;
+}
+
+function skipComment(lua: string, offset: number): number {
+    expect(lua, offset, "-");
+    expect(lua, offset + 1, "-");
+    offset += 2;
+
+    if (offset + 1 < lua.length && lua[offset] === "[" && lua[offset + 1] === "[") {
+        return skipMultiLineComment(lua, offset);
+    } else {
+        return skipSingleLineComment(lua, offset);
+    }
+}
+
+function skipMultiLineComment(lua: string, offset: number): number {
+    while (offset < lua.length && !(lua[offset] === "]" && lua[offset - 1] === "]")) {
+        offset++;
+    }
+    return offset + 1;
+}
+
+function skipSingleLineComment(lua: string, offset: number): number {
+    while (offset < lua.length && lua[offset] !== "\n") {
+        offset++;
+    }
+    return offset + 1;
+}
+
+function expect(lua: string, offset: number, char: string) {
+    if (lua[offset] !== char) {
+        throw new Error(`Expected ${char} at position ${offset} but found ${lua[offset]}`);
+    }
+}

--- a/src/transpilation/find-lua-requires.ts
+++ b/src/transpilation/find-lua-requires.ts
@@ -13,10 +13,10 @@ function findRequire(lua: string, offset: number): LuaRequire[] {
 
     while (offset < lua.length) {
         const c = lua[offset];
-        if (c === "r") {
+        if (c === "r" && (offset === 0 || isWhitespace(lua[offset - 1]) || lua[offset - 1] === "]")) {
             const m = matchRequire(lua, offset);
             if (m.matched) {
-                offset = m.match.to;
+                offset = m.match.to + 1;
                 result.push(m.match);
             } else {
                 offset = m.end;
@@ -73,7 +73,7 @@ function matchRequire(lua: string, offset: number): MatchResult<LuaRequire> {
 
     offset++;
 
-    return { matched: true, match: { from: start, to: offset, requirePath: requireString } };
+    return { matched: true, match: { from: start, to: offset - 1, requirePath: requireString } };
 }
 
 function readString(lua: string, offset: number, delimiter: string): { value: string; offset: number } {
@@ -107,13 +107,14 @@ function readString(lua: string, offset: number, delimiter: string): { value: st
 }
 
 function skipWhitespace(lua: string, offset: number): number {
-    while (
-        offset < lua.length &&
-        (lua[offset] === " " || lua[offset] === "\t" || lua[offset] === "\r" || lua[offset] === "\n")
-    ) {
+    while (offset < lua.length && isWhitespace(lua[offset])) {
         offset++;
     }
     return offset;
+}
+
+function isWhitespace(c: string): boolean {
+    return c === " " || c === "\t" || c === "\r" || c === "\n";
 }
 
 function skipComment(lua: string, offset: number): number {

--- a/src/transpilation/resolve.ts
+++ b/src/transpilation/resolve.ts
@@ -69,7 +69,9 @@ class ResolutionContext {
 
         if (this.noResolvePaths.has(required.requirePath)) {
             if (this.options.tstlVerbose) {
-                console.log(`Skipping module resolution of ${required.requirePath} as it is in the tsconfig noResolvePaths.`);
+                console.log(
+                    `Skipping module resolution of ${required.requirePath} as it is in the tsconfig noResolvePaths.`
+                );
             }
             return;
         }

--- a/src/transpilation/resolve.ts
+++ b/src/transpilation/resolve.ts
@@ -8,6 +8,7 @@ import { getEmitPathRelativeToOutDir, getProjectRoot, getSourceDir } from "./tra
 import { formatPathToLuaPath, normalizeSlashes, trimExtension } from "../utils";
 import { couldNotReadDependency, couldNotResolveRequire } from "./diagnostics";
 import { BuildMode, CompilerOptions } from "../CompilerOptions";
+import { findLuaRequires } from "./find-lua-requires";
 
 const resolver = resolve.ResolverFactory.createResolver({
     extensions: [".lua"],
@@ -314,6 +315,9 @@ function findRequiredPaths(code: string): string[] {
     while ((match = pattern.exec(code))) {
         paths.push(match[3]);
     }
+
+    const test = findLuaRequires(code);
+    console.log(test);
 
     return paths;
 }

--- a/src/transpilation/resolve.ts
+++ b/src/transpilation/resolve.ts
@@ -69,7 +69,7 @@ class ResolutionContext {
 
         if (this.noResolvePaths.has(required.requirePath)) {
             if (this.options.tstlVerbose) {
-                console.log(`Skipping module resolution of ${required} as it is in the tsconfig noResolvePaths.`);
+                console.log(`Skipping module resolution of ${required.requirePath} as it is in the tsconfig noResolvePaths.`);
             }
             return;
         }
@@ -78,7 +78,7 @@ class ResolutionContext {
         if (!dependencyPath) return this.couldNotResolveImport(required, file);
 
         if (this.options.tstlVerbose) {
-            console.log(`Resolved ${required} to ${normalizeSlashes(dependencyPath)}`);
+            console.log(`Resolved ${required.requirePath} to ${normalizeSlashes(dependencyPath)}`);
         }
 
         this.processDependency(dependencyPath);

--- a/src/transpilation/resolve.ts
+++ b/src/transpilation/resolve.ts
@@ -8,7 +8,7 @@ import { getEmitPathRelativeToOutDir, getProjectRoot, getSourceDir } from "./tra
 import { formatPathToLuaPath, normalizeSlashes, trimExtension } from "../utils";
 import { couldNotReadDependency, couldNotResolveRequire } from "./diagnostics";
 import { BuildMode, CompilerOptions } from "../CompilerOptions";
-import { findLuaRequires } from "./find-lua-requires";
+import { findLuaRequires, LuaRequire } from "./find-lua-requires";
 
 const resolver = resolve.ResolverFactory.createResolver({
     extensions: [".lua"],
@@ -41,12 +41,13 @@ class ResolutionContext {
         if (this.resolvedFiles.has(file.fileName)) return;
         this.resolvedFiles.set(file.fileName, file);
 
-        for (const required of findRequiredPaths(file.code)) {
+        // Do this backwards so the replacements do not mess with the positions of the previous requires
+        for (const required of findLuaRequires(file.code).reverse()) {
             // Do not resolve noResolution paths
-            if (required.startsWith("@NoResolution:")) {
+            if (required.requirePath.startsWith("@NoResolution:")) {
                 // Remove @NoResolution prefix if not building in library mode
                 if (!isBuildModeLibrary(this.program)) {
-                    const path = required.replace("@NoResolution:", "");
+                    const path = required.requirePath.replace("@NoResolution:", "");
                     replaceRequireInCode(file, required, path);
                     replaceRequireInSourceMap(file, required, path);
                 }
@@ -59,21 +60,21 @@ class ResolutionContext {
         }
     }
 
-    public resolveImport(file: ProcessedFile, required: string): void {
+    public resolveImport(file: ProcessedFile, required: LuaRequire): void {
         // Do no resolve lualib - always use the lualib of the application entry point, not the lualib from external packages
-        if (required === "lualib_bundle") {
+        if (required.requirePath === "lualib_bundle") {
             this.resolvedFiles.set("lualib_bundle", { fileName: "lualib_bundle", code: "" });
             return;
         }
 
-        if (this.noResolvePaths.has(required)) {
+        if (this.noResolvePaths.has(required.requirePath)) {
             if (this.options.tstlVerbose) {
                 console.log(`Skipping module resolution of ${required} as it is in the tsconfig noResolvePaths.`);
             }
             return;
         }
 
-        const dependencyPath = this.resolveDependencyPath(file, required);
+        const dependencyPath = this.resolveDependencyPath(file, required.requirePath);
         if (!dependencyPath) return this.couldNotResolveImport(required, file);
 
         if (this.options.tstlVerbose) {
@@ -111,13 +112,13 @@ class ResolutionContext {
         this.addAndResolveDependencies(dependency);
     }
 
-    private couldNotResolveImport(required: string, file: ProcessedFile): void {
+    private couldNotResolveImport(required: LuaRequire, file: ProcessedFile): void {
         const fallbackRequire = fallbackResolve(required, getSourceDir(this.program), path.dirname(file.fileName));
         replaceRequireInCode(file, required, fallbackRequire);
         replaceRequireInSourceMap(file, required, fallbackRequire);
 
         this.diagnostics.push(
-            couldNotResolveRequire(required, path.relative(getProjectRoot(this.program), file.fileName))
+            couldNotResolveRequire(required.requirePath, path.relative(getProjectRoot(this.program), file.fileName))
         );
     }
 
@@ -306,38 +307,23 @@ function isBuildModeLibrary(program: ts.Program) {
     return program.getCompilerOptions().buildMode === BuildMode.Library;
 }
 
-function findRequiredPaths(code: string): string[] {
-    // Find all require("<path>") paths in a lua code string
-    const paths: string[] = [];
-    const pattern = /(^|\s|;|=|\()require\s*\(?(["|'])(.+?)\2\)?/g;
-    // eslint-disable-next-line @typescript-eslint/ban-types
-    let match: RegExpExecArray | null;
-    while ((match = pattern.exec(code))) {
-        paths.push(match[3]);
-    }
-
-    const test = findLuaRequires(code);
-    console.log(test);
-
-    return paths;
-}
-
-function replaceRequireInCode(file: ProcessedFile, originalRequire: string, newRequire: string): void {
+function replaceRequireInCode(file: ProcessedFile, originalRequire: LuaRequire, newRequire: string): void {
     const requirePath = formatPathToLuaPath(newRequire.replace(".lua", ""));
-
-    // Escape special characters to prevent the regex from breaking...
-    const escapedRequire = originalRequire.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
-
-    file.code = file.code.replace(
-        new RegExp(`(^|\\s|;|=|\\()require\\s*\\(?["|']${escapedRequire}["|']\\)?`),
-        `$1require("${requirePath}")`
-    );
+    file.code = file.code =
+        file.code.substring(0, originalRequire.from) +
+        `require("${requirePath}")` +
+        file.code.substring(originalRequire.to + 1);
 }
 
-function replaceRequireInSourceMap(file: ProcessedFile, originalRequire: string, newRequire: string): void {
+function replaceRequireInSourceMap(file: ProcessedFile, originalRequire: LuaRequire, newRequire: string): void {
     const requirePath = formatPathToLuaPath(newRequire.replace(".lua", ""));
     if (file.sourceMapNode) {
-        replaceInSourceMap(file.sourceMapNode, file.sourceMapNode, `"${originalRequire}"`, `"${requirePath}"`);
+        replaceInSourceMap(
+            file.sourceMapNode,
+            file.sourceMapNode,
+            `"${originalRequire.requirePath}"`,
+            `"${requirePath}"`
+        );
     }
 }
 
@@ -379,10 +365,10 @@ function hasSourceFileInProject(filePath: string, program: ts.Program) {
 }
 
 // Transform an import path to a lua require that is probably not correct, but can be used as fallback when regular resolution fails
-function fallbackResolve(required: string, sourceRootDir: string, fileDir: string): string {
+function fallbackResolve(required: LuaRequire, sourceRootDir: string, fileDir: string): string {
     return formatPathToLuaPath(
         path
-            .normalize(path.join(path.relative(sourceRootDir, fileDir), required))
+            .normalize(path.join(path.relative(sourceRootDir, fileDir), required.requirePath))
             .split(path.sep)
             .filter(s => s !== "." && s !== "..")
             .join(path.sep)

--- a/test/transpile/module-resolution.spec.ts
+++ b/test/transpile/module-resolution.spec.ts
@@ -411,7 +411,7 @@ test("module resolution should not rewrite @NoResolution requires in library mod
 });
 
 // https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1050
-test("module resolution should not try to resolve resolve-like functions", () => {
+test("module resolution should not try to resolve require-like functions", () => {
     util.testModule`
         function custom_require(this: void, value: string) {
             return value;

--- a/test/unit/find-lua-requires.spec.ts
+++ b/test/unit/find-lua-requires.spec.ts
@@ -13,6 +13,16 @@ test("can find requires", () => {
     expect(requirePaths(findLuaRequires(lua))).toEqual(["req1", "req2", "req3"]);
 });
 
+test("handles requires with spacing", () => {
+    const lua = 'require \t  ( \t "req"  )';
+    expect(requirePaths(findLuaRequires(lua))).toEqual(["req"]);
+});
+
+test("handles requires without parentheses", () => {
+    const lua = 'require "req"';
+    expect(requirePaths(findLuaRequires(lua))).toEqual(["req"]);
+});
+
 test("has correct offsets", () => {
     const lua = `
         require("req1")
@@ -24,6 +34,19 @@ test("has correct offsets", () => {
     expect(lua.substring(requires[0].from, requires[0].to + 1)).toBe('require("req1")');
     expect(lua.substring(requires[1].from, requires[1].to + 1)).toBe("require('req2')");
     expect(lua.substring(requires[2].from, requires[2].to + 1)).toBe('require("req3")');
+});
+
+test("has correct offsets for offsets without parentheses", () => {
+    const lua = `
+        require"req1"
+        require 'req2'
+        local r3 = require"req3"
+    `;
+    const requires = findLuaRequires(lua);
+    expect(requires).toHaveLength(3);
+    expect(lua.substring(requires[0].from, requires[0].to + 1)).toBe('require"req1"');
+    expect(lua.substring(requires[1].from, requires[1].to + 1)).toBe("require 'req2'");
+    expect(lua.substring(requires[2].from, requires[2].to + 1)).toBe('require"req3"');
 });
 
 test("ignores requires that should not be included", () => {

--- a/test/unit/find-lua-requires.spec.ts
+++ b/test/unit/find-lua-requires.spec.ts
@@ -13,6 +13,19 @@ test("can find requires", () => {
     expect(requirePaths(findLuaRequires(lua))).toEqual(["req1", "req2", "req3"]);
 });
 
+test("has correct offsets", () => {
+    const lua = `
+        require("req1")
+        require('req2')
+        local r3 = require("req3")
+    `;
+    const requires = findLuaRequires(lua);
+    expect(requires).toHaveLength(3);
+    expect(lua.substring(requires[0].from, requires[0].to + 1)).toBe('require("req1")');
+    expect(lua.substring(requires[1].from, requires[1].to + 1)).toBe("require('req2')");
+    expect(lua.substring(requires[2].from, requires[2].to + 1)).toBe('require("req3")');
+});
+
 test("ignores requires that should not be included", () => {
     const lua = `
         require("req1")
@@ -92,7 +105,7 @@ describe("single-line comments", () => {
     });
 });
 
-describe("single-line comments", () => {
+describe("multi-line comments", () => {
     test("comment at end of file", () => {
         expect(findLuaRequires("--[[]]")).toEqual([]);
     });

--- a/test/unit/find-lua-requires.spec.ts
+++ b/test/unit/find-lua-requires.spec.ts
@@ -1,0 +1,123 @@
+import { findLuaRequires, LuaRequire } from "../../src/transpilation/find-lua-requires";
+
+test("empty string", () => {
+    expect(findLuaRequires("")).toEqual([]);
+});
+
+test("can find requires", () => {
+    const lua = `
+        require("req1")
+        require('req2')
+        local r3 = require("req3")
+    `;
+    expect(requirePaths(findLuaRequires(lua))).toEqual(["req1", "req2", "req3"]);
+});
+
+test("ignores requires that should not be included", () => {
+    const lua = `
+        require("req1")
+        local a = "require('This should not be included')"
+        require('req2')
+        local b = 'require("This should not be included")'
+        require("req3")
+        -- require("this should not be included")
+        require("req4")
+        --[[ require("this should not be included") ]]
+        require("req5")
+    `;
+    expect(requirePaths(findLuaRequires(lua))).toEqual(["req1", "req2", "req3", "req4", "req5"]);
+});
+
+test("non-terminated require", () => {
+    expect(findLuaRequires("require('abc")).toEqual([]);
+});
+
+describe.each(['"', "'"])("strings with delimiter %p", delimiter => {
+    test("escaped delimiter", () => {
+        const lua = `
+            require(${delimiter}req1${delimiter});
+            local a = ${delimiter}require(excludeThis\\${delimiter})${delimiter}
+            require(${delimiter}req\\${delimiter}2${delimiter});
+        `;
+        expect(requirePaths(findLuaRequires(lua))).toEqual(["req1", `req${delimiter}2`]);
+    });
+
+    test("multiple escaped delimiters", () => {
+        const lua = `
+            require(${delimiter}r\\${delimiter}e.- q%\\${delimiter}1${delimiter})
+        `;
+        expect(requirePaths(findLuaRequires(lua))).toEqual([`r${delimiter}e.- q%${delimiter}1`]);
+    });
+
+    test("handles other escaped characters", () => {
+        expect(requirePaths(findLuaRequires(`require(${delimiter}req\\n\\\\${delimiter})`))).toEqual(["req\\n\\\\"]);
+    });
+
+    test("handles non-delimiter quote", () => {
+        const oppositeDelimiter = delimiter === "'" ? '"' : "'";
+        const lua = `
+            require(${delimiter}req1${delimiter});
+            local a = ${delimiter}require(excludeThis${oppositeDelimiter})${delimiter};
+            require(${delimiter}req2${oppositeDelimiter}${delimiter});
+        `;
+        expect(requirePaths(findLuaRequires(lua))).toEqual(["req1", `req2${oppositeDelimiter}`]);
+    });
+
+    test("non-terminated string", () => {
+        const lua = `
+            require(${delimiter}myRequire${delimiter});
+            local a = ${delimiter}require("excludeThis")
+        `;
+        expect(requirePaths(findLuaRequires(lua))).toEqual(["myRequire"]);
+    });
+});
+
+describe("single-line comments", () => {
+    test("comment at end of file", () => {
+        expect(findLuaRequires("--")).toEqual([]);
+    });
+
+    test("require before and after comment", () => {
+        const lua = `
+            require("req1")-- comment\nrequire("req2")
+        `;
+        expect(requirePaths(findLuaRequires(lua))).toEqual(["req1", "req2"]);
+    });
+
+    test("require before and after empty comment", () => {
+        const lua = `
+            require("req1")--\nrequire("req2")
+        `;
+        expect(requirePaths(findLuaRequires(lua))).toEqual(["req1", "req2"]);
+    });
+});
+
+describe("single-line comments", () => {
+    test("comment at end of file", () => {
+        expect(findLuaRequires("--[[]]")).toEqual([]);
+    });
+
+    test("unterminated comment", () => {
+        expect(findLuaRequires("--[[")).toEqual([]);
+    });
+
+    test("require before and after comment", () => {
+        const lua = `
+            require("req1")--[[
+               ml comment require("this should be excluded") 
+            ]]require("req2")
+        `;
+        expect(requirePaths(findLuaRequires(lua))).toEqual(["req1", "req2"]);
+    });
+
+    test("require before and after empty comment", () => {
+        const lua = `
+            require("req1")--[[]]require("req2")
+        `;
+        expect(requirePaths(findLuaRequires(lua))).toEqual(["req1", "req2"]);
+    });
+});
+
+function requirePaths(matches: LuaRequire[]): string[] {
+    return matches.map(m => m.requirePath);
+}


### PR DESCRIPTION
Wrote a custom parser that only knows require statements, comments and string literals. This allows us to replace the regex we were previously using to avoid false-positive requires we would try to resolve/rewrite while they shouldn't be. The parser works by just scanning the lua file for require statements, and fast-forwarding through any string or comment.

Fixes #1330 and #1376