### PR TITLE
Minimal bundle luaLibImport option

### DIFF
--- a/src/CompilerOptions.ts
+++ b/src/CompilerOptions.ts
@@ -12,12 +12,14 @@ export interface TransformerImport {
     after?: boolean;
     afterDeclarations?: boolean;
     type?: "program" | "config" | "checker" | "raw" | "compilerOptions";
+
     [option: string]: any;
 }
 
 export interface LuaPluginImport {
     name: string;
     import?: string;
+
     [option: string]: any;
 }
 
@@ -49,6 +51,7 @@ export enum LuaLibImportKind {
     None = "none",
     Inline = "inline",
     Require = "require",
+    RequireMinimal = "require-minimal",
 }
 
 export enum LuaTarget {

--- a/src/LuaLib.ts
+++ b/src/LuaLib.ts
@@ -133,15 +133,15 @@ export function getLuaLibModulesInfo(luaTarget: LuaTarget, emitHost: EmitHost): 
     return luaLibModulesInfo.get(lualibPath) as LuaLibModulesInfo;
 }
 
-const exportToFeature = new Map<string, ReadonlyMap<string, LuaLibFeature>>();
-
+// This caches the names of lualib exports to their LuaLibFeature, avoiding a linear search for every lookup
+const lualibExportToFeature = new Map<string, ReadonlyMap<string, LuaLibFeature>>();
 export function getLuaLibFeatureForExportName(
     luaTarget: LuaTarget,
     emitHost: EmitHost,
     exportName: string
 ): LuaLibFeature | undefined {
     const luaLibPath = resolveLuaLibDir(luaTarget);
-    if (!exportToFeature.has(luaLibPath)) {
+    if (!lualibExportToFeature.has(luaLibPath)) {
         const luaLibModulesInfo = getLuaLibModulesInfo(luaTarget, emitHost);
         const map = new Map<string, LuaLibFeature>();
         for (const [feature, info] of Object.entries(luaLibModulesInfo)) {
@@ -149,10 +149,10 @@ export function getLuaLibFeatureForExportName(
                 map.set(exportName, feature as LuaLibFeature);
             }
         }
-        exportToFeature.set(luaLibPath, map);
+        lualibExportToFeature.set(luaLibPath, map);
     }
 
-    return exportToFeature.get(luaLibPath)!.get(exportName);
+    return lualibExportToFeature.get(luaLibPath)!.get(exportName);
 }
 
 export function readLuaLibFeature(feature: LuaLibFeature, luaTarget: LuaTarget, emitHost: EmitHost): string {

--- a/src/LuaLib.ts
+++ b/src/LuaLib.ts
@@ -273,7 +273,7 @@ export function findUsedLualibFeatures(
     const features = new Set<LuaLibFeature>();
 
     for (const lua of luaContents) {
-        const regex = /local\s+(\w+)\s*=\s*____lualib\.(\w+)/g;
+        const regex = /^local (\w+) = ____lualib\.(\w+)$/gm;
         while (true) {
             const match = regex.exec(lua);
             if (!match) break;

--- a/src/LuaPrinter.ts
+++ b/src/LuaPrinter.ts
@@ -235,7 +235,10 @@ export class LuaPrinter {
 
         const luaTarget = this.options.luaTarget ?? LuaTarget.Universal;
         const luaLibImport = this.options.luaLibImport ?? LuaLibImportKind.Require;
-        if (luaLibImport === LuaLibImportKind.Require && file.luaLibFeatures.size > 0) {
+        if (
+            (luaLibImport === LuaLibImportKind.Require || luaLibImport === LuaLibImportKind.RequireMinimal) &&
+            file.luaLibFeatures.size > 0
+        ) {
             // Import lualib features
             sourceChunks = this.printStatementArray(
                 loadImportedLualibFeatures(file.luaLibFeatures, luaTarget, this.emitHost)

--- a/src/lualib-build/plugin.ts
+++ b/src/lualib-build/plugin.ts
@@ -2,7 +2,13 @@ import { SourceNode } from "source-map";
 import * as ts from "typescript";
 import * as tstl from "..";
 import * as path from "path";
-import { LuaLibFeature, LuaLibModulesInfo, luaLibModulesInfoFileName, resolveRecursiveLualibFeatures } from "../LuaLib";
+import {
+    getLualibBundleReturn,
+    LuaLibFeature,
+    LuaLibModulesInfo,
+    luaLibModulesInfoFileName,
+    resolveRecursiveLualibFeatures,
+} from "../LuaLib";
 import { EmitHost, ProcessedFile } from "../transpilation/utils";
 import {
     isExportAlias,
@@ -63,7 +69,7 @@ class LuaLibPlugin implements tstl.Plugin {
         // Concatenate lualib files into bundle with exports table and add lualib_bundle.lua to results
         let lualibBundle = orderedFeatures.map(f => exportedLualibFeatures.get(LuaLibFeature[f])).join("\n");
         const exports = allFeatures.flatMap(feature => luaLibModuleInfo[feature].exports);
-        lualibBundle += `\nreturn {\n${exports.map(exportName => `  ${exportName} = ${exportName}`).join(",\n")}\n}\n`;
+        lualibBundle += getLualibBundleReturn(exports);
         result.push({ fileName: "lualib_bundle.lua", code: lualibBundle });
 
         return diagnostics;

--- a/src/transpilation/diagnostics.ts
+++ b/src/transpilation/diagnostics.ts
@@ -51,7 +51,7 @@ export const usingLuaBundleWithInlineMightGenerateDuplicateCode = createSerialDi
 
 export const cannotBundleLibrary = createDiagnosticFactory(
     () =>
-        'Cannot bundle probjects with"buildmode": "library". Projects including the library can still bundle (which will include external library files).'
+        'Cannot bundle projects with "buildmode": "library". Projects including the library can still bundle (which will include external library files).'
 );
 
 export const unsupportedJsxEmit = createDiagnosticFactory(() => 'JSX is only supported with "react" jsx option.');

--- a/src/transpilation/transpiler.ts
+++ b/src/transpilation/transpiler.ts
@@ -123,21 +123,9 @@ export class Transpiler {
             if (options.tstlVerbose) {
                 console.log("Including lualib bundle");
             }
-
-            const luaTarget = options.luaTarget ?? LuaTarget.Universal;
-            let code: string;
-            if (options.luaLibImport === LuaLibImportKind.RequireMinimal) {
-                const usedFeatures = findUsedLualibFeatures(
-                    luaTarget,
-                    this.emitHost,
-                    resolutionResult.resolvedFiles.map(f => f.code)
-                );
-                code = buildMinimalLualibBundle(usedFeatures, luaTarget, this.emitHost);
-            } else {
-                code = getLuaLibBundle(luaTarget, this.emitHost);
-            }
             // Add lualib bundle to source dir 'virtually', will be moved to correct output dir in emitPlan
             const fileName = normalizeSlashes(path.resolve(getSourceDir(program), "lualib_bundle.lua"));
+            const code = this.getLuaLibBundleContent(options, resolutionResult.resolvedFiles);
             resolutionResult.resolvedFiles.unshift({ fileName, code });
         }
 
@@ -156,6 +144,20 @@ export class Transpiler {
         performance.endSection("getEmitPlan");
 
         return { emitPlan };
+    }
+
+    private getLuaLibBundleContent(options: CompilerOptions, resolvedFiles: ProcessedFile[]) {
+        const luaTarget = options.luaTarget ?? LuaTarget.Universal;
+        if (options.luaLibImport === LuaLibImportKind.RequireMinimal) {
+            const usedFeatures = findUsedLualibFeatures(
+                luaTarget,
+                this.emitHost,
+                resolvedFiles.map(f => f.code)
+            );
+            return buildMinimalLualibBundle(usedFeatures, luaTarget, this.emitHost);
+        } else {
+            return getLuaLibBundle(luaTarget, this.emitHost);
+        }
     }
 }
 

--- a/test/unit/__snapshots__/bundle.spec.ts.snap
+++ b/test/unit/__snapshots__/bundle.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`LuaLibImportKind.Inline generates a warning: diagnostics 1`] = `"warning TSTL: Using 'luaBundle' with 'luaLibImport: \\"inline\\"' might generate duplicate code. It is recommended to use 'luaLibImport: \\"require\\"'."`;
 
-exports[`bundling not allowed for buildmode library: diagnostics 1`] = `"error TSTL: Cannot bundle probjects with\\"buildmode\\": \\"library\\". Projects including the library can still bundle (which will include external library files)."`;
+exports[`bundling not allowed for buildmode library: diagnostics 1`] = `"error TSTL: Cannot bundle projects with \\"buildmode\\": \\"library\\". Projects including the library can still bundle (which will include external library files)."`;
 
 exports[`luaEntry doesn't exist: diagnostics 1`] = `"error TSTL: Could not find bundle entry point 'entry.ts'. It should be a file in the project."`;
 

--- a/test/unit/builtins/loading.spec.ts
+++ b/test/unit/builtins/loading.spec.ts
@@ -16,17 +16,51 @@ describe("luaLibImport", () => {
             .tap(builder => expect(builder.getMainLuaCodeChunk()).toContain('require("lualib_bundle")'))
             .expectToMatchJsResult();
     });
+
+    function testLualibOnlyHasArrayIndexOf(builder: util.TestBuilder) {
+        const lualibBundle = builder.getLuaResult().transpiledFiles.find(f => f.outPath.endsWith("lualib_bundle.lua"))!;
+        expect(lualibBundle).toBeDefined();
+        expect(lualibBundle.lua).toEqual(expect.stringMatching("^local function __TS__ArrayIndexOf"));
+        expect(lualibBundle.lua).not.toContain("__TS__ArrayConcat");
+        expect(lualibBundle.lua).not.toContain("Error");
+    }
+
+    test("require-minimal", () => {
+        util.testExpression`[0].indexOf(1)`
+            .setOptions({ luaLibImport: tstl.LuaLibImportKind.RequireMinimal })
+            .tap(builder => expect(builder.getMainLuaCodeChunk()).toContain('require("lualib_bundle")'))
+            .tap(testLualibOnlyHasArrayIndexOf)
+            .expectToMatchJsResult();
+    });
+
+    test("require-minimal from another file", () => {
+        util.testModule`
+            import "./other";
+        `
+            .setOptions({ luaLibImport: tstl.LuaLibImportKind.RequireMinimal })
+            .addExtraFile(
+                "other.lua",
+                `
+                local ____lualib = require("lualib_bundle");
+                local __TS__ArrayIndexOf = ____lualib.__TS__ArrayIndexOf;
+            `
+            )
+            .tap(testLualibOnlyHasArrayIndexOf)
+            .expectToMatchJsResult();
+    });
 });
 
-test.each([tstl.LuaLibImportKind.Inline, tstl.LuaLibImportKind.None, tstl.LuaLibImportKind.Require])(
-    "should not include lualib without code (%p)",
-    luaLibImport => {
-        util.testModule``.setOptions({ luaLibImport }).tap(builder => expect(builder.getMainLuaCodeChunk()).toBe(""));
-    }
-);
+test.each([
+    tstl.LuaLibImportKind.Inline,
+    tstl.LuaLibImportKind.None,
+    tstl.LuaLibImportKind.Require,
+    tstl.LuaLibImportKind.RequireMinimal,
+])("should not include lualib without code (%p)", luaLibImport => {
+    util.testModule``.setOptions({ luaLibImport }).tap(builder => expect(builder.getMainLuaCodeChunk()).toBe(""));
+});
 
 test("lualib should not include tstl header", () => {
-    util.testExpression`[0].push(1)`.tap(builder =>
+    util.testExpression`[0].indexOf(1)`.tap(builder =>
         expect(builder.getMainLuaCodeChunk()).not.toContain("Generated with")
     );
 });

--- a/test/unit/builtins/loading.spec.ts
+++ b/test/unit/builtins/loading.spec.ts
@@ -46,6 +46,7 @@ local __TS__ArrayIndexOf = ____lualib.__TS__ArrayIndexOf
 __TS__ArrayIndexOf({}, 1)
             `
             )
+            // note: indent matters in above code, because searching for lualib checks for start & end of line
             .tap(testLualibOnlyHasArrayIndexOf)
             .expectNoExecutionError();
     });

--- a/test/unit/builtins/loading.spec.ts
+++ b/test/unit/builtins/loading.spec.ts
@@ -33,7 +33,7 @@ describe("luaLibImport", () => {
             .expectToMatchJsResult();
     });
 
-    test("require-minimal from another file", () => {
+    test("require-minimal with lualib in another file", () => {
         util.testModule`
             import "./other";
         `
@@ -41,12 +41,13 @@ describe("luaLibImport", () => {
             .addExtraFile(
                 "other.lua",
                 `
-                local ____lualib = require("lualib_bundle");
-                local __TS__ArrayIndexOf = ____lualib.__TS__ArrayIndexOf;
+local ____lualib = require("lualib_bundle")
+local __TS__ArrayIndexOf = ____lualib.__TS__ArrayIndexOf
+__TS__ArrayIndexOf({}, 1)
             `
             )
             .tap(testLualibOnlyHasArrayIndexOf)
-            .expectToMatchJsResult();
+            .expectNoExecutionError();
     });
 });
 


### PR DESCRIPTION
This adds the option "require-minimal" to luaLibImport.
With this, the emitted `lualib_bundle.lua` only contains used features.

This does a text search on all resolved (lua) files to determine which lualib features were used, so that projects which import lua libraries using lualib features still work.

