### PR TITLE
Fix crash on invalid call extension operator use

### DIFF
--- a/src/transformation/utils/diagnostics.ts
+++ b/src/transformation/utils/diagnostics.ts
@@ -155,3 +155,11 @@ export const unsupportedOptionalCompileMembersOnly = createErrorDiagnosticFactor
 export const undefinedInArrayLiteral = createErrorDiagnosticFactory(
     "Array literals may not contain undefined or null."
 );
+
+export const invalidMethodCallExtensionUse = createErrorDiagnosticFactory(
+    "This language extension must be called as a method."
+);
+
+export const invalidSpreadInCallExtension = createErrorDiagnosticFactory(
+    "Spread elements are not supported in call extensions."
+);

--- a/src/transformation/visitors/language-extensions/table.ts
+++ b/src/transformation/visitors/language-extensions/table.ts
@@ -1,16 +1,22 @@
 import * as ts from "typescript";
 import * as lua from "../../../LuaAST";
 import { TransformationContext } from "../../context";
-import { ExtensionKind, getExtensionKindForNode } from "../../utils/language-extensions";
-import { transformExpressionList } from "../expression-list";
-import { LanguageExtensionCallTransformer } from "./call-extension";
+import {
+    ExtensionKind,
+    getBinaryCallExtensionArgs,
+    getExtensionKindForNode,
+    getNaryCallExtensionArgs,
+} from "../../utils/language-extensions";
+import { transformOrderedExpressions } from "../expression-list";
+import { LanguageExtensionCallTransformerMap } from "./call-extension";
 
 export function isTableNewCall(context: TransformationContext, node: ts.NewExpression) {
     return getExtensionKindForNode(context, node.expression) === ExtensionKind.TableNewType;
 }
+
 export const tableNewExtensions = [ExtensionKind.TableNewType];
 
-export const tableExtensionTransformers: { [P in ExtensionKind]?: LanguageExtensionCallTransformer } = {
+export const tableExtensionTransformers: LanguageExtensionCallTransformerMap = {
     [ExtensionKind.TableDeleteType]: transformTableDeleteExpression,
     [ExtensionKind.TableDeleteMethodType]: transformTableDeleteExpression,
     [ExtensionKind.TableGetType]: transformTableGetExpression,
@@ -19,8 +25,8 @@ export const tableExtensionTransformers: { [P in ExtensionKind]?: LanguageExtens
     [ExtensionKind.TableHasMethodType]: transformTableHasExpression,
     [ExtensionKind.TableSetType]: transformTableSetExpression,
     [ExtensionKind.TableSetMethodType]: transformTableSetExpression,
-    [ExtensionKind.TableAddKeyType]: transformTableAddExpression,
-    [ExtensionKind.TableAddKeyMethodType]: transformTableAddExpression,
+    [ExtensionKind.TableAddKeyType]: transformTableAddKeyExpression,
+    [ExtensionKind.TableAddKeyMethodType]: transformTableAddKeyExpression,
 };
 
 function transformTableDeleteExpression(
@@ -28,33 +34,17 @@ function transformTableDeleteExpression(
     node: ts.CallExpression,
     extensionKind: ExtensionKind
 ): lua.Expression {
-    const args = node.arguments.slice();
-    if (
-        extensionKind === ExtensionKind.TableDeleteMethodType &&
-        (ts.isPropertyAccessExpression(node.expression) || ts.isElementAccessExpression(node.expression))
-    ) {
-        // In case of method (no table argument), push method owner to front of args list
-        args.unshift(node.expression.expression);
+    const args = getBinaryCallExtensionArgs(context, node, extensionKind);
+    if (!args) {
+        return lua.createNilLiteral();
     }
 
-    const [table, accessExpression] = transformExpressionList(context, args);
+    const [table, key] = transformOrderedExpressions(context, args);
     // arg0[arg1] = nil
     context.addPrecedingStatements(
-        lua.createAssignmentStatement(
-            lua.createTableIndexExpression(table, accessExpression),
-            lua.createNilLiteral(),
-            node
-        )
+        lua.createAssignmentStatement(lua.createTableIndexExpression(table, key), lua.createNilLiteral(), node)
     );
     return lua.createBooleanLiteral(true);
-}
-
-function transformWithTableArgument(context: TransformationContext, node: ts.CallExpression): lua.Expression[] {
-    if (ts.isPropertyAccessExpression(node.expression) || ts.isElementAccessExpression(node.expression)) {
-        return transformExpressionList(context, [node.expression.expression, ...node.arguments]);
-    }
-    // todo: report diagnostic?
-    return [lua.createNilLiteral(), ...transformExpressionList(context, node.arguments)];
 }
 
 function transformTableGetExpression(
@@ -62,14 +52,14 @@ function transformTableGetExpression(
     node: ts.CallExpression,
     extensionKind: ExtensionKind
 ): lua.Expression {
-    const args =
-        extensionKind === ExtensionKind.TableGetMethodType
-            ? transformWithTableArgument(context, node)
-            : transformExpressionList(context, node.arguments);
+    const args = getBinaryCallExtensionArgs(context, node, extensionKind);
+    if (!args) {
+        return lua.createNilLiteral();
+    }
 
-    const [table, accessExpression] = args;
+    const [table, key] = transformOrderedExpressions(context, args);
     // arg0[arg1]
-    return lua.createTableIndexExpression(table, accessExpression, node);
+    return lua.createTableIndexExpression(table, key, node);
 }
 
 function transformTableHasExpression(
@@ -77,14 +67,14 @@ function transformTableHasExpression(
     node: ts.CallExpression,
     extensionKind: ExtensionKind
 ): lua.Expression {
-    const args =
-        extensionKind === ExtensionKind.TableHasMethodType
-            ? transformWithTableArgument(context, node)
-            : transformExpressionList(context, node.arguments);
+    const args = getBinaryCallExtensionArgs(context, node, extensionKind);
+    if (!args) {
+        return lua.createNilLiteral();
+    }
 
-    const [table, accessExpression] = args;
+    const [table, key] = transformOrderedExpressions(context, args);
     // arg0[arg1]
-    const tableIndexExpression = lua.createTableIndexExpression(table, accessExpression);
+    const tableIndexExpression = lua.createTableIndexExpression(table, key);
 
     // arg0[arg1] ~= nil
     return lua.createBinaryExpression(
@@ -100,37 +90,33 @@ function transformTableSetExpression(
     node: ts.CallExpression,
     extensionKind: ExtensionKind
 ): lua.Expression {
-    const args =
-        extensionKind === ExtensionKind.TableSetMethodType
-            ? transformWithTableArgument(context, node)
-            : transformExpressionList(context, node.arguments);
+    const args = getNaryCallExtensionArgs(context, node, extensionKind, 3);
+    if (!args) {
+        return lua.createNilLiteral();
+    }
 
-    const [table, accessExpression, value] = args;
+    const [table, key, value] = transformOrderedExpressions(context, args);
     // arg0[arg1] = arg2
     context.addPrecedingStatements(
-        lua.createAssignmentStatement(lua.createTableIndexExpression(table, accessExpression), value, node)
+        lua.createAssignmentStatement(lua.createTableIndexExpression(table, key), value, node)
     );
     return lua.createNilLiteral();
 }
 
-function transformTableAddExpression(
+function transformTableAddKeyExpression(
     context: TransformationContext,
     node: ts.CallExpression,
     extensionKind: ExtensionKind
 ): lua.Expression {
-    const args =
-        extensionKind === ExtensionKind.TableAddKeyMethodType
-            ? transformWithTableArgument(context, node)
-            : transformExpressionList(context, node.arguments);
+    const args = getNaryCallExtensionArgs(context, node, extensionKind, 2);
+    if (!args) {
+        return lua.createNilLiteral();
+    }
 
-    const [table, value] = args;
+    const [table, key] = transformOrderedExpressions(context, args);
     // arg0[arg1] = true
     context.addPrecedingStatements(
-        lua.createAssignmentStatement(
-            lua.createTableIndexExpression(table, value),
-            lua.createBooleanLiteral(true),
-            node
-        )
+        lua.createAssignmentStatement(lua.createTableIndexExpression(table, key), lua.createBooleanLiteral(true), node)
     );
     return lua.createNilLiteral();
 }

--- a/test/unit/__snapshots__/optionalChaining.spec.ts.snap
+++ b/test/unit/__snapshots__/optionalChaining.spec.ts.snap
@@ -63,8 +63,11 @@ exports[`Unsupported optional chains Compile members only: diagnostics 1`] = `"m
 exports[`Unsupported optional chains Language extensions: code 1`] = `
 "local ____table_has_result_0 = ({}).has
 if ____table_has_result_0 ~= nil then
-    ____table_has_result_0 = nil[3] ~= nil
+    ____table_has_result_0 = nil
 end"
 `;
 
-exports[`Unsupported optional chains Language extensions: diagnostics 1`] = `"main.ts(2,17): error TSTL: Optional calls are not supported for builtin or language extension functions."`;
+exports[`Unsupported optional chains Language extensions: diagnostics 1`] = `
+"main.ts(2,17): error TSTL: Optional calls are not supported for builtin or language extension functions.
+main.ts(2,17): error TSTL: This language extension must be called as a method."
+`;

--- a/test/unit/language-extensions/__snapshots__/operators.spec.ts.snap
+++ b/test/unit/language-extensions/__snapshots__/operators.spec.ts.snap
@@ -2,15 +2,15 @@
 
 exports[`does not crash on invalid operator use global function: code 1`] = `""`;
 
-exports[`does not crash on invalid operator use global function: diagnostics 1`] = `"main.ts(3,9): error TS2554: Expected 2 arguments, but got 1."`;
+exports[`does not crash on invalid operator use global function: diagnostics 1`] = `"main.ts(3,13): error TS2554: Expected 2 arguments, but got 1."`;
 
 exports[`does not crash on invalid operator use method: code 1`] = `"left = {}"`;
 
-exports[`does not crash on invalid operator use method: diagnostics 1`] = `"main.ts(5,14): error TS2554: Expected 1 arguments, but got 0."`;
+exports[`does not crash on invalid operator use method: diagnostics 1`] = `"main.ts(5,18): error TS2554: Expected 1 arguments, but got 0."`;
 
 exports[`does not crash on invalid operator use unary operator: code 1`] = `"op(_G)"`;
 
-exports[`does not crash on invalid operator use unary operator: diagnostics 1`] = `"main.ts(2,27): error TS2304: Cannot find name 'LuaUnaryMinus'."`;
+exports[`does not crash on invalid operator use unary operator: diagnostics 1`] = `"main.ts(2,31): error TS2304: Cannot find name 'LuaUnaryMinus'."`;
 
 exports[`operator mapping - invalid use (const foo = (op as any)(1, 2);): code 1`] = `"foo = op(_G, 1, 2)"`;
 

--- a/test/unit/language-extensions/__snapshots__/operators.spec.ts.snap
+++ b/test/unit/language-extensions/__snapshots__/operators.spec.ts.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`does not crash on invalid operator use global function: code 1`] = `""`;
+
+exports[`does not crash on invalid operator use global function: diagnostics 1`] = `"main.ts(3,9): error TS2554: Expected 2 arguments, but got 1."`;
+
+exports[`does not crash on invalid operator use method: code 1`] = `"left = {}"`;
+
+exports[`does not crash on invalid operator use method: diagnostics 1`] = `"main.ts(5,14): error TS2554: Expected 1 arguments, but got 0."`;
+
+exports[`does not crash on invalid operator use unary operator: code 1`] = `"op(_G)"`;
+
+exports[`does not crash on invalid operator use unary operator: diagnostics 1`] = `"main.ts(2,27): error TS2304: Cannot find name 'LuaUnaryMinus'."`;
+
 exports[`operator mapping - invalid use (const foo = (op as any)(1, 2);): code 1`] = `"foo = op(_G, 1, 2)"`;
 
 exports[`operator mapping - invalid use (const foo = (op as any)(1, 2);): diagnostics 1`] = `"main.ts(3,22): error TSTL: This function must be called directly and cannot be referred to."`;

--- a/test/unit/language-extensions/__snapshots__/table.spec.ts.snap
+++ b/test/unit/language-extensions/__snapshots__/table.spec.ts.snap
@@ -133,3 +133,11 @@ __TS__ArrayMap({\\"a\\", \\"b\\", \\"c\\"}, ____table.has)"
 `;
 
 exports[`LuaTableHas extension invalid use method expression ("LuaTable<string, number>"): diagnostics 1`] = `"main.ts(3,37): error TSTL: This function must be called directly and cannot be referred to."`;
+
+exports[`does not crash on invalid extension use global function: code 1`] = `""`;
+
+exports[`does not crash on invalid extension use global function: diagnostics 1`] = `"main.ts(3,9): error TS2554: Expected 2 arguments, but got 1."`;
+
+exports[`does not crash on invalid extension use method: code 1`] = `"left = {}"`;
+
+exports[`does not crash on invalid extension use method: diagnostics 1`] = `"main.ts(5,14): error TS2554: Expected 2 arguments, but got 0."`;

--- a/test/unit/language-extensions/table.spec.ts
+++ b/test/unit/language-extensions/table.spec.ts
@@ -1,5 +1,5 @@
 import * as util from "../../util";
-import { invalidCallExtensionUse } from "../../../src/transformation/utils/diagnostics";
+import {invalidCallExtensionUse} from "../../../src/transformation/utils/diagnostics";
 
 describe("LuaTableGet & LuaTableSet extensions", () => {
     test("stand-alone function", () => {
@@ -92,7 +92,7 @@ describe("LuaTableHas extension", () => {
             export const hasBaz = tableHas(table, "baz");
         `
             .withLanguageExtensions()
-            .expectToEqual({ hasFoo: true, hasBaz: false });
+            .expectToEqual({hasFoo: true, hasBaz: false});
     });
 
     test("LuaTableHas nested expression", () => {
@@ -103,7 +103,7 @@ describe("LuaTableHas extension", () => {
             export const result = \`table has foo: \${tableHas(table, "foo")}\`;
         `
             .withLanguageExtensions()
-            .expectToEqual({ result: "table has foo: true" });
+            .expectToEqual({result: "table has foo: true"});
     });
 
     test("LuaTableHas namespace function", () => {
@@ -117,7 +117,7 @@ describe("LuaTableHas extension", () => {
             export const hasBaz = Table.tableHas(table, "baz");
         `
             .withLanguageExtensions()
-            .expectToEqual({ hasFoo: true, hasBaz: false });
+            .expectToEqual({hasFoo: true, hasBaz: false});
     });
 
     test("LuaTableHasMethod method", () => {
@@ -133,7 +133,7 @@ describe("LuaTableHas extension", () => {
             export const hasBaz = table.has("baz");
         `
             .withLanguageExtensions()
-            .expectToEqual({ hasFoo: true, hasBaz: false });
+            .expectToEqual({hasFoo: true, hasBaz: false});
     });
 
     test("LuaTableHas as statement", () => {
@@ -153,7 +153,7 @@ describe("LuaTableHas extension", () => {
             export const numCalls = count;
         `
             .withLanguageExtensions()
-            .expectToEqual({ numCalls: 1 });
+            .expectToEqual({numCalls: 1});
     });
 
     test.each([
@@ -205,7 +205,7 @@ describe("LuaTableDelete extension", () => {
             tableDelete(table, "foo");
         `
             .withLanguageExtensions()
-            .expectToEqual({ table: { baz: "baz" } });
+            .expectToEqual({table: {baz: "baz"}});
     });
 
     test("LuaTableDelete namespace function", () => {
@@ -218,7 +218,7 @@ describe("LuaTableDelete extension", () => {
             Table.tableDelete(table, "foo");
         `
             .withLanguageExtensions()
-            .expectToEqual({ table: { baz: "baz" } });
+            .expectToEqual({table: {baz: "baz"}});
     });
 
     test("LuaTableHasMethod method", () => {
@@ -233,7 +233,7 @@ describe("LuaTableDelete extension", () => {
             table.delete("foo");
         `
             .withLanguageExtensions()
-            .expectToEqual({ table: { bar: 12 } });
+            .expectToEqual({table: {bar: 12}});
     });
 
     test.each([
@@ -272,7 +272,7 @@ describe("LuaTableAddKey extension", () => {
             tableAddKey(table, "baz");
         `
             .withLanguageExtensions()
-            .expectToEqual({ table: { foo: "bar", baz: true } });
+            .expectToEqual({table: {foo: "bar", baz: true}});
     });
 
     test("LuaTableAddKey namespace function", () => {
@@ -284,7 +284,7 @@ describe("LuaTableAddKey extension", () => {
             Table.tableAddKey(table, "baz");
         `
             .withLanguageExtensions()
-            .expectToEqual({ table: { foo: "bar", baz: true } });
+            .expectToEqual({table: {foo: "bar", baz: true}});
     });
 
     test("LuaTableAddKey method", () => {
@@ -296,7 +296,7 @@ describe("LuaTableAddKey extension", () => {
             table.addKey("bar");
         `
             .withLanguageExtensions()
-            .expectToEqual({ table: { bar: true } });
+            .expectToEqual({table: {bar: true}});
     });
 
     test.each([
@@ -362,7 +362,7 @@ describe("LuaTable extension interface", () => {
         keyType => {
             util.testExpression`new LuaTable<${keyType}, unknown>()`
                 .withLanguageExtensions()
-                .setOptions({ strict: true })
+                .setOptions({strict: true})
                 .expectToHaveDiagnostics()
                 .expectDiagnosticsToMatchSnapshot();
         }
@@ -412,7 +412,7 @@ describe("LuaTable extension interface", () => {
             return tbl;
         `
             .withLanguageExtensions()
-            .expectToEqual({ baz: 5 });
+            .expectToEqual({baz: 5});
     });
 
     test("table add", () => {
@@ -422,7 +422,7 @@ describe("LuaTable extension interface", () => {
             return tbl
         `
             .withLanguageExtensions()
-            .expectToEqual({ foo: true });
+            .expectToEqual({foo: true});
     });
 
     test.each(['new LuaTable().get("foo");', 'new LuaTable().set("foo", "bar");'])(
@@ -445,7 +445,7 @@ describe("LuaTable extension interface", () => {
             return results;
         `
             .withLanguageExtensions()
-            .expectToEqual({ foo: 1, bar: 3, baz: 5 });
+            .expectToEqual({foo: 1, bar: 3, baz: 5});
     });
 });
 
@@ -467,3 +467,25 @@ test.each([
         .withLanguageExtensions()
         .expectToEqual(expected);
 });
+
+describe("does not crash on invalid extension use", () => {
+    test("global function", () => {
+        util.testModule`
+        declare const op: LuaTableGet<{}, string, any>
+        op({})
+        `
+            .withLanguageExtensions()
+            .expectDiagnosticsToMatchSnapshot()
+    })
+
+    test("method", () => {
+        util.testModule`
+        const left = {} as {
+            op: LuaTableGet<{}, string, any>
+        }
+        left.op()
+        `
+            .withLanguageExtensions()
+            .expectDiagnosticsToMatchSnapshot()
+    })
+})

--- a/test/unit/language-extensions/table.spec.ts
+++ b/test/unit/language-extensions/table.spec.ts
@@ -1,5 +1,5 @@
 import * as util from "../../util";
-import {invalidCallExtensionUse} from "../../../src/transformation/utils/diagnostics";
+import { invalidCallExtensionUse } from "../../../src/transformation/utils/diagnostics";
 
 describe("LuaTableGet & LuaTableSet extensions", () => {
     test("stand-alone function", () => {
@@ -92,7 +92,7 @@ describe("LuaTableHas extension", () => {
             export const hasBaz = tableHas(table, "baz");
         `
             .withLanguageExtensions()
-            .expectToEqual({hasFoo: true, hasBaz: false});
+            .expectToEqual({ hasFoo: true, hasBaz: false });
     });
 
     test("LuaTableHas nested expression", () => {
@@ -103,7 +103,7 @@ describe("LuaTableHas extension", () => {
             export const result = \`table has foo: \${tableHas(table, "foo")}\`;
         `
             .withLanguageExtensions()
-            .expectToEqual({result: "table has foo: true"});
+            .expectToEqual({ result: "table has foo: true" });
     });
 
     test("LuaTableHas namespace function", () => {
@@ -117,7 +117,7 @@ describe("LuaTableHas extension", () => {
             export const hasBaz = Table.tableHas(table, "baz");
         `
             .withLanguageExtensions()
-            .expectToEqual({hasFoo: true, hasBaz: false});
+            .expectToEqual({ hasFoo: true, hasBaz: false });
     });
 
     test("LuaTableHasMethod method", () => {
@@ -133,7 +133,7 @@ describe("LuaTableHas extension", () => {
             export const hasBaz = table.has("baz");
         `
             .withLanguageExtensions()
-            .expectToEqual({hasFoo: true, hasBaz: false});
+            .expectToEqual({ hasFoo: true, hasBaz: false });
     });
 
     test("LuaTableHas as statement", () => {
@@ -153,7 +153,7 @@ describe("LuaTableHas extension", () => {
             export const numCalls = count;
         `
             .withLanguageExtensions()
-            .expectToEqual({numCalls: 1});
+            .expectToEqual({ numCalls: 1 });
     });
 
     test.each([
@@ -205,7 +205,7 @@ describe("LuaTableDelete extension", () => {
             tableDelete(table, "foo");
         `
             .withLanguageExtensions()
-            .expectToEqual({table: {baz: "baz"}});
+            .expectToEqual({ table: { baz: "baz" } });
     });
 
     test("LuaTableDelete namespace function", () => {
@@ -218,7 +218,7 @@ describe("LuaTableDelete extension", () => {
             Table.tableDelete(table, "foo");
         `
             .withLanguageExtensions()
-            .expectToEqual({table: {baz: "baz"}});
+            .expectToEqual({ table: { baz: "baz" } });
     });
 
     test("LuaTableHasMethod method", () => {
@@ -233,7 +233,7 @@ describe("LuaTableDelete extension", () => {
             table.delete("foo");
         `
             .withLanguageExtensions()
-            .expectToEqual({table: {bar: 12}});
+            .expectToEqual({ table: { bar: 12 } });
     });
 
     test.each([
@@ -272,7 +272,7 @@ describe("LuaTableAddKey extension", () => {
             tableAddKey(table, "baz");
         `
             .withLanguageExtensions()
-            .expectToEqual({table: {foo: "bar", baz: true}});
+            .expectToEqual({ table: { foo: "bar", baz: true } });
     });
 
     test("LuaTableAddKey namespace function", () => {
@@ -284,7 +284,7 @@ describe("LuaTableAddKey extension", () => {
             Table.tableAddKey(table, "baz");
         `
             .withLanguageExtensions()
-            .expectToEqual({table: {foo: "bar", baz: true}});
+            .expectToEqual({ table: { foo: "bar", baz: true } });
     });
 
     test("LuaTableAddKey method", () => {
@@ -296,7 +296,7 @@ describe("LuaTableAddKey extension", () => {
             table.addKey("bar");
         `
             .withLanguageExtensions()
-            .expectToEqual({table: {bar: true}});
+            .expectToEqual({ table: { bar: true } });
     });
 
     test.each([
@@ -362,7 +362,7 @@ describe("LuaTable extension interface", () => {
         keyType => {
             util.testExpression`new LuaTable<${keyType}, unknown>()`
                 .withLanguageExtensions()
-                .setOptions({strict: true})
+                .setOptions({ strict: true })
                 .expectToHaveDiagnostics()
                 .expectDiagnosticsToMatchSnapshot();
         }
@@ -412,7 +412,7 @@ describe("LuaTable extension interface", () => {
             return tbl;
         `
             .withLanguageExtensions()
-            .expectToEqual({baz: 5});
+            .expectToEqual({ baz: 5 });
     });
 
     test("table add", () => {
@@ -422,7 +422,7 @@ describe("LuaTable extension interface", () => {
             return tbl
         `
             .withLanguageExtensions()
-            .expectToEqual({foo: true});
+            .expectToEqual({ foo: true });
     });
 
     test.each(['new LuaTable().get("foo");', 'new LuaTable().set("foo", "bar");'])(
@@ -445,7 +445,7 @@ describe("LuaTable extension interface", () => {
             return results;
         `
             .withLanguageExtensions()
-            .expectToEqual({foo: 1, bar: 3, baz: 5});
+            .expectToEqual({ foo: 1, bar: 3, baz: 5 });
     });
 });
 
@@ -475,8 +475,8 @@ describe("does not crash on invalid extension use", () => {
         op({})
         `
             .withLanguageExtensions()
-            .expectDiagnosticsToMatchSnapshot()
-    })
+            .expectDiagnosticsToMatchSnapshot();
+    });
 
     test("method", () => {
         util.testModule`
@@ -486,6 +486,6 @@ describe("does not crash on invalid extension use", () => {
         left.op()
         `
             .withLanguageExtensions()
-            .expectDiagnosticsToMatchSnapshot()
-    })
-})
+            .expectDiagnosticsToMatchSnapshot();
+    });
+});


### PR DESCRIPTION
Fixes #1385.

This also:
- Fixes using operator call extensions with preceding statements
- Adds a diagnostic if a spread element is used in call extensions, which is not supported