### PR TITLE
Implement Number.toFixed

### DIFF
--- a/src/LuaLib.ts
+++ b/src/LuaLib.ts
@@ -58,6 +58,7 @@ export enum LuaLibFeature {
     NumberIsFinite = "NumberIsFinite",
     NumberIsNaN = "NumberIsNaN",
     NumberToString = "NumberToString",
+    NumberToFixed = "NumberToFixed",
     ObjectAssign = "ObjectAssign",
     ObjectDefineProperty = "ObjectDefineProperty",
     ObjectEntries = "ObjectEntries",

--- a/src/lualib/NumberToFixed.ts
+++ b/src/lualib/NumberToFixed.ts
@@ -1,0 +1,14 @@
+/// https://www.ecma-international.org/ecma-262/10.0/index.html#sec-number.prototype.tofixed
+export function __TS__NumberToFixed(this: number, fractionDigits?: number): string {
+    if (Math.abs(this) >= 1e21 || this !== this) {
+        return this.toString();
+    }
+    const f = Math.floor(fractionDigits ?? 0);
+    // reduced to 99 as string.format only supports 2-digit numbers
+    if (f < 0 || f > 99) {
+        throw "toFixed() digits argument must be between 0 and 99";
+    }
+    // throws "invalid format (width or precision too long)" if strlen > 99
+    // if (f < 80) return fmt; else try {return fmt} catch(_) { throw "toFixed() digits argument..." }
+    return string.format(`%.${f}f`, this);
+}

--- a/src/transformation/builtins/number.ts
+++ b/src/transformation/builtins/number.ts
@@ -20,6 +20,8 @@ export function transformNumberPrototypeCall(
             return params.length === 0
                 ? lua.createCallExpression(lua.createIdentifier("tostring"), [caller], node)
                 : transformLuaLibFunction(context, LuaLibFeature.NumberToString, node, caller, ...params);
+        case "toFixed":
+            return transformLuaLibFunction(context, LuaLibFeature.NumberToFixed, node, caller, ...params);
         default:
             context.diagnostics.push(unsupportedProperty(calledMethod.name, "number", expressionName));
     }


### PR DESCRIPTION
Needs some throughts on if `Number.toFixed` has to follow JS rounding behaviour vs having simple implementation and possibly being more fast
Otherwise seems to work fine 