### PR TITLE
Fixed multi returning all values

### DIFF
--- a/src/LuaAST.ts
+++ b/src/LuaAST.ts
@@ -44,6 +44,7 @@ export enum SyntaxKind {
     MethodCallExpression,
     Identifier,
     TableIndexExpression,
+    ParenthesizedExpression,
 
     // Operators
 
@@ -842,4 +843,21 @@ export function isInlineFunctionExpression(expression: FunctionExpression): expr
         expression.body.statements[0].expressions !== undefined &&
         (expression.flags & NodeFlags.Inline) !== 0
     );
+}
+
+export type ParenthesizedExpression = Expression & {
+    expression: Expression;
+};
+
+export function isParenthesizedExpression(node: Node): node is ParenthesizedExpression {
+    return node.kind === SyntaxKind.ParenthesizedExpression;
+}
+
+export function createParenthesizedExpression(expression: Expression, tsOriginal?: ts.Node): ParenthesizedExpression {
+    const parenthesizedExpression = createNode(
+        SyntaxKind.ParenthesizedExpression,
+        tsOriginal
+    ) as ParenthesizedExpression;
+    parenthesizedExpression.expression = expression;
+    return parenthesizedExpression;
 }

--- a/src/LuaPrinter.ts
+++ b/src/LuaPrinter.ts
@@ -612,6 +612,8 @@ export class LuaPrinter {
                 return this.printIdentifier(expression as lua.Identifier);
             case lua.SyntaxKind.TableIndexExpression:
                 return this.printTableIndexExpression(expression as lua.TableIndexExpression);
+            case lua.SyntaxKind.ParenthesizedExpression:
+                return this.printParenthesizedExpression(expression as lua.ParenthesizedExpression);
             default:
                 throw new Error(`Tried to print unknown statement kind: ${lua.SyntaxKind[expression.kind]}`);
         }
@@ -820,6 +822,10 @@ export class LuaPrinter {
             chunks.push("[", this.printExpression(expression.index), "]");
         }
         return this.createSourceNode(expression, chunks);
+    }
+
+    public printParenthesizedExpression(expression: lua.ParenthesizedExpression) {
+        return this.createSourceNode(expression, ["(", this.printExpression(expression.expression), ")"]);
     }
 
     public printOperator(kind: lua.Operator): SourceNode {

--- a/test/util.ts
+++ b/test/util.ts
@@ -161,7 +161,7 @@ export abstract class TestBuilder {
         skipLibCheck: true,
         target: ts.ScriptTarget.ES2017,
         lib: ["lib.esnext.d.ts"],
-        moduleResolution: ts.ModuleResolutionKind.NodeJs,
+        moduleResolution: ts.ModuleResolutionKind.Node10,
         resolveJsonModule: true,
         experimentalDecorators: true,
         sourceMap: true,
@@ -173,7 +173,8 @@ export abstract class TestBuilder {
     }
 
     public withLanguageExtensions(): this {
-        this.setOptions({ types: [path.resolve(__dirname, "..", "language-extensions")] });
+        const langExtTypes = path.resolve(__dirname, "..", "language-extensions");
+        this.options.types = this.options.types ? [...this.options.types, langExtTypes] : [langExtTypes];
         // Polyfill lualib for JS
         this.setJsHeader(`
             function $multi(...args) { return args; }


### PR DESCRIPTION
We try to avoid using `select()` when we use `[0]` to access the first value of multiple returns (e.g. `multiCall()[0]`). In that case, we  omit the `select()`. Unfortunately, this only works if the value is assigned directly (`local x = multiCall()`). In cases where the value is not assigned, omitting the select and keeping just the call expression (`multiCall()`) will lead to all return values being passed on. (See #1411)

To fix this, we now wrap the call in parentheses using a new Lua parentheses expression. Using parentheses is the correct way to keep only the first value of multiple returns (see https://www.lua.org/manual/5.1/manual.html#2.5)

TL;DR: `multiCall()[0]` used to transpile to `multiCall()` now it transpiles to `(multiCall())` which ensures correct semantics across all potential usages.

This fixes #1411