### PR TITLE
support extends "tstl" object for tsconfig.json in node_modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
                 "prettier": "^2.8.4",
                 "ts-jest": "^29.1.0",
                 "ts-node": "^10.9.1",
-                "typescript": "^5.0.2"
+                "typescript": "^5.0.4"
             },
             "engines": {
                 "node": ">=16.10.0"
@@ -6090,9 +6090,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
-            "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+            "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -10840,9 +10840,9 @@
             }
         },
         "typescript": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
-            "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+            "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
             "dev": true
         },
         "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,6 @@
         "prettier": "^2.8.4",
         "ts-jest": "^29.1.0",
         "ts-node": "^10.9.1",
-        "typescript": "^5.0.2"
+        "typescript": "^5.0.4"
     }
 }

--- a/src/cli/tsconfig.ts
+++ b/src/cli/tsconfig.ts
@@ -58,10 +58,6 @@ export function parseConfigFileWithSystem(
     return updateParsedConfigFile(parsedConfigFile);
 }
 
-function pathIsRelative(path: string): boolean {
-    return /^\.\.?($|[\\/])/.test(path);
-}
-
 function resolveModuleConfig(
     moduleName: string,
     configRootDir: string,
@@ -79,9 +75,9 @@ function getExtendedTstlOptions(
     cycleCache: Set<string>,
     system: ts.System
 ): TypeScriptToLuaOptions {
-    const absolutePath = path.isAbsolute(configFilePath)
+    const absolutePath = ts.pathIsAbsolute(configFilePath)
         ? configFilePath
-        : pathIsRelative(configFilePath)
+        : ts.pathIsRelative(configFilePath)
         ? path.resolve(configRootDir, configFilePath)
         : resolveModuleConfig(configFilePath, configRootDir, system);
 

--- a/src/cli/tsconfig.ts
+++ b/src/cli/tsconfig.ts
@@ -58,7 +58,11 @@ export function parseConfigFileWithSystem(
     return updateParsedConfigFile(parsedConfigFile);
 }
 
-function resolveJsonConfig(
+function pathIsRelative(path: string): boolean {
+    return /^\.\.?($|[\\/])/.test(path);
+}
+
+function resolveModuleConfig(
     moduleName: string,
     configRootDir: string,
     host: ts.ModuleResolutionHost
@@ -75,7 +79,11 @@ function getExtendedTstlOptions(
     cycleCache: Set<string>,
     system: ts.System
 ): TypeScriptToLuaOptions {
-    const absolutePath = resolveJsonConfig(configFilePath, configRootDir, system);
+    const absolutePath = path.isAbsolute(configFilePath)
+        ? configFilePath
+        : pathIsRelative(configFilePath)
+        ? path.resolve(configRootDir, configFilePath)
+        : resolveModuleConfig(configFilePath, configRootDir, system);
 
     if (!absolutePath) {
         return {};

--- a/src/cli/tsconfig.ts
+++ b/src/cli/tsconfig.ts
@@ -58,13 +58,29 @@ export function parseConfigFileWithSystem(
     return updateParsedConfigFile(parsedConfigFile);
 }
 
+function resolveJsonConfig(
+    moduleName: string,
+    configRootDir: string,
+    host: ts.ModuleResolutionHost
+): string | undefined {
+    const resolved = ts.nodeNextJsonConfigResolver(moduleName, path.join(configRootDir, "tsconfig.json"), host);
+    if (resolved.resolvedModule) {
+        return resolved.resolvedModule.resolvedFileName;
+    }
+}
+
 function getExtendedTstlOptions(
     configFilePath: string,
     configRootDir: string,
     cycleCache: Set<string>,
     system: ts.System
 ): TypeScriptToLuaOptions {
-    const absolutePath = path.isAbsolute(configFilePath) ? configFilePath : path.resolve(configRootDir, configFilePath);
+    const absolutePath = resolveJsonConfig(configFilePath, configRootDir, system);
+
+    if (!absolutePath) {
+        return {};
+    }
+
     const newConfigRoot = path.dirname(absolutePath);
 
     if (cycleCache.has(absolutePath)) {

--- a/src/cli/tsconfig.ts
+++ b/src/cli/tsconfig.ts
@@ -58,7 +58,7 @@ export function parseConfigFileWithSystem(
     return updateParsedConfigFile(parsedConfigFile);
 }
 
-function resolveModuleConfig(
+function resolveNpmModuleConfig(
     moduleName: string,
     configRootDir: string,
     host: ts.ModuleResolutionHost
@@ -79,7 +79,7 @@ function getExtendedTstlOptions(
         ? configFilePath
         : ts.pathIsRelative(configFilePath)
         ? path.resolve(configRootDir, configFilePath)
-        : resolveModuleConfig(configFilePath, configRootDir, system);
+        : resolveNpmModuleConfig(configFilePath, configRootDir, system); // if a path is neither relative nor absolute, it is probably a npm module
 
     if (!absolutePath) {
         return {};

--- a/src/typescript-internal.d.ts
+++ b/src/typescript-internal.d.ts
@@ -50,4 +50,10 @@ declare module "typescript" {
 
     function skipOuterExpressions(node: Expression, kinds?: OuterExpressionKinds): Expression;
     export function isOuterExpression(node: Node, kinds?: OuterExpressionKinds): node is OuterExpression;
+
+    export function nodeNextJsonConfigResolver(
+        moduleName: string,
+        containingFile: string,
+        host: ModuleResolutionHost
+    ): ResolvedModuleWithFailedLookupLocations;
 }

--- a/src/typescript-internal.d.ts
+++ b/src/typescript-internal.d.ts
@@ -56,4 +56,7 @@ declare module "typescript" {
         containingFile: string,
         host: ModuleResolutionHost
     ): ResolvedModuleWithFailedLookupLocations;
+
+    export function pathIsAbsolute(path: string): boolean;
+    export function pathIsRelative(path: string): boolean;
 }


### PR DESCRIPTION
#1436 doesn't handle such case:
```
{
    "extends": "my-npm-module/tsconfig.dev.json",
}
```
This PR fix this with ts internal API.