### PR TITLE
Fix different function (address) return on use bind, on object method

### DIFF
--- a/src/lualib/FunctionBind.ts
+++ b/src/lualib/FunctionBind.ts
@@ -3,6 +3,19 @@ export function __TS__FunctionBind(
     fn: (this: void, ...argArray: any[]) => any,
     ...boundArgs: any[]
 ): (...args: any[]) => any {
+    if (typeof boundArgs[0] === "object") {
+        const address = tostring(fn);
+        const bound = boundArgs[0];
+        if (!bound.__TS__wrappedMethods) bound.__TS__wrappedMethods = {};
+        if (!bound.__TS__wrappedMethods[address]) {
+            bound.__TS__wrappedMethods[address] = (...args: any[]) => {
+                args.unshift(...boundArgs);
+                return fn(...args);
+            };
+        }
+        return bound.__TS__wrappedMethods[address];
+    }
+
     return (...args: any[]) => {
         args.unshift(...boundArgs);
         return fn(...args);

--- a/test/unit/classes/classes.spec.ts
+++ b/test/unit/classes/classes.spec.ts
@@ -315,6 +315,20 @@ test("ClassMethodCall", () => {
     `.expectToMatchJsResult();
 });
 
+test("ClassMethodHasSameAddressAfterBinding", () => {
+    util.testFunction`
+        class a {
+            public isSame() {
+                let cb1 = '' + this.method.bind(this)
+                let cb2 = '' + this.method.bind(this)
+                return cb1 === cb2
+            }
+            public method() {}
+        }
+        return new a().isSame();
+    `.expectToEqual(true);
+});
+
 test("ClassNumericLiteralMethodCall", () => {
     util.testFunction`
         class a {


### PR DESCRIPTION
That importanf for friendly subscribe/unsubscribe callbacks.
```ts
class A {
  start() {
    subscribe(this.doSome.bind(this))
  }
  stop() {
    unsubscribe(this.doSome.bind(this))
  }
  doSome() {}
}
```

How its works - on binding method also wrap to arrow function, but then once save to `__TS__wrappedMethods` in binding context. On next bind same method with same content, result getting from __TS__wrappedMethods.

Any solution to make `.bind(this)` is auto to make code more comfortable and shortly ?