### PR TITLE
Add "luaLibImport: require-minimal" option value under TSConfig schema

### DIFF
--- a/tsconfig-schema.json
+++ b/tsconfig-schema.json
@@ -44,7 +44,7 @@
                     "description": "Specifies how js standard features missing in lua are imported.",
                     "type": "string",
                     "default": "require",
-                    "enum": ["none", "inline", "require"]
+                    "enum": ["none", "inline", "require", "require-minimal"]
                 },
                 "luaTarget": {
                     "description": "Specifies the Lua version you want to generate code for.",


### PR DESCRIPTION
According to the [docs](https://typescripttolua.github.io/docs/configuration#custom-options), it's allowed to set the following enum values for this option:

- `none`
- `inline`
- `require`
- `require-minimal`

However, the current TSConfig schema doesn't support `require-minimal`, making the VSCode complain about this value:
![require-minimal-error](https://github.com/TypeScriptToLua/TypeScriptToLua/assets/1957938/7f19e3ec-4c1a-4fa8-b5ba-34ae785136e8)

The fix attempts to resolve this problem.