### PR TITLE
Fix synthetic transformer nodes throwing on getChildren when transforming switch statements

### DIFF
--- a/src/transformation/visitors/switch.ts
+++ b/src/transformation/visitors/switch.ts
@@ -9,10 +9,16 @@ const containsBreakOrReturn = (nodes: Iterable<ts.Node>): boolean => {
     for (const s of nodes) {
         if (ts.isBreakStatement(s) || ts.isReturnStatement(s)) {
             return true;
-        } else if (ts.isBlock(s) && containsBreakOrReturn(s.getChildren())) {
+        } else if (ts.isBlock(s) && containsBreakOrReturn(s.statements)) {
             return true;
-        } else if (s.kind === ts.SyntaxKind.SyntaxList && containsBreakOrReturn(s.getChildren())) {
-            return true;
+        } else if (s.kind === ts.SyntaxKind.SyntaxList) {
+            // We cannot use getChildren() because that breaks when using synthetic nodes from transformers
+            // So get children the long way
+            const children: ts.Node[] = [];
+            ts.forEachChild(s, c => children.push(c));
+            if (containsBreakOrReturn(children)) {
+                return true;
+            }
         }
     }
 

--- a/test/transpile/transformers/transformers.spec.ts
+++ b/test/transpile/transformers/transformers.spec.ts
@@ -35,3 +35,22 @@ describe("factory types", () => {
             .expectToEqual(true);
     });
 });
+
+// https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1464
+test("transformer with switch does not break (#1464)", () => {
+    util.testFunction`
+        const foo: number = 3;
+        switch (foo) {
+            case 2: {
+                return 10;
+            }
+            case 3: {
+                return false;
+            }
+        }
+    `
+        .setOptions({
+            plugins: [{ transform: path.join(__dirname, "fixtures.ts"), import: "program", value: true }],
+        })
+        .expectToEqual(true);
+});


### PR DESCRIPTION
Fixes #1464 