### PR TITLE
Lua table is empty

### DIFF
--- a/language-extensions/index.d.ts
+++ b/language-extensions/index.d.ts
@@ -563,6 +563,20 @@ declare type LuaTableDeleteMethod<TKey extends AnyNotNil> = ((key: TKey) => bool
     LuaExtension<"TableDeleteMethod">;
 
 /**
+ * Calls to functions with this type are translated to `next(myTable) == nil`.
+ * For more information see: https://typescripttolua.github.io/docs/advanced/language-extensions
+ *
+ * @param TTable The type to access as a Lua table.
+ */
+declare type LuaTableIsEmpty<TTable extends AnyTable> = ((table: TTable) => boolean) & LuaExtension<"TableIsEmpty">;
+
+/**
+ * Calls to methods with this type are translated to `next(myTable) == nil`, where `table` is the object with the method.
+ * For more information see: https://typescripttolua.github.io/docs/advanced/language-extensions
+ */
+declare type LuaTableIsEmptyMethod = (() => boolean) & LuaExtension<"TableIsEmptyMethod">;
+
+/**
  * A convenience type for working directly with a Lua table.
  * For more information see: https://typescripttolua.github.io/docs/advanced/language-extensions
  *
@@ -575,6 +589,7 @@ declare interface LuaTable<TKey extends AnyNotNil = AnyNotNil, TValue = any> ext
     set: LuaTableSetMethod<TKey, TValue>;
     has: LuaTableHasMethod<TKey>;
     delete: LuaTableDeleteMethod<TKey>;
+    isEmpty: LuaTableIsEmptyMethod;
 }
 
 /**
@@ -612,6 +627,7 @@ declare interface LuaMap<K extends AnyNotNil = AnyNotNil, V = any> extends LuaPa
     set: LuaTableSetMethod<K, V>;
     has: LuaTableHasMethod<K>;
     delete: LuaTableDeleteMethod<K>;
+    isEmpty: LuaTableIsEmptyMethod;
 }
 
 /**
@@ -633,6 +649,7 @@ declare const LuaMap: (new <K extends AnyNotNil = AnyNotNil, V = any>() => LuaMa
 declare interface ReadonlyLuaMap<K extends AnyNotNil = AnyNotNil, V = any> extends LuaPairsIterable<K, V> {
     get: LuaTableGetMethod<K, V | undefined>;
     has: LuaTableHasMethod<K>;
+    isEmpty: LuaTableIsEmptyMethod;
 }
 
 /**
@@ -645,6 +662,7 @@ declare interface LuaSet<T extends AnyNotNil = AnyNotNil> extends LuaPairsKeyIte
     add: LuaTableAddKeyMethod<T>;
     has: LuaTableHasMethod<T>;
     delete: LuaTableDeleteMethod<T>;
+    isEmpty: LuaTableIsEmptyMethod;
 }
 
 /**
@@ -662,6 +680,7 @@ declare const LuaSet: (new <T extends AnyNotNil = AnyNotNil>() => LuaSet<T>) & L
  */
 declare interface ReadonlyLuaSet<T extends AnyNotNil = AnyNotNil> extends LuaPairsKeyIterable<T> {
     has: LuaTableHasMethod<T>;
+    isEmpty: LuaTableIsEmptyMethod;
 }
 
 interface ObjectConstructor {

--- a/src/transformation/utils/language-extensions.ts
+++ b/src/transformation/utils/language-extensions.ts
@@ -122,31 +122,9 @@ export function getIterableExtensionKindForNode(
     return getIterableExtensionTypeForType(context, type);
 }
 
-export const methodExtensionKinds: ReadonlySet<ExtensionKind> = new Set<ExtensionKind>([
-    ExtensionKind.AdditionOperatorMethodType,
-    ExtensionKind.SubtractionOperatorMethodType,
-    ExtensionKind.MultiplicationOperatorMethodType,
-    ExtensionKind.DivisionOperatorMethodType,
-    ExtensionKind.ModuloOperatorMethodType,
-    ExtensionKind.PowerOperatorMethodType,
-    ExtensionKind.FloorDivisionOperatorMethodType,
-    ExtensionKind.BitwiseAndOperatorMethodType,
-    ExtensionKind.BitwiseOrOperatorMethodType,
-    ExtensionKind.BitwiseExclusiveOrOperatorMethodType,
-    ExtensionKind.BitwiseLeftShiftOperatorMethodType,
-    ExtensionKind.BitwiseRightShiftOperatorMethodType,
-    ExtensionKind.ConcatOperatorMethodType,
-    ExtensionKind.LessThanOperatorMethodType,
-    ExtensionKind.GreaterThanOperatorMethodType,
-    ExtensionKind.NegationOperatorMethodType,
-    ExtensionKind.BitwiseNotOperatorMethodType,
-    ExtensionKind.LengthOperatorMethodType,
-    ExtensionKind.TableDeleteMethodType,
-    ExtensionKind.TableGetMethodType,
-    ExtensionKind.TableHasMethodType,
-    ExtensionKind.TableSetMethodType,
-    ExtensionKind.TableAddKeyMethodType,
-]);
+export const methodExtensionKinds: ReadonlySet<ExtensionKind> = new Set<ExtensionKind>(
+    Object.values(ExtensionKind).filter(key => key.endsWith("Method"))
+);
 
 export function getNaryCallExtensionArgs(
     context: TransformationContext,

--- a/src/transformation/utils/language-extensions.ts
+++ b/src/transformation/utils/language-extensions.ts
@@ -53,6 +53,8 @@ export enum ExtensionKind {
     TableSetMethodType = "TableSetMethod",
     TableAddKeyType = "TableAddKey",
     TableAddKeyMethodType = "TableAddKeyMethod",
+    TableIsEmptyType = "TableIsEmpty",
+    TableIsEmptyMethodType = "TableIsEmptyMethod",
 }
 
 const extensionValues: Set<string> = new Set(Object.values(ExtensionKind));


### PR DESCRIPTION
Added LuaTableIsEmpty & LuaTableIsEmptyMethod
and added an isEmpty method to LuaTable, LuaMap & LuaSet

Refactored existing table tests: Extensions used inside expressions are now tested in a single suite.

Closes #1466 