### PR TITLE
fix: add check to see in ownerSymbol parent is the global symbol

### DIFF
--- a/src/transformation/builtins/index.ts
+++ b/src/transformation/builtins/index.ts
@@ -81,7 +81,8 @@ function tryTransformBuiltinGlobalMethodCall(
 ) {
     const ownerType = context.checker.getTypeAtLocation(calledMethod.expression);
     const ownerSymbol = tryGetStandardLibrarySymbolOfType(context, ownerType);
-    if (!ownerSymbol || ownerSymbol.parent) return;
+    if (!ownerSymbol || (ownerSymbol.parent && context.checker.getFullyQualifiedName(ownerSymbol.parent) !== "global"))
+        return;
 
     let result: lua.Expression | undefined;
     switch (ownerSymbol.name) {


### PR DESCRIPTION
when determining when to transform global builtin calls.