### PR TITLE
Fix excessive sourcemap traceback import in bundle mode

### DIFF
--- a/src/LuaPrinter.ts
+++ b/src/LuaPrinter.ts
@@ -173,7 +173,8 @@ export class LuaPrinter {
 
     public print(file: lua.File): PrintResult {
         // Add traceback lualib if sourcemap traceback option is enabled
-        if (this.options.sourceMapTraceback) {
+        // Not required locally when in bundle mode
+        if (this.options.sourceMapTraceback && !isBundleEnabled(this.options)) {
             file.luaLibFeatures.add(LuaLibFeature.SourceMapTraceBack);
         }
 

--- a/src/transpilation/transpiler.ts
+++ b/src/transpilation/transpiler.ts
@@ -1,7 +1,7 @@
 import * as path from "path";
 import * as ts from "typescript";
 import { CompilerOptions, isBundleEnabled, LuaLibImportKind, LuaTarget } from "../CompilerOptions";
-import { buildMinimalLualibBundle, findUsedLualibFeatures, getLuaLibBundle } from "../LuaLib";
+import { buildMinimalLualibBundle, findUsedLualibFeatures, getLuaLibBundle, LuaLibFeature } from "../LuaLib";
 import { normalizeSlashes, trimExtension } from "../utils";
 import { getBundleResult } from "./bundle";
 import { getPlugins, Plugin } from "./plugins";
@@ -155,6 +155,10 @@ export class Transpiler {
                 this.emitHost,
                 resolvedFiles.map(f => f.code)
             );
+            // Will be required later by bundle result when sourcemap traceback option is enabled
+            if (options.sourceMapTraceback) {
+                usedFeatures.add(LuaLibFeature.SourceMapTraceBack);
+            }
             return buildMinimalLualibBundle(usedFeatures, luaTarget, this.emitHost);
         } else {
             return getLuaLibBundle(luaTarget, this.emitHost);


### PR DESCRIPTION
### Environment
- `luaBundle{Entry}` enabled
- `sourceMapTraceback` enabled

### Before:

`__TS__SourceMapTraceBack` being required in every module even when not being used.

```lua
____modules = {
["lualib_bundle"] = function(...) 
local function __TS__SourceMapTraceBack(fileName, sourceMap)
    ...
end
 end,
["mod1"] = function(...) 
local ____lualib = require("lualib_bundle")
local __TS__SourceMapTraceBack = ____lualib.__TS__SourceMapTraceBack
 end,
["mod2"] = function(...) 
local ____lualib = require("lualib_bundle")
local __TS__SourceMapTraceBack = ____lualib.__TS__SourceMapTraceBack
 end,
}

local __TS__SourceMapTraceBack = require("lualib_bundle").__TS__SourceMapTraceBack
__TS__SourceMapTraceBack(debug.getinfo(1).short_src, {...})
```

### After:
```lua
____modules = {
["lualib_bundle"] = function(...) 
local function __TS__SourceMapTraceBack(fileName, sourceMap)
    ...
end
 end,
["mod1"] = function(...) 
 end,
["mod2"] = function(...) 
 end,
}

local __TS__SourceMapTraceBack = require("lualib_bundle").__TS__SourceMapTraceBack
__TS__SourceMapTraceBack(debug.getinfo(1).short_src, {...})
```
