### PR TITLE
Add support for Glob-Patterns in "noResolvePaths"

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,10 +47,12 @@
     "dependencies": {
         "@typescript-to-lua/language-extensions": "1.0.0",
         "enhanced-resolve": "^5.8.2",
+        "picomatch": "^2.3.1",
         "resolve": "^1.15.1",
         "source-map": "^0.7.3"
     },
     "devDependencies": {
+        "@types/picomatch": "^2.3.0",
         "@types/fs-extra": "^8.1.0",
         "@types/glob": "^7.1.1",
         "@types/jest": "^27.5.2",


### PR DESCRIPTION
Add support for glob patterns in `noResolvePaths` using [picomatch](https://github.com/micromatch/picomatch ).

Also supplies `0` as the duration for the CachedInputFileSystem as updated typing requires so.  
This change should not change any caching behavior as it explicitly causes the current behavior to be used (see [here](https://github.com/webpack/enhanced-resolve/blob/3a28f47788de794d9da4d1702a3a583d8422cd48/lib/CachedInputFileSystem.js#L458))

Fixes #1161.