### PR TITLE
Add support for TS 5.2 using and await using keywords

### DIFF
--- a/src/LuaLib.ts
+++ b/src/LuaLib.ts
@@ -107,6 +107,7 @@ export enum LuaLibFeature {
     TypeOf = "TypeOf",
     Unpack = "Unpack",
     Using = "Using",
+    UsingAsync = "UsingAsync",
 }
 
 export interface LuaLibFeatureInfo {

--- a/src/LuaLib.ts
+++ b/src/LuaLib.ts
@@ -106,6 +106,7 @@ export enum LuaLibFeature {
     SymbolRegistry = "SymbolRegistry",
     TypeOf = "TypeOf",
     Unpack = "Unpack",
+    Using = "Using",
 }
 
 export interface LuaLibFeatureInfo {

--- a/src/lualib/Symbol.ts
+++ b/src/lualib/Symbol.ts
@@ -9,6 +9,7 @@ export function __TS__Symbol(this: void, description?: string | number): symbol 
 }
 
 export const Symbol = {
+    dispose: __TS__Symbol("Symbol.dispose"),
     iterator: __TS__Symbol("Symbol.iterator"),
     hasInstance: __TS__Symbol("Symbol.hasInstance"),
 

--- a/src/lualib/Symbol.ts
+++ b/src/lualib/Symbol.ts
@@ -9,6 +9,7 @@ export function __TS__Symbol(this: void, description?: string | number): symbol 
 }
 
 export const Symbol = {
+    asyncDispose: __TS__Symbol("Symbol.asyncDispose"),
     dispose: __TS__Symbol("Symbol.dispose"),
     iterator: __TS__Symbol("Symbol.iterator"),
     hasInstance: __TS__Symbol("Symbol.hasInstance"),

--- a/src/lualib/Using.ts
+++ b/src/lualib/Using.ts
@@ -1,0 +1,22 @@
+export function __TS__Using<TArgs extends Disposable[], TReturn>(
+    this: undefined,
+    cb: (...args: TArgs) => TReturn,
+    ...args: TArgs
+): TReturn {
+    let thrownError;
+    const [ok, result] = xpcall(
+        () => cb(...args),
+        err => (thrownError = err)
+    );
+
+    const argArray = [...args];
+    for (let i = argArray.length - 1; i >= 0; i--) {
+        argArray[i][Symbol.dispose]();
+    }
+
+    if (!ok) {
+        throw thrownError;
+    }
+
+    return result;
+}

--- a/src/lualib/UsingAsync.ts
+++ b/src/lualib/UsingAsync.ts
@@ -1,0 +1,27 @@
+export async function __TS__UsingAsync<TArgs extends Array<Disposable | AsyncDisposable>, TReturn>(
+    this: undefined,
+    cb: (...args: TArgs) => TReturn,
+    ...args: TArgs
+): Promise<TReturn> {
+    let thrownError;
+    const [ok, result] = xpcall(
+        () => cb(...args),
+        err => (thrownError = err)
+    );
+
+    const argArray = [...args];
+    for (let i = argArray.length - 1; i >= 0; i--) {
+        if (Symbol.dispose in argArray[i]) {
+            (argArray[i] as Disposable)[Symbol.dispose]();
+        }
+        if (Symbol.asyncDispose in argArray[i]) {
+            await (argArray[i] as AsyncDisposable)[Symbol.asyncDispose]();
+        }
+    }
+
+    if (!ok) {
+        throw thrownError;
+    }
+
+    return result;
+}

--- a/src/transformation/index.ts
+++ b/src/transformation/index.ts
@@ -34,8 +34,11 @@ export function createVisitorMap(customVisitors: Visitors[]): VisitorMap {
 export function transformSourceFile(program: ts.Program, sourceFile: ts.SourceFile, visitorMap: VisitorMap) {
     const context = new TransformationContext(program, sourceFile, visitorMap);
 
-    const result = ts.transform(sourceFile, [usingTransformer(context)]);
+    // TS -> TS pre-transformation
+    const preTransformers = [usingTransformer(context)];
+    const result = ts.transform(sourceFile, preTransformers);
 
+    // TS -> Lua transformation
     const [file] = context.transformNode(result.transformed[0]) as [lua.File];
 
     return { file, diagnostics: context.diagnostics };

--- a/src/transformation/index.ts
+++ b/src/transformation/index.ts
@@ -3,6 +3,7 @@ import * as lua from "../LuaAST";
 import { getOrUpdate } from "../utils";
 import { ObjectVisitor, TransformationContext, VisitorMap, Visitors } from "./context";
 import { standardVisitors } from "./visitors";
+import { usingTransformer } from "./pre-transformers/using-transformer";
 
 export function createVisitorMap(customVisitors: Visitors[]): VisitorMap {
     const objectVisitorMap: Map<ts.SyntaxKind, Array<ObjectVisitor<ts.Node>>> = new Map();
@@ -32,7 +33,10 @@ export function createVisitorMap(customVisitors: Visitors[]): VisitorMap {
 
 export function transformSourceFile(program: ts.Program, sourceFile: ts.SourceFile, visitorMap: VisitorMap) {
     const context = new TransformationContext(program, sourceFile, visitorMap);
-    const [file] = context.transformNode(sourceFile) as [lua.File];
+
+    const result = ts.transform(sourceFile, [usingTransformer(context)]);
+
+    const [file] = context.transformNode(result.transformed[0]) as [lua.File];
 
     return { file, diagnostics: context.diagnostics };
 }

--- a/src/transformation/visitors/function.ts
+++ b/src/transformation/visitors/function.ts
@@ -227,7 +227,15 @@ export function transformFunctionToExpression(
 
     const type = context.checker.getTypeAtLocation(node);
     let functionContext: lua.Identifier | undefined;
-    if (getFunctionContextType(context, type) !== ContextType.Void) {
+
+    const firstParam = node.parameters[0];
+    const hasThisVoidParameter =
+        firstParam &&
+        ts.isIdentifier(firstParam.name) &&
+        ts.identifierToKeywordKind(firstParam.name) === ts.SyntaxKind.ThisKeyword &&
+        firstParam.type?.kind === ts.SyntaxKind.VoidKeyword;
+
+    if (!hasThisVoidParameter && getFunctionContextType(context, type) !== ContextType.Void) {
         if (ts.isArrowFunction(node)) {
             // dummy context for arrow functions with parameters
             if (node.parameters.length > 0) {

--- a/src/transformation/visitors/variable-declaration.ts
+++ b/src/transformation/visitors/variable-declaration.ts
@@ -282,8 +282,8 @@ export function transformVariableDeclaration(
 }
 
 export function checkVariableDeclarationList(context: TransformationContext, node: ts.VariableDeclarationList): void {
-    if ((node.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const)) === 0) {
-        const token = node.getFirstToken();
+    if ((node.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const | ts.NodeFlags.Using | ts.NodeFlags.AwaitUsing)) === 0) {
+        const token = ts.getOriginalNode(node).getFirstToken();
         assert(token);
         context.diagnostics.push(unsupportedVarDeclaration(token));
     }

--- a/src/typescript-internal.d.ts
+++ b/src/typescript-internal.d.ts
@@ -59,4 +59,6 @@ declare module "typescript" {
 
     export function pathIsAbsolute(path: string): boolean;
     export function pathIsRelative(path: string): boolean;
+
+    export function setParent<T extends Node>(child: T, parent: T["parent"] | undefined): T;
 }

--- a/test/unit/using.spec.ts
+++ b/test/unit/using.spec.ts
@@ -1,0 +1,114 @@
+import * as util from "../util";
+
+const usingTestLib = `
+    export const logs: string[] = [];
+
+    function loggedDisposable(id: string): Disposable {
+        logs.push(\`Creating \${id}\`);
+
+        return {
+            [Symbol.dispose]() {
+                logs.push(\`Disposing \${id}\`);
+            }
+        }
+    }`;
+
+test("using disposes object at end of function", () => {
+    util.testModule`        
+        function func() {
+            using a = loggedDisposable("a");
+            using b = loggedDisposable("b");
+
+            logs.push("function content");
+        }
+        
+        func();
+    `
+        .setTsHeader(usingTestLib)
+        .expectToEqual({ logs: ["Creating a", "Creating b", "function content", "Disposing b", "Disposing a"] });
+});
+
+test("handles multi-variable declarations", () => {
+    util.testModule`        
+        function func() {
+            using a = loggedDisposable("a"), b = loggedDisposable("b");
+
+            logs.push("function content");
+        }
+        
+        func();
+    `
+        .setTsHeader(usingTestLib)
+        .expectToEqual({ logs: ["Creating a", "Creating b", "function content", "Disposing b", "Disposing a"] });
+});
+
+test("using disposes object at end of nested block", () => {
+    util.testModule`        
+        function func() {
+            using a = loggedDisposable("a");
+
+            {
+                using b = loggedDisposable("b");
+                logs.push("nested block");
+            }
+
+            logs.push("function content");
+        }
+        
+        func();
+    `
+        .setTsHeader(usingTestLib)
+        .expectToEqual({
+            logs: ["Creating a", "Creating b", "nested block", "Disposing b", "function content", "Disposing a"],
+        });
+});
+
+test("using does not affect function return value", () => {
+    util.testModule`        
+        function func() {
+            using a = loggedDisposable("a");
+            using b = loggedDisposable("b");
+
+            logs.push("function content");
+
+            return "success";
+        }
+        
+        export const result = func();
+    `
+        .setTsHeader(usingTestLib)
+        .expectToEqual({
+            result: "success",
+            logs: ["Creating a", "Creating b", "function content", "Disposing b", "Disposing a"],
+        });
+});
+
+test("using disposes even when error happens", () => {
+    util.testModule` 
+        function func() {
+            using a = loggedDisposable("a");
+            using b = loggedDisposable("b");
+
+            throw "test-induced exception";
+        }
+
+        try 
+        {
+            func();
+        }
+        catch (e)
+        {
+            logs.push(\`caught exception: \${e}\`);
+        }
+    `
+        .setTsHeader(usingTestLib)
+        .expectToEqual({
+            logs: [
+                "Creating a",
+                "Creating b",
+                "Disposing b",
+                "Disposing a",
+                "caught exception: test-induced exception",
+            ],
+        });
+});


### PR DESCRIPTION
Adds support for the new `using` and `await using` feature introduced in TypeScript 5.2, see: https://devblogs.microsoft.com/typescript/announcing-typescript-5-2/

This way of transforming the TS AST could be used to replace many more occurrences of lualib-like things, without needing to add that logic and checking to the main transformer visitors. This could potentially help with maintainability of lualib replacements. Performance difference still TBD.
