### PR TITLE
Auto publish language-extensions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,3 +21,5 @@ jobs:
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+      - run: cd language-extensions
+      - run: npm publish

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "fix:prettier": "prettier --write .",
         "check:language-extensions": "tsc --strict language-extensions/index.d.ts",
         "preversion": "npm run build && npm test",
-        "postversion": "git push && git push --tags"
+        "postversion": "git push && git push --tags && NEW_VERSION=$(npm pkg get version --workspaces=false | tr -d \") && cd language-extensions && npm version $NEW_VERSION && git push && git push --tags" 
     },
     "bin": {
         "tstl": "dist/tstl.js"


### PR DESCRIPTION
When. a release of the main package is created via `npm version`, the subpackage `language-extensions` will get bumped to the same version. Both will then be published to npm via GitHub Actions