### PR TITLE
Do not cause unrelated exception when throwing Error object in environment without debug module

### DIFF
--- a/src/lualib/Error.ts
+++ b/src/lualib/Error.ts
@@ -3,7 +3,10 @@ interface ErrorType {
     new (...args: any[]): Error;
 }
 
-function getErrorStack(constructor: () => any): string {
+function getErrorStack(constructor: () => any): string | undefined {
+    // If debug module is not available in this environment, don't bother trying to get stack trace
+    if (debug === undefined) return undefined;
+
     let level = 1;
     while (true) {
         const info = debug.getinfo(level, "f");
@@ -49,7 +52,7 @@ function initErrorClass(Type: ErrorType, name: string): any {
 export const Error: ErrorConstructor = initErrorClass(
     class implements Error {
         public name = "Error";
-        public stack: string;
+        public stack?: string;
 
         constructor(public message = "") {
             this.stack = getErrorStack((this.constructor as any).new);

--- a/test/unit/error.spec.ts
+++ b/test/unit/error.spec.ts
@@ -324,3 +324,22 @@ test.each([...builtinErrors, "CustomError"])("get stack from %s", errorType => {
     expect(stack).toMatch("innerFunction");
     expect(stack).toMatch("outerFunction");
 });
+
+test("still works without debug module", () => {
+    util.testFunction`
+        try
+        {
+            throw new Error("hello, world");
+        }
+        catch (e)
+        {
+            return e;
+        }
+    `
+        .setLuaHeader("debug = nil")
+        .expectToEqual({
+            message: "hello, world",
+            name: "Error",
+            stack: undefined,
+        });
+});


### PR DESCRIPTION
This was reported in the discord.

Some environments remove the debug module for various reasons such as security. In that case throwing an `Error` object should just contain an `undefined` stack trace.

Currently we try to get the stacktrace anyway and it is throwing a nil indexing exception in the Error constructor, that has been corrected in this PR.