### PR TITLE
Add `forceNoSelf` option to `tstl`

### DIFF
--- a/src/CompilerOptions.ts
+++ b/src/CompilerOptions.ts
@@ -32,6 +32,7 @@ export interface TypeScriptToLuaOptions {
     luaLibImport?: LuaLibImportKind;
     luaPlugins?: LuaPluginImport[];
     noImplicitGlobalVariables?: boolean;
+    forceNoSelf?: string[];
     noImplicitSelf?: boolean;
     noHeader?: boolean;
     noResolvePaths?: string[];

--- a/src/cli/parse.ts
+++ b/src/cli/parse.ts
@@ -65,6 +65,12 @@ export const optionDeclarations: CommandLineOption[] = [
         type: "boolean",
     },
     {
+        name: "forceNoSelf",
+        description:
+            "List of file names to match, and if they are matched, they will be counted as having the noSelfInFile option.",
+        type: "array",
+    },
+    {
         name: "noImplicitSelf",
         description: 'If "this" is implicitly considered an any type, do not generate a self parameter.',
         type: "boolean",

--- a/src/transformation/utils/function-context.ts
+++ b/src/transformation/utils/function-context.ts
@@ -20,7 +20,11 @@ function hasNoSelfAncestor(options: CompilerOptions, declaration: ts.Declaration
     if (!scopeDeclaration) {
         return false;
     } else if (ts.isSourceFile(scopeDeclaration)) {
-        if (options.forceNoSelf !== undefined && typeof options.forceNoSelf === "object") {
+        if (
+            options.forceNoSelf !== undefined &&
+            typeof options.forceNoSelf === "object" &&
+            Array.isArray(options.forceNoSelf)
+        ) {
             for (const name of options.forceNoSelf) {
                 if (scopeDeclaration.fileName.includes(name)) {
                     return true;

--- a/src/transformation/utils/function-context.ts
+++ b/src/transformation/utils/function-context.ts
@@ -20,11 +20,7 @@ function hasNoSelfAncestor(options: CompilerOptions, declaration: ts.Declaration
     if (!scopeDeclaration) {
         return false;
     } else if (ts.isSourceFile(scopeDeclaration)) {
-        if (
-            options.forceNoSelf !== undefined &&
-            typeof options.forceNoSelf === "object" &&
-            Array.isArray(options.forceNoSelf)
-        ) {
+        if (Array.isArray(options.forceNoSelf)) {
             for (const name of options.forceNoSelf) {
                 if (scopeDeclaration.fileName.includes(name)) {
                     return true;

--- a/tsconfig-schema.json
+++ b/tsconfig-schema.json
@@ -57,6 +57,11 @@
                     "type": "boolean",
                     "default": false
                 },
+                "forceNoSelf": {
+                    "description": "List of file names to match, and if they are matched, they will be counted as having the noSelfInFile option.",
+                    "type": "array",
+                    "default": []
+                },
                 "noImplicitSelf": {
                     "description": "If true, treats all project files as if they were prefixed with\n/** @noSelfInFile **/.",
                     "type": "boolean",


### PR DESCRIPTION
This PR aims to provide a way of forcing the `noSelf` flag to files which you cant add this flag to.

An example usage, you are using a type library which is set up wrong, and therefore doesn't include `this: void`, even if it should be included.
And therefore, when you try to build the files, they end up having `nil` added as the first parameter of all functions from that library.

Personally, I had this exact issue (see issue https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1487), and I cant edit the types file since their github repo is private and therefore maintaining the forked version would be a disaster.

Then, you could go into your `tsconfig.json` and add such file to the `noSelfExcludes` list, which would fix that.

I'm open for suggestions on how this could be done better :)


Example usage for FiveM's types (aka citizenfx)
![image](https://github.com/TypeScriptToLua/TypeScriptToLua/assets/54480523/c95a129c-e176-4d8d-a3fb-72b35bfe7504)