### PR TITLE
Self param is not generated for arrow functions with 0 params

### DIFF
--- a/src/transformation/visitors/function.ts
+++ b/src/transformation/visitors/function.ts
@@ -236,15 +236,8 @@ export function transformFunctionToExpression(
         firstParam.type?.kind === ts.SyntaxKind.VoidKeyword;
 
     if (!hasThisVoidParameter && getFunctionContextType(context, type) !== ContextType.Void) {
-        if (ts.isArrowFunction(node)) {
-            // dummy context for arrow functions with parameters
-            if (node.parameters.length > 0) {
-                functionContext = lua.createAnonymousIdentifier();
-            }
-        } else {
-            // self context
-            functionContext = createSelfIdentifier();
-        }
+        // self context
+        functionContext = createSelfIdentifier();
     }
 
     let flags = lua.NodeFlags.None;


### PR DESCRIPTION
This PR aims to resolve issue #1349 

See this playground as an example of the issue
https://typescripttolua.github.io/play/#code/MYewdgzgLgBFCm0YF4YAoCUKB8MDeAUDMTKJCADbwB0FIA5mlABYCWEGBAvgQQGYBXMMCitwcRFABMmfERJkIlGnUYt2nHgQTRM2yTIxA