### PR TITLE
Support for returning values from the global scope

### DIFF
--- a/src/transformation/utils/annotations.ts
+++ b/src/transformation/utils/annotations.ts
@@ -6,6 +6,7 @@ export enum AnnotationKind {
     NoResolution = "noResolution",
     NoSelf = "noSelf",
     NoSelfInFile = "noSelfInFile",
+    ReturnDefaultExport = "returnDefaultExport",
 }
 
 const annotationValues = new Map(Object.values(AnnotationKind).map(k => [k.toLowerCase(), k]));

--- a/src/transformation/utils/diagnostics.ts
+++ b/src/transformation/utils/diagnostics.ts
@@ -113,7 +113,7 @@ export const unsupportedVarDeclaration = createErrorDiagnosticFactory(
 );
 
 export const invalidMultiFunctionUse = createErrorDiagnosticFactory(
-    "The $multi function must be called in a return statement."
+    "The $multi function must be called in a return or export default statement."
 );
 
 export const invalidMultiFunctionReturnType = createErrorDiagnosticFactory(


### PR DESCRIPTION
Lua, unlike TypeScript, allows for the global scope to return values to the `require`'ing script. This is a niche use case, but if you need to interop with existing Lua scripts that are structured around this ability, it's essential to support it. See #1120 for background information.

First, I tried implementing @Cheatoid's `$return(...)` proposal, but the problem is that function calls are expressions rather than statements, so it's not trivial to drop a `return` statement in the intended location. I chose instead to implement a file annotation that instructs TSTL to emit the default export rather than the entire exports object.

Here's how it looks:
```typescript
/** @returnDefaultExport */
export default "Hello, World!";
```
```lua
local ____exports = {}
____exports.default = {"Hello, World!"}
return unpack(____exports.default)
```

And yes, it works with multiple values. 😁 
```typescript
/** @returnDefaultExport */
export default $multi(1, 2, 3);
```
```lua
local ____exports = {}
____exports.default = {1, 2, 3}
return unpack(____exports.default)
```

Tests not currently included. I'm wide open to suggestions on that front.