### PR TITLE
Fix no self in file check in call visitor

### DIFF
--- a/src/transformation/visitors/call.ts
+++ b/src/transformation/visitors/call.ts
@@ -288,10 +288,12 @@ export const transformCallExpression: FunctionVisitor<ts.CallExpression> = (node
 };
 
 function isContextualCallExpression(context: TransformationContext, signature: ts.Signature | undefined): boolean {
-    const declaration = signature?.getDeclaration();
+    if (signature) {
+        const declaration = signature.getDeclaration();
 
-    if (declaration) {
-        return getDeclarationContextType(context, declaration) === ContextType.Void;
+        if (declaration) {
+            return getDeclarationContextType(context, declaration) === ContextType.Void;
+        }
     }
 
     return context.options.noImplicitSelf !== undefined ? context.options.noImplicitSelf : false;

--- a/src/transformation/visitors/call.ts
+++ b/src/transformation/visitors/call.ts
@@ -271,7 +271,7 @@ export const transformCallExpression: FunctionVisitor<ts.CallExpression> = (node
 
     const isContextualCall = isContextualCallExpression(context, signature, node.getSourceFile());
 
-    if (!isContextualCall) {
+    if (isContextualCall) {
         [callPath, parameters] = transformCallAndArguments(context, calledExpression, node.arguments, signature);
     } else {
         // if is optionalContinuation, context will be handled by transformOptionalChain.
@@ -287,7 +287,7 @@ export const transformCallExpression: FunctionVisitor<ts.CallExpression> = (node
     }
 
     const callExpression = lua.createCallExpression(callPath, parameters, node);
-    if (optionalContinuation && isContextualCall) {
+    if (optionalContinuation && !isContextualCall) {
         optionalContinuation.contextualCall = callExpression;
     }
     return wrapResultInTable ? wrapInTable(callExpression) : callExpression;
@@ -304,11 +304,11 @@ function isContextualCallExpression(
         const declaration = signature.getDeclaration();
 
         if (declaration) {
-            const contextTypeCheck = getDeclarationContextType(context, declaration) !== ContextType.Void;
+            const contextTypeCheck = getDeclarationContextType(context, declaration) === ContextType.Void;
 
             // respect implicit self over noSelfInFile
-            if (hasNoSelfInFile && contextTypeCheck !== true) {
-                return false;
+            if (hasNoSelfInFile && contextTypeCheck === true) {
+                return true;
             }
 
             return contextTypeCheck;
@@ -316,10 +316,10 @@ function isContextualCallExpression(
     }
 
     if (hasNoSelfInFile) {
-        return false;
+        return true;
     }
 
-    return !context.options.noImplicitSelf;
+    return context.options.noImplicitSelf ?? false;
 }
 
 export function getCalledExpression(node: ts.CallExpression): ts.Expression {

--- a/src/transformation/visitors/call.ts
+++ b/src/transformation/visitors/call.ts
@@ -262,8 +262,10 @@ export const transformCallExpression: FunctionVisitor<ts.CallExpression> = (node
 
     let callPath: lua.Expression;
     let parameters: lua.Expression[];
+
     const isContextualCall = isContextualCallExpression(context, signature);
-    if (!isContextualCall) {
+
+    if (isContextualCall) {
         [callPath, parameters] = transformCallAndArguments(context, calledExpression, node.arguments, signature);
     } else {
         // if is optionalContinuation, context will be handled by transformOptionalChain.
@@ -287,10 +289,12 @@ export const transformCallExpression: FunctionVisitor<ts.CallExpression> = (node
 
 function isContextualCallExpression(context: TransformationContext, signature: ts.Signature | undefined): boolean {
     const declaration = signature?.getDeclaration();
-    if (!declaration) {
-        return !context.options.noImplicitSelf;
+
+    if (declaration) {
+        return getDeclarationContextType(context, declaration) === ContextType.Void;
     }
-    return getDeclarationContextType(context, declaration) !== ContextType.Void;
+
+    return context.options.noImplicitSelf !== undefined ? context.options.noImplicitSelf : false;
 }
 
 export function getCalledExpression(node: ts.CallExpression): ts.Expression {

--- a/src/transformation/visitors/call.ts
+++ b/src/transformation/visitors/call.ts
@@ -307,20 +307,18 @@ function isContextualCallExpression(
             false;
     }
 
-    if (signature) {
-        const declaration = signature.getDeclaration();
+    const declaration = signature?.getDeclaration();
 
-        if (declaration) {
-            const contextTypeCheck = getDeclarationContextType(context, declaration) !== ContextType.Void;
+    if (declaration) {
+        const contextTypeCheck = getDeclarationContextType(context, declaration) !== ContextType.Void;
 
-            // respect implicit self over noSelfInFile
-            // look at "explicit this parameter respected over @noSelf" test
-            if (hasNoSelfInFile && contextTypeCheck !== true) {
-                return false;
-            }
-
-            return contextTypeCheck;
+        // respect implicit self over noSelfInFile
+        // look at "explicit this parameter respected over @noSelf" test
+        if (hasNoSelfInFile && contextTypeCheck !== true) {
+            return false;
         }
+
+        return contextTypeCheck;
     }
 
     if (hasNoSelfInFile) {

--- a/src/transformation/visitors/call.ts
+++ b/src/transformation/visitors/call.ts
@@ -302,12 +302,9 @@ function isContextualCallExpression(
     let hasNoSelfInFile = false;
 
     if (symbol?.declarations) {
-        for (const declaration of symbol.declarations) {
-            const srcFile = declaration.getSourceFile();
-
-            hasNoSelfInFile = getFileAnnotations(srcFile).has(AnnotationKind.NoSelfInFile);
-            break;
-        }
+        hasNoSelfInFile =
+            symbol.declarations.some(d => getFileAnnotations(d.getSourceFile()).has(AnnotationKind.NoSelfInFile)) ??
+            false;
     }
 
     if (signature) {

--- a/test/unit/functions/noSelfAnnotation.spec.ts
+++ b/test/unit/functions/noSelfAnnotation.spec.ts
@@ -66,12 +66,7 @@ test("explicit this parameter respected over @noSelf", () => {
 test("respect noSelfInFile over noImplicitSelf", () => {
     const result = util.testModule`
         /** @noSelfInFile **/
-
-        const funcByValue: Record<string, Function> = {
-            hello: () => 1
-        };
-
-        const func = funcByValue["hello"];
+        const func: Function = () => 1;
         export const result = func(1);
     `
         .expectToMatchJsResult()

--- a/test/unit/functions/noSelfAnnotation.spec.ts
+++ b/test/unit/functions/noSelfAnnotation.spec.ts
@@ -97,8 +97,6 @@ test("respect noSelfInFile over noImplicitSelf (func declared in other file)", (
 
     expect(result.transpiledFiles).not.toHaveLength(0);
 
-    console.log(result);
-    console.log(result.transpiledFiles);
     const mainFile = result.transpiledFiles.find(f => f.outPath.includes("main.lua"));
     expect(mainFile).toBeDefined();
 

--- a/test/unit/functions/noSelfAnnotation.spec.ts
+++ b/test/unit/functions/noSelfAnnotation.spec.ts
@@ -1,3 +1,4 @@
+import path = require("path");
 import * as util from "../../util";
 
 const methodHolders = ["class", "interface"];
@@ -75,6 +76,30 @@ test("respect noSelfInFile over noImplicitSelf", () => {
     expect(result.transpiledFiles).not.toHaveLength(0);
 
     const mainFile = result.transpiledFiles.find(f => f.outPath === "main.lua");
+    expect(mainFile).toBeDefined();
+
+    // avoid ts error "not defined", even though toBeDefined is being checked above
+    if (!mainFile) return;
+
+    expect(mainFile.lua).toBeDefined();
+    expect(mainFile.lua).toContain("func(1)");
+    expect(mainFile.lua).not.toContain("_G");
+});
+
+const projectPath = path.resolve(__dirname, "noSelfAnnotationRespect");
+
+const projectFile = util
+    .testProject(path.join(projectPath, "tsconfig.json"))
+    .setMainFileName(path.join(projectPath, "main.ts"));
+
+test("respect noSelfInFile over noImplicitSelf (func declared in other file)", () => {
+    const result = projectFile.getLuaResult();
+
+    expect(result.transpiledFiles).not.toHaveLength(0);
+
+    console.log(result);
+    console.log(result.transpiledFiles);
+    const mainFile = result.transpiledFiles.find(f => f.outPath.includes("main.lua"));
     expect(mainFile).toBeDefined();
 
     // avoid ts error "not defined", even though toBeDefined is being checked above

--- a/test/unit/functions/noSelfAnnotationRespect/functions.ts
+++ b/test/unit/functions/noSelfAnnotationRespect/functions.ts
@@ -1,0 +1,6 @@
+/* eslint-disable spaced-comment */
+/* eslint-disable @typescript-eslint/ban-types */
+
+/** @noSelfInFile **/
+export const func: Function = () => 1;
+export const result = func(1);

--- a/test/unit/functions/noSelfAnnotationRespect/main.ts
+++ b/test/unit/functions/noSelfAnnotationRespect/main.ts
@@ -1,0 +1,4 @@
+import { func, result } from "./functions";
+
+export const result1 = result;
+export const result2 = func(1);

--- a/test/unit/functions/noSelfAnnotationRespect/tsconfig.json
+++ b/test/unit/functions/noSelfAnnotationRespect/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "moduleResolution": "Node",
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "target": "esnext",
+        "lib": ["esnext"],
+        "types": [],
+        "rootDir": "."
+    }
+}


### PR DESCRIPTION
This PR aims to resolve the issue addressed in issue #1387 

Also went ahead and made the `isContextualCallExpression` function more readable, as the previous one was a bit "hacky" in my opinion

### Code to reproduce the issue:
```ts
/** @noSelfInFile **/

const funcByValue: Record<string, Function> = {
  hello: () => 1
};

const func = funcByValue["hello"];
func(1);

const funcByValue2: Record<string, (...args: any[]) => any> = {
  hello: () => 1
};

const func2 = funcByValue2["hello"];
func2(1);
```

You will notice that the first function in the outputted code will include the self parameter, and the second one won't include it. Whereas neither one should have the self parameter, as the file has `noSelfInFile`

### Example output before changes
```lua
--[[ Generated with https://github.com/TypeScriptToLua/TypeScriptToLua ]]
---
-- @noSelfInFile *
funcByValue = {hello = function() return 1 end}
func = funcByValue.hello
func(_G, 1)
funcByValue2 = {hello = function() return 1 end}
func2 = funcByValue2.hello
func2(1)
```

https://typescripttolua.github.io/play/#code/PQKhAIAEDsHsGUCmAbAZgSWgMQJbMeGMAFDEDGs0AzgC7ioCu0ZAQgJ4BqAhsg4gFzgASogoAnACYAeWmJzQA5gBpwWJmRo5KAPnABecAG9i4U+ABEACxTJY5wQAoAlPt0BGJcQC+AblIVqOkZmfXp1dm5eRABtKxs7AF0-YLIHNyd-Slow5giePgAmQRFxaVl5ZXAHADparjEFKkEuaDZohJc9XRa2XQNjMwtrZFt7Ks73Ty9MwJyyAtCUvKiC2OHRpOIUgrSMoA