### PR TITLE
Add `String.prototype.match()` support

### DIFF
--- a/src/transformation/builtins/string.ts
+++ b/src/transformation/builtins/string.ts
@@ -65,7 +65,8 @@ export function transformStringPrototypeCall(
             return transformLuaLibFunction(context, LuaLibFeature.StringSubstr, node, caller, ...params);
         case "substring":
             return transformLuaLibFunction(context, LuaLibFeature.StringSubstring, node, caller, ...params);
-
+        case "match":
+            return createStringCall("match", node, caller, ...params);
         case "slice": {
             const literalArg1 = getNumberLiteralValue(params[0]);
             if (params[0] && literalArg1 !== undefined) {


### PR DESCRIPTION
This PR aims to resolve issue #1503, aka adds support for `String.prototype.match()`

### Example usage
```ts
const string1 = "The quick brown fox jumps over the lazy dog.";
const match = string1.match("brown");
```

Only concern I have is whether the functions really return the same things, it seems to do so though.