### PR TITLE
Add basic check for customName in property access transform

### DIFF
--- a/src/transformation/visitors/access.ts
+++ b/src/transformation/visitors/access.ts
@@ -23,6 +23,7 @@ import {
     captureThisValue,
 } from "./optional-chaining";
 import { SyntaxKind } from "typescript";
+import { getCustomNameFromSymbol } from "./identifier";
 
 function addOneToArrayAccessArgument(
     context: TransformationContext,
@@ -108,9 +109,15 @@ export function transformPropertyAccessExpressionWithCapture(
     node: ts.PropertyAccessExpression,
     thisValueCapture: lua.Identifier | undefined
 ): ExpressionWithThisValue {
-    const property = node.name.text;
     const type = context.checker.getTypeAtLocation(node.expression);
     const isOptionalLeft = isOptionalContinuation(node.expression);
+
+    let property = node.name.text;
+    const symbol = context.checker.getSymbolAtLocation(node.name);
+    const customName = getCustomNameFromSymbol(symbol);
+    if (customName) {
+        property = customName;
+    }
 
     const constEnumValue = tryGetConstEnumValue(context, node);
     if (constEnumValue) {

--- a/test/translation/__snapshots__/transformation.spec.ts.snap
+++ b/test/translation/__snapshots__/transformation.spec.ts.snap
@@ -24,6 +24,8 @@ escapedCharsInTemplateString = "\\\\ \\0 \\b \\t \\n \\v \\f \\" ' \`"
 nonEmptyTemplateString = ("Level 0: \\n\\t " .. ("Level 1: \\n\\t\\t " .. ("Level 3: \\n\\t\\t\\t " .. "Last level \\n --") .. " \\n --") .. " \\n --") .. " \\n --""
 `;
 
+exports[`Transformation (customNameWithNoSelf) 1`] = `"TestNamespace.pass()"`;
+
 exports[`Transformation (exportStatement) 1`] = `
 "local ____exports = {}
 local xyz = 4

--- a/test/translation/transformation/customNameWithNoSelf.ts
+++ b/test/translation/transformation/customNameWithNoSelf.ts
@@ -1,0 +1,7 @@
+/** @noSelf */
+declare namespace TestNamespace {
+    /** @customName pass */
+    function fail(): void;
+}
+
+TestNamespace.fail();


### PR DESCRIPTION
While simple name changes work as expected names with nested methods will still behave like string literals.
I will try to find a solution for this as well, but since this is my first commit I want to make this as simple as possible.

partially fixes #1528 