### PR TITLE
Fix crash when using lualib_bundle in an environment without coroutines

### DIFF
--- a/src/lualib/Await.ts
+++ b/src/lualib/Await.ts
@@ -16,6 +16,7 @@
 
 import { __TS__Promise } from "./Promise";
 
+const coroutine = _G.coroutine ?? {};
 const cocreate = coroutine.create;
 const coresume = coroutine.resume;
 const costatus = coroutine.status;

--- a/test/unit/builtins/loading.spec.ts
+++ b/test/unit/builtins/loading.spec.ts
@@ -67,6 +67,18 @@ test("lualib should not include tstl header", () => {
     );
 });
 
+test("using lualib does not crash when coroutine is not defined", () => {
+    util.testModule`
+        declare const _G: any;
+        declare function require(this: void, name: string): any
+
+        _G.coroutine = undefined;
+        require("lualib_bundle");
+        export const result = 1
+    `
+        .expectToEqual({ result: 1 });
+})
+
 describe("Unknown builtin property", () => {
     test("access", () => {
         util.testExpression`Math.unknownProperty`

--- a/test/unit/builtins/loading.spec.ts
+++ b/test/unit/builtins/loading.spec.ts
@@ -75,9 +75,8 @@ test("using lualib does not crash when coroutine is not defined", () => {
         _G.coroutine = undefined;
         require("lualib_bundle");
         export const result = 1
-    `
-        .expectToEqual({ result: 1 });
-})
+    `.expectToEqual({ result: 1 });
+});
 
 describe("Unknown builtin property", () => {
     test("access", () => {


### PR DESCRIPTION
 This PR fixes a crash that occurs when using lualib_bundle in an environment without coroutine (the `coroutine` global is undefined).
In the Factorio lua environment, coroutines are not supported.

Instead, with a runtime error if coroutines are used, instead of a crash anytime lualib_bundle is imported.

