### PR TITLE
Fixes handling of statements before super call in subclass constructors

### DIFF
--- a/src/transformation/visitors/class/members/constructor.ts
+++ b/src/transformation/visitors/class/members/constructor.ts
@@ -45,23 +45,22 @@ export function transformConstructorDeclaration(
 
     const classInstanceFields = transformClassInstanceFields(context, instanceFields);
 
-    // If there are field initializers and the first statement is a super call,
-    // move super call between default assignments and initializers
+    // If there are field initializers and there is a super call somewhere,
+    // move super call and everything before it to between default assignments and initializers
     if (
         (constructorFieldsDeclarations.length > 0 || classInstanceFields.length > 0) &&
         statement.body &&
         statement.body.statements.length > 0
     ) {
-        const firstStatement = statement.body.statements[0];
-        if (
-            ts.isExpressionStatement(firstStatement) &&
-            ts.isCallExpression(firstStatement.expression) &&
-            firstStatement.expression.expression.kind === ts.SyntaxKind.SuperKeyword
-        ) {
-            const superCall = body.shift();
-            if (superCall) {
-                bodyWithFieldInitializers.push(superCall);
-            }
+        const superIndex = statement.body.statements.findIndex(
+            s =>
+                ts.isExpressionStatement(s) &&
+                ts.isCallExpression(s.expression) &&
+                s.expression.expression.kind === ts.SyntaxKind.SuperKeyword
+        );
+
+        if (superIndex !== -1) {
+            bodyWithFieldInitializers.push(...body.splice(0, superIndex + 1));
         }
     }
 

--- a/test/unit/classes/classes.spec.ts
+++ b/test/unit/classes/classes.spec.ts
@@ -181,6 +181,27 @@ test("SubclassConstructor", () => {
     `.expectToMatchJsResult();
 });
 
+test("SubclassConstructorPropertyInitiailizationSuperOrder", () => {
+    util.testFunction`
+        class a {
+            field: number;
+            constructor(field: number) {
+                this.field = field;
+            }
+        }
+        class b extends a {
+            fieldDouble = this.field * 2;
+            constructor(field: number) {
+                const newField = field + 1;
+                super(newField);
+            }
+        }
+
+        const result = new b(10);
+        return [result.field, result.fieldDouble];
+    `.expectToMatchJsResult();
+});
+
 test("Subclass constructor across merged namespace", () => {
     util.testModule`
         namespace NS {


### PR DESCRIPTION
Adjusts logic introduced in #700 so that subclasses properly support statements before the `super()` call, to work with the changes introduced in  microsoft/TypeScript#29374.