### PR TITLE
chore: update deps to latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.27.1
+
+- Upgraded TypeScript to 5.6.3
+
 ## 1.27.0
 
 - Upgraded TypeScript to 5.6.2

--- a/benchmark/src/benchmark_util.ts
+++ b/benchmark/src/benchmark_util.ts
@@ -9,7 +9,7 @@ export function compareNumericBenchmarks<T extends BenchmarkResult>(
     oldResults: T[],
     unit: string,
     extractValue: (result: T) => number,
-    formatValue: (value: number) => string
+    formatValue: (value: number) => string,
 ): string {
     let comparisonTable = makeMarkdownTableRow([
         "name",

--- a/benchmark/src/memory_benchmark.ts
+++ b/benchmark/src/memory_benchmark.ts
@@ -46,7 +46,7 @@ const formatMemory = (memInKB: number) => toFixed(memInKB / 1024, 3);
 
 export function compareMemoryBenchmarks(
     oldResults: MemoryBenchmarkResult[],
-    newResults: MemoryBenchmarkResult[]
+    newResults: MemoryBenchmarkResult[],
 ): ComparisonInfo {
     // Can not use Object.values because we want a fixed order.
     const categories = [MemoryBenchmarkCategory.TotalMemory, MemoryBenchmarkCategory.Garbage];
@@ -56,7 +56,7 @@ export function compareMemoryBenchmarks(
         .join("\n");
 
     const text = `### master:\n\`\`\`json\n${json.encode(oldResults)}\n\`\`\`\n### commit:\n\`\`\`json\n${json.encode(
-        newResults
+        newResults,
     )}\n\`\`\``;
 
     return { summary, text };
@@ -65,7 +65,7 @@ export function compareMemoryBenchmarks(
 function compareCategory(
     newResults: MemoryBenchmarkResult[],
     oldResults: MemoryBenchmarkResult[],
-    category: MemoryBenchmarkCategory
+    category: MemoryBenchmarkCategory,
 ): string {
     return compareNumericBenchmarks(newResults, oldResults, "mb", result => result.categories[category], formatMemory);
 }

--- a/benchmark/src/run.ts
+++ b/benchmark/src/run.ts
@@ -52,7 +52,7 @@ function sortByName({ benchmarkName: a }: BenchmarkResult, { benchmarkName: b }:
 
 function compareBenchmarks(
     oldResults: BenchmarkResult[],
-    newResults: BenchmarkResult[]
+    newResults: BenchmarkResult[],
 ): Record<BenchmarkKind, ComparisonInfo> {
     const oldResultsMemory = oldResults.filter(isMemoryBenchmarkResult);
     const newResultsMemory = newResults.filter(isMemoryBenchmarkResult);

--- a/benchmark/src/runtime_benchmark.ts
+++ b/benchmark/src/runtime_benchmark.ts
@@ -23,7 +23,7 @@ export function runRuntimeBenchmark(benchmarkFunction: () => void): RuntimeBench
 
 export function compareRuntimeBenchmarks(
     oldResults: RuntimeBenchmarkResult[],
-    newResults: RuntimeBenchmarkResult[]
+    newResults: RuntimeBenchmarkResult[],
 ): ComparisonInfo {
     const summary =
         "### runtime\n\n" +
@@ -32,11 +32,11 @@ export function compareRuntimeBenchmarks(
             oldResults,
             "s",
             result => result.time,
-            time => toFixed(time, 4)
+            time => toFixed(time, 4),
         );
 
     const text = `### master\n\`\`\`json\n${json.encode(oldResults)}\n\`\`\`\n### commit\n\`\`\`json\n${json.encode(
-        newResults
+        newResults,
     )}\n\`\`\``;
 
     return { summary, text };

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -226,5 +226,5 @@ export default tseslint.config(
             "test/transpile/outFile/",
             "test/transpile/resolve-plugin/",
         ],
-    }
+    },
 );

--- a/language-extensions/index.d.ts
+++ b/language-extensions/index.d.ts
@@ -76,10 +76,10 @@ declare type LuaIterator<TValue, TState> = TState extends undefined
               (
                   this: void,
                   state: TState,
-                  lastValue: TValue extends LuaMultiReturn<infer TTuple> ? TTuple[0] : TValue
+                  lastValue: TValue extends LuaMultiReturn<infer TTuple> ? TTuple[0] : TValue,
               ) => TValue,
               TState,
-              TValue extends LuaMultiReturn<infer TTuple> ? TTuple[0] : TValue
+              TValue extends LuaMultiReturn<infer TTuple> ? TTuple[0] : TValue,
           ]
       >;
 
@@ -471,7 +471,7 @@ declare type LuaLengthMethod<TReturn> = (() => TReturn) & LuaExtension<"LengthMe
  */
 declare type LuaTableGet<TTable extends AnyTable, TKey extends AnyNotNil, TValue> = ((
     table: TTable,
-    key: TKey
+    key: TKey,
 ) => TValue) &
     LuaExtension<"TableGet">;
 
@@ -496,7 +496,7 @@ declare type LuaTableGetMethod<TKey extends AnyNotNil, TValue> = ((key: TKey) =>
 declare type LuaTableSet<TTable extends AnyTable, TKey extends AnyNotNil, TValue> = ((
     table: TTable,
     key: TKey,
-    value: TValue
+    value: TValue,
 ) => void) &
     LuaExtension<"TableSet">;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "typescript-to-lua",
-    "version": "1.26.2",
+    "version": "1.27.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
@@ -10,40 +10,40 @@
             "license": "MIT",
             "dependencies": {
                 "@typescript-to-lua/language-extensions": "1.19.0",
-                "enhanced-resolve": "5.8.2",
-                "picomatch": "^2.3.1",
-                "resolve": "^1.15.1",
-                "source-map": "^0.7.3"
+                "enhanced-resolve": "5.17.1",
+                "picomatch": "^4.0.2",
+                "resolve": "^1.22.8",
+                "source-map": "^0.7.4"
             },
             "bin": {
                 "tstl": "dist/tstl.js"
             },
             "devDependencies": {
-                "@types/fs-extra": "^8.1.0",
-                "@types/glob": "^7.1.1",
-                "@types/jest": "^27.5.2",
-                "@types/node": "^13.7.7",
-                "@types/picomatch": "^2.3.0",
-                "@types/resolve": "1.14.0",
-                "eslint": "^9.11.0",
-                "eslint-plugin-jest": "^28.8.3",
-                "fs-extra": "^8.1.0",
-                "javascript-stringify": "^2.0.1",
-                "jest": "^29.5.0",
-                "jest-circus": "^29.5.0",
-                "lua-types": "^2.13.0",
+                "@types/fs-extra": "^11.0.4",
+                "@types/glob": "^8.1.0",
+                "@types/jest": "^29.5.14",
+                "@types/node": "^22.9.0",
+                "@types/picomatch": "^3.0.1",
+                "@types/resolve": "1.20.6",
+                "eslint": "^9.14.0",
+                "eslint-plugin-jest": "^28.9.0",
+                "fs-extra": "^11.2.0",
+                "javascript-stringify": "^2.1.0",
+                "jest": "^29.7.0",
+                "jest-circus": "^29.7.0",
+                "lua-types": "^2.13.1",
                 "lua-wasm-bindings": "^0.3.1",
-                "prettier": "^2.8.8",
-                "ts-jest": "^29.1.0",
-                "ts-node": "^10.9.1",
-                "typescript": "^5.6.2",
-                "typescript-eslint": "^8.7.0"
+                "prettier": "^3.3.3",
+                "ts-jest": "^29.2.5",
+                "ts-node": "^10.9.2",
+                "typescript": "5.6.3",
+                "typescript-eslint": "^8.13.0"
             },
             "engines": {
                 "node": ">=16.10.0"
             },
             "peerDependencies": {
-                "typescript": "5.6.2"
+                "typescript": "5.6.3"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -738,9 +738,9 @@
             }
         },
         "node_modules/@eslint-community/regexpp": {
-            "version": "4.11.1",
-            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.1.tgz",
-            "integrity": "sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==",
+            "version": "4.12.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+            "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -763,9 +763,9 @@
             }
         },
         "node_modules/@eslint/core": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.6.0.tgz",
-            "integrity": "sha512-8I2Q8ykA4J0x0o7cg67FPVnehcqWTBehu/lmY+bolPFHGjh49YzGBMXTvpqVgEbBdvNCSxj6iFgiIyHzf03lzg==",
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.7.0.tgz",
+            "integrity": "sha512-xp5Jirz5DyPYlPiKat8jaq0EmYvDXKKpzTbxXMpT9eqlRJkRKIz9AGMdlvYjih+im+QlhWrpvVjl8IPC/lHlUw==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -797,9 +797,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.11.1",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.11.1.tgz",
-            "integrity": "sha512-/qu+TWz8WwPWc7/HcIJKi+c+MOm46GdVaSlTTQcaqaL53+GsoA6MxWp5PtTx48qbSP7ylM1Kn7nhvkugfJvRSA==",
+            "version": "9.14.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.14.0.tgz",
+            "integrity": "sha512-pFoEtFWCPyDOl+C6Ift+wC7Ro89otjigCf5vcuWqWgqNSQbRrpjSvdeE6ofLz4dHmyxD5f7gIdGT4+p36L6Twg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -829,6 +829,44 @@
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
+        "node_modules/@humanfs/core": {
+            "version": "0.19.1",
+            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+            "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanfs/node": {
+            "version": "0.16.6",
+            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+            "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@humanfs/core": "^0.19.1",
+                "@humanwhocodes/retry": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+            "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/nzakas"
+            }
+        },
         "node_modules/@humanwhocodes/module-importer": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
@@ -844,9 +882,9 @@
             }
         },
         "node_modules/@humanwhocodes/retry": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.0.tgz",
-            "integrity": "sha512-d2CGZR2o7fS6sWB7DG/3a95bGKQyHMACZ5aW8qGkkqQpUoZV6C0X7Pc7l4ZNMZkfNBf4VWNe9E1jRsf0G146Ew==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
+            "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -1039,41 +1077,6 @@
                     "optional": true
                 }
             }
-        },
-        "node_modules/@jest/core/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/@jest/core/node_modules/pretty-format": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-            "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "ansi-styles": "^5.0.0",
-                "react-is": "^18.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/core/node_modules/react-is": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@jest/environment": {
             "version": "29.7.0",
@@ -1500,23 +1503,24 @@
             "license": "MIT"
         },
         "node_modules/@types/fs-extra": {
-            "version": "8.1.5",
-            "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.5.tgz",
-            "integrity": "sha512-0dzKcwO+S8s2kuF5Z9oUWatQJj5Uq/iqphEtE3GQJVRRYm/tD1LglU2UnXi2A8jLq5umkGouOXOR9y0n613ZwQ==",
+            "version": "11.0.4",
+            "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
+            "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
+                "@types/jsonfile": "*",
                 "@types/node": "*"
             }
         },
         "node_modules/@types/glob": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
-            "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
+            "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/minimatch": "*",
+                "@types/minimatch": "^5.1.2",
                 "@types/node": "*"
             }
         },
@@ -1558,14 +1562,14 @@
             }
         },
         "node_modules/@types/jest": {
-            "version": "27.5.2",
-            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.5.2.tgz",
-            "integrity": "sha512-mpT8LJJ4CMeeahobofYWIjFo0xonRS/HfxnVEPMPFSQdGUt1uHCnoPT7Zhb+sjDU2wz0oKV0OLUR0WzrHNgfeA==",
+            "version": "29.5.14",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+            "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "jest-matcher-utils": "^27.0.0",
-                "pretty-format": "^27.0.0"
+                "expect": "^29.0.0",
+                "pretty-format": "^29.0.0"
             }
         },
         "node_modules/@types/json-schema": {
@@ -1575,6 +1579,16 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/jsonfile": {
+            "version": "6.1.4",
+            "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
+            "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/minimatch": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
@@ -1583,28 +1597,28 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "13.13.52",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
-            "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==",
+            "version": "22.9.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
+            "integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~6.19.8"
+            }
         },
         "node_modules/@types/picomatch": {
-            "version": "2.3.4",
-            "resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-2.3.4.tgz",
-            "integrity": "sha512-0so8lU8O5zatZS/2Fi4zrwks+vZv7e0dygrgEZXljODXBig97l4cPQD+9LabXfGJOWwoRkTVz6Q4edZvD12UOA==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-3.0.1.tgz",
+            "integrity": "sha512-1MRgzpzY0hOp9pW/kLRxeQhUWwil6gnrUYd3oEpeYBqp/FexhaCPv3F8LsYr47gtUU45fO2cm1dbwkSrHEo8Uw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/resolve": {
-            "version": "1.14.0",
-            "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.14.0.tgz",
-            "integrity": "sha512-bmjNBW6tok+67iOsASeYSJxSgY++BIR35nGyGLORTDirhra9reJ0shgGL3U7KPDUbOBCx8JrlCjd4d/y5uiMRQ==",
+            "version": "1.20.6",
+            "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.6.tgz",
+            "integrity": "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==",
             "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*"
-            }
+            "license": "MIT"
         },
         "node_modules/@types/semver": {
             "version": "7.5.8",
@@ -1638,17 +1652,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.7.0.tgz",
-            "integrity": "sha512-RIHOoznhA3CCfSTFiB6kBGLQtB/sox+pJ6jeFu6FxJvqL8qRxq/FfGO/UhsGgQM9oGdXkV4xUgli+dt26biB6A==",
+            "version": "8.13.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.13.0.tgz",
+            "integrity": "sha512-nQtBLiZYMUPkclSeC3id+x4uVd1SGtHuElTxL++SfP47jR0zfkZBJHc+gL4qPsgTuypz0k8Y2GheaDYn6Gy3rg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.7.0",
-                "@typescript-eslint/type-utils": "8.7.0",
-                "@typescript-eslint/utils": "8.7.0",
-                "@typescript-eslint/visitor-keys": "8.7.0",
+                "@typescript-eslint/scope-manager": "8.13.0",
+                "@typescript-eslint/type-utils": "8.13.0",
+                "@typescript-eslint/utils": "8.13.0",
+                "@typescript-eslint/visitor-keys": "8.13.0",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.3.1",
                 "natural-compare": "^1.4.0",
@@ -1672,16 +1686,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.7.0.tgz",
-            "integrity": "sha512-lN0btVpj2unxHlNYLI//BQ7nzbMJYBVQX5+pbNXvGYazdlgYonMn4AhhHifQ+J4fGRYA/m1DjaQjx+fDetqBOQ==",
+            "version": "8.13.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.13.0.tgz",
+            "integrity": "sha512-w0xp+xGg8u/nONcGw1UXAr6cjCPU1w0XVyBs6Zqaj5eLmxkKQAByTdV/uGgNN5tVvN/kKpoQlP2cL7R+ajZZIQ==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.7.0",
-                "@typescript-eslint/types": "8.7.0",
-                "@typescript-eslint/typescript-estree": "8.7.0",
-                "@typescript-eslint/visitor-keys": "8.7.0",
+                "@typescript-eslint/scope-manager": "8.13.0",
+                "@typescript-eslint/types": "8.13.0",
+                "@typescript-eslint/typescript-estree": "8.13.0",
+                "@typescript-eslint/visitor-keys": "8.13.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -1701,14 +1715,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.7.0.tgz",
-            "integrity": "sha512-87rC0k3ZlDOuz82zzXRtQ7Akv3GKhHs0ti4YcbAJtaomllXoSO8hi7Ix3ccEvCd824dy9aIX+j3d2UMAfCtVpg==",
+            "version": "8.13.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.13.0.tgz",
+            "integrity": "sha512-XsGWww0odcUT0gJoBZ1DeulY1+jkaHUciUq4jKNv4cpInbvvrtDoyBH9rE/n2V29wQJPk8iCH1wipra9BhmiMA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.7.0",
-                "@typescript-eslint/visitor-keys": "8.7.0"
+                "@typescript-eslint/types": "8.13.0",
+                "@typescript-eslint/visitor-keys": "8.13.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1719,14 +1733,14 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.7.0.tgz",
-            "integrity": "sha512-tl0N0Mj3hMSkEYhLkjREp54OSb/FI6qyCzfiiclvJvOqre6hsZTGSnHtmFLDU8TIM62G7ygEa1bI08lcuRwEnQ==",
+            "version": "8.13.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.13.0.tgz",
+            "integrity": "sha512-Rqnn6xXTR316fP4D2pohZenJnp+NwQ1mo7/JM+J1LWZENSLkJI8ID8QNtlvFeb0HnFSK94D6q0cnMX6SbE5/vA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "8.7.0",
-                "@typescript-eslint/utils": "8.7.0",
+                "@typescript-eslint/typescript-estree": "8.13.0",
+                "@typescript-eslint/utils": "8.13.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^1.3.0"
             },
@@ -1744,9 +1758,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.7.0.tgz",
-            "integrity": "sha512-LLt4BLHFwSfASHSF2K29SZ+ZCsbQOM+LuarPjRUuHm+Qd09hSe3GCeaQbcCr+Mik+0QFRmep/FyZBO6fJ64U3w==",
+            "version": "8.13.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.13.0.tgz",
+            "integrity": "sha512-4cyFErJetFLckcThRUFdReWJjVsPCqyBlJTi6IDEpc1GWCIIZRFxVppjWLIMcQhNGhdWJJRYFHpHoDWvMlDzng==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1758,14 +1772,14 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.7.0.tgz",
-            "integrity": "sha512-MC8nmcGHsmfAKxwnluTQpNqceniT8SteVwd2voYlmiSWGOtjvGXdPl17dYu2797GVscK30Z04WRM28CrKS9WOg==",
+            "version": "8.13.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.13.0.tgz",
+            "integrity": "sha512-v7SCIGmVsRK2Cy/LTLGN22uea6SaUIlpBcO/gnMGT/7zPtxp90bphcGf4fyrCQl3ZtiBKqVTG32hb668oIYy1g==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "@typescript-eslint/types": "8.7.0",
-                "@typescript-eslint/visitor-keys": "8.7.0",
+                "@typescript-eslint/types": "8.13.0",
+                "@typescript-eslint/visitor-keys": "8.13.0",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
@@ -1813,16 +1827,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.7.0.tgz",
-            "integrity": "sha512-ZbdUdwsl2X/s3CiyAu3gOlfQzpbuG3nTWKPoIvAu1pu5r8viiJvv2NPN2AqArL35NCYtw/lrPPfM4gxrMLNLPw==",
+            "version": "8.13.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.13.0.tgz",
+            "integrity": "sha512-A1EeYOND6Uv250nybnLZapeXpYMl8tkzYUxqmoKAWnI4sei3ihf2XdZVd+vVOmHGcp3t+P7yRrNsyyiXTvShFQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
-                "@typescript-eslint/scope-manager": "8.7.0",
-                "@typescript-eslint/types": "8.7.0",
-                "@typescript-eslint/typescript-estree": "8.7.0"
+                "@typescript-eslint/scope-manager": "8.13.0",
+                "@typescript-eslint/types": "8.13.0",
+                "@typescript-eslint/typescript-estree": "8.13.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1836,13 +1850,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.7.0.tgz",
-            "integrity": "sha512-b1tx0orFCCh/THWPQa2ZwWzvOeyzzp36vkJYOpVg0u8UVOIsfVrnuC9FqAw9gRKn+rG2VmWQ/zDJZzkxUnj/XQ==",
+            "version": "8.13.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.13.0.tgz",
+            "integrity": "sha512-7N/+lztJqH4Mrf0lb10R/CbI1EaAMMGyF5y0oJvFoAhafwgiRA7TXyd8TFn8FC8k5y2dTsYogg238qavRGNnlw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.7.0",
+                "@typescript-eslint/types": "8.13.0",
                 "eslint-visitor-keys": "^3.4.3"
             },
             "engines": {
@@ -1873,9 +1887,9 @@
             "license": "MIT"
         },
         "node_modules/acorn": {
-            "version": "8.12.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
-            "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+            "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -1979,6 +1993,19 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/anymatch/node_modules/picomatch": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/arg": {
@@ -2494,16 +2521,6 @@
                 "node": ">=0.3.1"
             }
         },
-        "node_modules/diff-sequences": {
-            "version": "27.5.1",
-            "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
-            "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-            }
-        },
         "node_modules/ejs": {
             "version": "3.1.10",
             "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
@@ -2548,9 +2565,9 @@
             "license": "MIT"
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.8.2",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.8.2.tgz",
-            "integrity": "sha512-F27oB3WuHDzvR2DOGNTaYy0D5o0cnrv8TeI482VM4kYgQd/FT9lUQwuNsJ0oOHtBUq7eiW5ytqzp7nBFknL+GA==",
+            "version": "5.17.1",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.1.tgz",
+            "integrity": "sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==",
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.4",
@@ -2594,22 +2611,22 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.11.1",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.11.1.tgz",
-            "integrity": "sha512-MobhYKIoAO1s1e4VUrgx1l1Sk2JBR/Gqjjgw8+mfgoLE2xwsHur4gdfTxyTgShrhvdVFTaJSgMiQBl1jv/AWxg==",
+            "version": "9.14.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.14.0.tgz",
+            "integrity": "sha512-c2FHsVBr87lnUtjP4Yhvk4yEhKrQavGafRA/Se1ouse8PfbfC/Qh9Mxa00yWsZRlqeUB9raXip0aiiUZkgnr9g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
-                "@eslint-community/regexpp": "^4.11.0",
+                "@eslint-community/regexpp": "^4.12.1",
                 "@eslint/config-array": "^0.18.0",
-                "@eslint/core": "^0.6.0",
+                "@eslint/core": "^0.7.0",
                 "@eslint/eslintrc": "^3.1.0",
-                "@eslint/js": "9.11.1",
+                "@eslint/js": "9.14.0",
                 "@eslint/plugin-kit": "^0.2.0",
+                "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
-                "@humanwhocodes/retry": "^0.3.0",
-                "@nodelib/fs.walk": "^1.2.8",
+                "@humanwhocodes/retry": "^0.4.0",
                 "@types/estree": "^1.0.6",
                 "@types/json-schema": "^7.0.15",
                 "ajv": "^6.12.4",
@@ -2617,9 +2634,9 @@
                 "cross-spawn": "^7.0.2",
                 "debug": "^4.3.2",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^8.0.2",
-                "eslint-visitor-keys": "^4.0.0",
-                "espree": "^10.1.0",
+                "eslint-scope": "^8.2.0",
+                "eslint-visitor-keys": "^4.2.0",
+                "espree": "^10.3.0",
                 "esquery": "^1.5.0",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
@@ -2629,13 +2646,11 @@
                 "ignore": "^5.2.0",
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
-                "is-path-inside": "^3.0.3",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "lodash.merge": "^4.6.2",
                 "minimatch": "^3.1.2",
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.9.3",
-                "strip-ansi": "^6.0.1",
                 "text-table": "^0.2.0"
             },
             "bin": {
@@ -2657,9 +2672,9 @@
             }
         },
         "node_modules/eslint-plugin-jest": {
-            "version": "28.8.3",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.8.3.tgz",
-            "integrity": "sha512-HIQ3t9hASLKm2IhIOqnu+ifw7uLZkIlR7RYNv7fMcEi/p0CIiJmfriStQS2LDkgtY4nyLbIZAD+JL347Yc2ETQ==",
+            "version": "28.9.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-28.9.0.tgz",
+            "integrity": "sha512-rLu1s1Wf96TgUUxSw6loVIkNtUjq1Re7A9QdCCHSohnvXEBAjuL420h0T/fMmkQlNsQP2GhQzEUpYHPfxBkvYQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2683,9 +2698,9 @@
             }
         },
         "node_modules/eslint-scope": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.0.2.tgz",
-            "integrity": "sha512-6E4xmrTw5wtxnLA5wYL3WDfhZ/1bUBGOXV0zQvVRDOtrR8D0p6W7fs3JweNYhwRYeGvd/1CKX2se0/2s7Q/nJA==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
+            "integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -2700,9 +2715,9 @@
             }
         },
         "node_modules/eslint-visitor-keys": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
-            "integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+            "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -2713,15 +2728,15 @@
             }
         },
         "node_modules/espree": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-10.1.0.tgz",
-            "integrity": "sha512-M1M6CpiE6ffoigIOWYO9UDP8TMUw9kqb21tf+08IgDYjCsOvCuDt4jQcZmoYxx+w7zlKw9/N0KXfto+I8/FrXA==",
+            "version": "10.3.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
+            "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "acorn": "^8.12.0",
+                "acorn": "^8.14.0",
                 "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^4.0.0"
+                "eslint-visitor-keys": "^4.2.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2840,19 +2855,6 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
-        "node_modules/expect/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
         "node_modules/expect/node_modules/diff-sequences": {
             "version": "29.6.3",
             "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
@@ -2894,28 +2896,6 @@
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
-        },
-        "node_modules/expect/node_modules/pretty-format": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-            "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "ansi-styles": "^5.0.0",
-                "react-is": "^18.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/expect/node_modules/react-is": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -3086,18 +3066,18 @@
             "license": "ISC"
         },
         "node_modules/fs-extra": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+            "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.0",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
             },
             "engines": {
-                "node": ">=6 <7 || >=8"
+                "node": ">=14.14"
             }
         },
         "node_modules/fs.realpath": {
@@ -3425,16 +3405,6 @@
                 "node": ">=0.12.0"
             }
         },
-        "node_modules/is-path-inside": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/is-stream": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -3636,19 +3606,6 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
-        "node_modules/jest-circus/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
         "node_modules/jest-circus/node_modules/diff-sequences": {
             "version": "29.6.3",
             "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
@@ -3690,28 +3647,6 @@
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
-        },
-        "node_modules/jest-circus/node_modules/pretty-format": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-            "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "ansi-styles": "^5.0.0",
-                "react-is": "^18.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-circus/node_modules/react-is": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/jest-cli": {
             "version": "29.7.0",
@@ -3793,67 +3728,6 @@
                 }
             }
         },
-        "node_modules/jest-config/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/jest-config/node_modules/pretty-format": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-            "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "ansi-styles": "^5.0.0",
-                "react-is": "^18.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-config/node_modules/react-is": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/jest-diff": {
-            "version": "27.5.1",
-            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.5.1.tgz",
-            "integrity": "sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "chalk": "^4.0.0",
-                "diff-sequences": "^27.5.1",
-                "jest-get-type": "^27.5.1",
-                "pretty-format": "^27.5.1"
-            },
-            "engines": {
-                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-            }
-        },
-        "node_modules/jest-diff/node_modules/jest-get-type": {
-            "version": "27.5.1",
-            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.5.1.tgz",
-            "integrity": "sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-            }
-        },
         "node_modules/jest-docblock": {
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
@@ -3883,41 +3757,6 @@
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
-        },
-        "node_modules/jest-each/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/jest-each/node_modules/pretty-format": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-            "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "ansi-styles": "^5.0.0",
-                "react-is": "^18.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-each/node_modules/react-is": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/jest-environment-node": {
             "version": "29.7.0",
@@ -3987,67 +3826,6 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
-        "node_modules/jest-leak-detector/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/jest-leak-detector/node_modules/pretty-format": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-            "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "ansi-styles": "^5.0.0",
-                "react-is": "^18.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-leak-detector/node_modules/react-is": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/jest-matcher-utils": {
-            "version": "27.5.1",
-            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.5.1.tgz",
-            "integrity": "sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "chalk": "^4.0.0",
-                "jest-diff": "^27.5.1",
-                "jest-get-type": "^27.5.1",
-                "pretty-format": "^27.5.1"
-            },
-            "engines": {
-                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-            }
-        },
-        "node_modules/jest-matcher-utils/node_modules/jest-get-type": {
-            "version": "27.5.1",
-            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.5.1.tgz",
-            "integrity": "sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-            }
-        },
         "node_modules/jest-message-util": {
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
@@ -4068,41 +3846,6 @@
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
-        },
-        "node_modules/jest-message-util/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/jest-message-util/node_modules/pretty-format": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-            "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "ansi-styles": "^5.0.0",
-                "react-is": "^18.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-message-util/node_modules/react-is": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/jest-mock": {
             "version": "29.7.0",
@@ -4281,19 +4024,6 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
-        "node_modules/jest-snapshot/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
         "node_modules/jest-snapshot/node_modules/diff-sequences": {
             "version": "29.6.3",
             "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
@@ -4336,28 +4066,6 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
-        "node_modules/jest-snapshot/node_modules/pretty-format": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-            "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "ansi-styles": "^5.0.0",
-                "react-is": "^18.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-snapshot/node_modules/react-is": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/jest-util": {
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
@@ -4374,6 +4082,19 @@
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-util/node_modules/picomatch": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/jest-validate": {
@@ -4394,19 +4115,6 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
-        "node_modules/jest-validate/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
         "node_modules/jest-validate/node_modules/camelcase": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
@@ -4419,28 +4127,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/jest-validate/node_modules/pretty-format": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-            "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "ansi-styles": "^5.0.0",
-                "react-is": "^18.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-validate/node_modules/react-is": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/jest-watcher": {
             "version": "29.7.0",
@@ -4569,11 +4255,14 @@
             }
         },
         "node_modules/jsonfile": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
             "dev": true,
             "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
             }
@@ -4749,6 +4438,19 @@
             },
             "engines": {
                 "node": ">=8.6"
+            }
+        },
+        "node_modules/micromatch/node_modules/picomatch": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
         "node_modules/mimic-fn": {
@@ -4987,12 +4689,12 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
             "license": "MIT",
             "engines": {
-                "node": ">=8.6"
+                "node": ">=12"
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
@@ -5088,34 +4790,34 @@
             }
         },
         "node_modules/prettier": {
-            "version": "2.8.8",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-            "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+            "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
             "dev": true,
             "license": "MIT",
             "bin": {
-                "prettier": "bin-prettier.js"
+                "prettier": "bin/prettier.cjs"
             },
             "engines": {
-                "node": ">=10.13.0"
+                "node": ">=14"
             },
             "funding": {
                 "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
         "node_modules/pretty-format": {
-            "version": "27.5.1",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-            "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+            "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "ansi-regex": "^5.0.1",
+                "@jest/schemas": "^29.6.3",
                 "ansi-styles": "^5.0.0",
-                "react-is": "^17.0.1"
+                "react-is": "^18.0.0"
             },
             "engines": {
-                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/pretty-format/node_modules/ansi-styles": {
@@ -5194,9 +4896,9 @@
             "license": "MIT"
         },
         "node_modules/react-is": {
-            "version": "17.0.2",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+            "version": "18.3.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
             "dev": true,
             "license": "MIT"
         },
@@ -5729,9 +5431,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.6.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
-            "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
+            "version": "5.6.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+            "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -5743,15 +5445,15 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.7.0.tgz",
-            "integrity": "sha512-nEHbEYJyHwsuf7c3V3RS7Saq+1+la3i0ieR3qP0yjqWSzVmh8Drp47uOl9LjbPANac4S7EFSqvcYIKXUUwIfIQ==",
+            "version": "8.13.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.13.0.tgz",
+            "integrity": "sha512-vIMpDRJrQd70au2G8w34mPps0ezFSPMEX4pXkTzUkrNbRX+36ais2ksGWN0esZL+ZMaFJEneOBHzCgSqle7DHw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.7.0",
-                "@typescript-eslint/parser": "8.7.0",
-                "@typescript-eslint/utils": "8.7.0"
+                "@typescript-eslint/eslint-plugin": "8.13.0",
+                "@typescript-eslint/parser": "8.13.0",
+                "@typescript-eslint/utils": "8.13.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5766,14 +5468,21 @@
                 }
             }
         },
+        "node_modules/undici-types": {
+            "version": "6.19.8",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+            "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">= 4.0.0"
+                "node": ">= 10.0.0"
             }
         },
         "node_modules/update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -42,34 +42,34 @@
         "node": ">=16.10.0"
     },
     "peerDependencies": {
-        "typescript": "5.6.2"
+        "typescript": "5.6.3"
     },
     "dependencies": {
         "@typescript-to-lua/language-extensions": "1.19.0",
-        "enhanced-resolve": "5.8.2",
-        "picomatch": "^2.3.1",
-        "resolve": "^1.15.1",
-        "source-map": "^0.7.3"
+        "enhanced-resolve": "5.17.1",
+        "picomatch": "^4.0.2",
+        "resolve": "^1.22.8",
+        "source-map": "^0.7.4"
     },
     "devDependencies": {
-        "@types/fs-extra": "^8.1.0",
-        "@types/glob": "^7.1.1",
-        "@types/jest": "^27.5.2",
-        "@types/node": "^13.7.7",
-        "@types/picomatch": "^2.3.0",
-        "@types/resolve": "1.14.0",
-        "eslint": "^9.11.0",
-        "eslint-plugin-jest": "^28.8.3",
-        "fs-extra": "^8.1.0",
-        "javascript-stringify": "^2.0.1",
-        "jest": "^29.5.0",
-        "jest-circus": "^29.5.0",
-        "lua-types": "^2.13.0",
+        "@types/fs-extra": "^11.0.4",
+        "@types/glob": "^8.1.0",
+        "@types/jest": "^29.5.14",
+        "@types/node": "^22.9.0",
+        "@types/picomatch": "^3.0.1",
+        "@types/resolve": "1.20.6",
+        "eslint": "^9.14.0",
+        "eslint-plugin-jest": "^28.9.0",
+        "fs-extra": "^11.2.0",
+        "javascript-stringify": "^2.1.0",
+        "jest": "^29.7.0",
+        "jest-circus": "^29.7.0",
+        "lua-types": "^2.13.1",
         "lua-wasm-bindings": "^0.3.1",
-        "prettier": "^2.8.8",
-        "ts-jest": "^29.1.0",
-        "ts-node": "^10.9.1",
-        "typescript": "^5.6.2",
-        "typescript-eslint": "^8.7.0"
+        "prettier": "^3.3.3",
+        "ts-jest": "^29.2.5",
+        "ts-node": "^10.9.2",
+        "typescript": "5.6.3",
+        "typescript-eslint": "^8.13.0"
     }
 }

--- a/src/LuaAST.ts
+++ b/src/LuaAST.ts
@@ -189,7 +189,7 @@ function getSourcePosition(sourceNode: ts.Node): TextRange | undefined {
     if (sourceFile !== undefined && parseTreeNode.pos >= 0) {
         const { line, character } = ts.getLineAndCharacterOfPosition(
             sourceFile,
-            parseTreeNode.pos + parseTreeNode.getLeadingTriviaWidth()
+            parseTreeNode.pos + parseTreeNode.getLeadingTriviaWidth(),
         );
 
         return { line, column: character };
@@ -220,7 +220,7 @@ export function createFile(
     statements: Statement[],
     luaLibFeatures: Set<LuaLibFeature>,
     trivia: string,
-    tsOriginal?: ts.Node
+    tsOriginal?: ts.Node,
 ): File {
     const file = createNode(SyntaxKind.File, tsOriginal) as File;
     file.statements = statements;
@@ -279,7 +279,7 @@ export function isVariableDeclarationStatement(node: Node): node is VariableDecl
 export function createVariableDeclarationStatement(
     left: Identifier | Identifier[],
     right?: Expression | Expression[],
-    tsOriginal?: ts.Node
+    tsOriginal?: ts.Node,
 ): VariableDeclarationStatement {
     const statement = createNode(SyntaxKind.VariableDeclarationStatement, tsOriginal) as VariableDeclarationStatement;
     statement.left = castArray(left);
@@ -301,7 +301,7 @@ export function isAssignmentStatement(node: Node): node is AssignmentStatement {
 export function createAssignmentStatement(
     left: AssignmentLeftHandSideExpression | AssignmentLeftHandSideExpression[],
     right?: Expression | Expression[],
-    tsOriginal?: ts.Node
+    tsOriginal?: ts.Node,
 ): AssignmentStatement {
     const statement = createNode(SyntaxKind.AssignmentStatement, tsOriginal) as AssignmentStatement;
     statement.left = castArray(left);
@@ -324,7 +324,7 @@ export function createIfStatement(
     condition: Expression,
     ifBlock: Block,
     elseBlock?: Block | IfStatement,
-    tsOriginal?: ts.Node
+    tsOriginal?: ts.Node,
 ): IfStatement {
     const statement = createNode(SyntaxKind.IfStatement, tsOriginal) as IfStatement;
     statement.condition = condition;
@@ -397,7 +397,7 @@ export function createForStatement(
     controlVariableInitializer: Expression,
     limitExpression: Expression,
     stepExpression?: Expression,
-    tsOriginal?: ts.Node
+    tsOriginal?: ts.Node,
 ): ForStatement {
     const statement = createNode(SyntaxKind.ForStatement, tsOriginal) as ForStatement;
     statement.body = body;
@@ -422,7 +422,7 @@ export function createForInStatement(
     body: Block,
     names: Identifier[],
     expressions: Expression[],
-    tsOriginal?: ts.Node
+    tsOriginal?: ts.Node,
 ): ForInStatement {
     const statement = createNode(SyntaxKind.ForInStatement, tsOriginal) as ForInStatement;
     statement.body = body;
@@ -594,7 +594,7 @@ export function createStringLiteral(value: string, tsOriginal?: ts.Node): String
 }
 
 export function isLiteral(
-    node: Node
+    node: Node,
 ): node is NilLiteral | DotsLiteral | ArgLiteral | BooleanLiteral | NumericLiteral | StringLiteral {
     return (
         isNilLiteral(node) ||
@@ -622,7 +622,7 @@ export function createFunctionExpression(
     params?: Identifier[],
     dots?: DotsLiteral,
     flags = NodeFlags.None,
-    tsOriginal?: ts.Node
+    tsOriginal?: ts.Node,
 ): FunctionExpression {
     const expression = createNode(SyntaxKind.FunctionExpression, tsOriginal) as FunctionExpression;
     expression.body = body;
@@ -645,7 +645,7 @@ export function isTableFieldExpression(node: Node): node is TableFieldExpression
 export function createTableFieldExpression(
     value: Expression,
     key?: Expression,
-    tsOriginal?: ts.Node
+    tsOriginal?: ts.Node,
 ): TableFieldExpression {
     const expression = createNode(SyntaxKind.TableFieldExpression, tsOriginal) as TableFieldExpression;
     expression.value = value;
@@ -681,7 +681,7 @@ export function isUnaryExpression(node: Node): node is UnaryExpression {
 export function createUnaryExpression(
     operand: Expression,
     operator: UnaryOperator,
-    tsOriginal?: ts.Node
+    tsOriginal?: ts.Node,
 ): UnaryExpression {
     const expression = createNode(SyntaxKind.UnaryExpression, tsOriginal) as UnaryExpression;
     expression.operand = operand;
@@ -704,7 +704,7 @@ export function createBinaryExpression(
     left: Expression,
     right: Expression,
     operator: BinaryOperator,
-    tsOriginal?: ts.Node
+    tsOriginal?: ts.Node,
 ): BinaryExpression {
     const expression = createNode(SyntaxKind.BinaryExpression, tsOriginal) as BinaryExpression;
     expression.left = left;
@@ -726,7 +726,7 @@ export function isCallExpression(node: Node): node is CallExpression {
 export function createCallExpression(
     expression: Expression,
     params: Expression[],
-    tsOriginal?: ts.Node
+    tsOriginal?: ts.Node,
 ): CallExpression {
     const callExpression = createNode(SyntaxKind.CallExpression, tsOriginal) as CallExpression;
     callExpression.expression = expression;
@@ -749,7 +749,7 @@ export function createMethodCallExpression(
     prefixExpression: Expression,
     name: Identifier,
     params: Expression[],
-    tsOriginal?: ts.Node
+    tsOriginal?: ts.Node,
 ): MethodCallExpression {
     const callExpression = createNode(SyntaxKind.MethodCallExpression, tsOriginal) as MethodCallExpression;
     callExpression.prefixExpression = prefixExpression;
@@ -774,7 +774,7 @@ export function createIdentifier(
     text: string,
     tsOriginal?: ts.Node,
     symbolId?: SymbolId,
-    originalName?: string
+    originalName?: string,
 ): Identifier {
     const expression = createNode(SyntaxKind.Identifier, tsOriginal) as Identifier;
     expression.exportable = true;
@@ -808,7 +808,7 @@ export function isTableIndexExpression(node: Node): node is TableIndexExpression
 export function createTableIndexExpression(
     table: Expression,
     index: Expression,
-    tsOriginal?: ts.Node
+    tsOriginal?: ts.Node,
 ): TableIndexExpression {
     const expression = createNode(SyntaxKind.TableIndexExpression, tsOriginal) as TableIndexExpression;
     expression.table = table;
@@ -827,7 +827,7 @@ export type FunctionDefinition = (VariableDeclarationStatement | AssignmentState
 };
 
 export function isFunctionDefinition(
-    statement: VariableDeclarationStatement | AssignmentStatement
+    statement: VariableDeclarationStatement | AssignmentStatement,
 ): statement is FunctionDefinition {
     return statement.left.length === 1 && statement.right?.length === 1 && isFunctionExpression(statement.right[0]);
 }
@@ -856,7 +856,7 @@ export function isParenthesizedExpression(node: Node): node is ParenthesizedExpr
 export function createParenthesizedExpression(expression: Expression, tsOriginal?: ts.Node): ParenthesizedExpression {
     const parenthesizedExpression = createNode(
         SyntaxKind.ParenthesizedExpression,
-        tsOriginal
+        tsOriginal,
     ) as ParenthesizedExpression;
     parenthesizedExpression.expression = expression;
     return parenthesizedExpression;

--- a/src/LuaLib.ts
+++ b/src/LuaLib.ts
@@ -157,7 +157,7 @@ const lualibExportToFeature = new Map<LuaTarget, ReadonlyMap<string, LuaLibFeatu
 
 export function getLuaLibExportToFeatureMap(
     luaTarget: LuaTarget,
-    emitHost: EmitHost
+    emitHost: EmitHost,
 ): ReadonlyMap<string, LuaLibFeature> {
     if (!lualibExportToFeature.has(luaTarget)) {
         const luaLibModulesInfo = getLuaLibModulesInfo(luaTarget, emitHost);
@@ -192,7 +192,7 @@ export function resolveRecursiveLualibFeatures(
     features: Iterable<LuaLibFeature>,
     luaTarget: LuaTarget,
     emitHost: EmitHost,
-    luaLibModulesInfo: LuaLibModulesInfo = getLuaLibModulesInfo(luaTarget, emitHost)
+    luaLibModulesInfo: LuaLibModulesInfo = getLuaLibModulesInfo(luaTarget, emitHost),
 ): LuaLibFeature[] {
     const loadedFeatures = new Set<LuaLibFeature>();
     const result: LuaLibFeature[] = [];
@@ -219,7 +219,7 @@ export function resolveRecursiveLualibFeatures(
 export function loadInlineLualibFeatures(
     features: Iterable<LuaLibFeature>,
     luaTarget: LuaTarget,
-    emitHost: EmitHost
+    emitHost: EmitHost,
 ): string {
     return resolveRecursiveLualibFeatures(features, luaTarget, emitHost)
         .map(feature => readLuaLibFeature(feature, luaTarget, emitHost))
@@ -229,7 +229,7 @@ export function loadInlineLualibFeatures(
 export function loadImportedLualibFeatures(
     features: Iterable<LuaLibFeature>,
     luaTarget: LuaTarget,
-    emitHost: EmitHost
+    emitHost: EmitHost,
 ): lua.Statement[] {
     const luaLibModuleInfo = getLuaLibModulesInfo(luaTarget, emitHost);
 
@@ -250,8 +250,8 @@ export function loadImportedLualibFeatures(
         statements.push(
             lua.createVariableDeclarationStatement(
                 lua.createIdentifier(item),
-                lua.createTableIndexExpression(luaLibId, lua.createStringLiteral(item))
-            )
+                lua.createTableIndexExpression(luaLibId, lua.createStringLiteral(item)),
+            ),
         );
     }
     return statements;
@@ -280,7 +280,7 @@ export function getLualibBundleReturn(exportedValues: string[]): string {
 export function buildMinimalLualibBundle(
     features: Iterable<LuaLibFeature>,
     luaTarget: LuaTarget,
-    emitHost: EmitHost
+    emitHost: EmitHost,
 ): string {
     const code = loadInlineLualibFeatures(features, luaTarget, emitHost);
     const moduleInfo = getLuaLibModulesInfo(luaTarget, emitHost);
@@ -292,7 +292,7 @@ export function buildMinimalLualibBundle(
 export function findUsedLualibFeatures(
     luaTarget: LuaTarget,
     emitHost: EmitHost,
-    luaContents: string[]
+    luaContents: string[],
 ): Set<LuaLibFeature> {
     const features = new Set<LuaLibFeature>();
     const exportToFeatureMap = getLuaLibExportToFeatureMap(luaTarget, emitHost);

--- a/src/LuaPrinter.ts
+++ b/src/LuaPrinter.ts
@@ -164,7 +164,11 @@ export class LuaPrinter {
 
     public static readonly sourceMapTracebackPlaceholder = "{#SourceMapTraceback}";
 
-    constructor(private emitHost: EmitHost, private program: ts.Program, private sourceFile: string) {
+    constructor(
+        private emitHost: EmitHost,
+        private program: ts.Program,
+        private sourceFile: string,
+    ) {
         this.options = program.getCompilerOptions();
         this.luaFile = normalizeSlashes(getEmitPath(this.sourceFile, this.program));
         // Source nodes contain relative path from mapped lua file to original TS source file
@@ -241,7 +245,7 @@ export class LuaPrinter {
         ) {
             // Import lualib features
             sourceChunks = this.printStatementArray(
-                loadImportedLualibFeatures(file.luaLibFeatures, luaTarget, this.emitHost)
+                loadImportedLualibFeatures(file.luaLibFeatures, luaTarget, this.emitHost),
             );
         } else if (luaLibImport === LuaLibImportKind.Inline && file.luaLibFeatures.size > 0) {
             // Inline lualib features
@@ -341,7 +345,7 @@ export class LuaPrinter {
             resultNode = this.concatNodes(
                 statement.leadingComments.map(c => this.printComment(c)).join("\n"),
                 "\n",
-                resultNode
+                resultNode,
             );
         }
 
@@ -349,7 +353,7 @@ export class LuaPrinter {
             resultNode = this.concatNodes(
                 resultNode,
                 "\n",
-                statement.trailingComments.map(c => this.printComment(c)).join("\n")
+                statement.trailingComments.map(c => this.printComment(c)).join("\n"),
             );
         }
 
@@ -727,8 +731,8 @@ export class LuaPrinter {
         chunks.push(
             this.printExpressionInParenthesesIfNeeded(
                 expression.operand,
-                LuaPrinter.operatorPrecedence[expression.operator]
-            )
+                LuaPrinter.operatorPrecedence[expression.operator],
+            ),
         );
 
         return this.createSourceNode(expression, chunks);
@@ -739,14 +743,17 @@ export class LuaPrinter {
         const isRightAssociative = LuaPrinter.rightAssociativeOperators.has(expression.operator);
         const precedence = LuaPrinter.operatorPrecedence[expression.operator];
         chunks.push(
-            this.printExpressionInParenthesesIfNeeded(expression.left, isRightAssociative ? precedence + 1 : precedence)
+            this.printExpressionInParenthesesIfNeeded(
+                expression.left,
+                isRightAssociative ? precedence + 1 : precedence,
+            ),
         );
         chunks.push(" ", this.printOperator(expression.operator), " ");
         chunks.push(
             this.printExpressionInParenthesesIfNeeded(
                 expression.right,
-                isRightAssociative ? precedence : precedence + 1
-            )
+                isRightAssociative ? precedence : precedence + 1,
+            ),
         );
 
         return this.createSourceNode(expression, chunks);
@@ -808,7 +815,7 @@ export class LuaPrinter {
         return this.createSourceNode(
             expression,
             expression.text,
-            expression.originalName !== expression.text ? expression.originalName : undefined
+            expression.originalName !== expression.text ? expression.originalName : undefined,
         );
     }
 

--- a/src/cli/diagnostics.ts
+++ b/src/cli/diagnostics.ts
@@ -25,50 +25,50 @@ const createCommandLineError = <TArgs extends any[]>(code: number, getMessage: (
 
 export const unknownCompilerOption = createCommandLineError(
     5023,
-    (name: string) => `Unknown compiler option '${name}'.`
+    (name: string) => `Unknown compiler option '${name}'.`,
 );
 
 export const compilerOptionRequiresAValueOfType = createCommandLineError(
     5024,
-    (name: string, type: string) => `Compiler option '${name}' requires a value of type ${type}.`
+    (name: string, type: string) => `Compiler option '${name}' requires a value of type ${type}.`,
 );
 
 export const compilerOptionCouldNotParseJson = createCommandLineError(
     5025,
-    (name: string, error: string) => `Compiler option '${name}' failed to parse the given JSON value: '${error}'.`
+    (name: string, error: string) => `Compiler option '${name}' failed to parse the given JSON value: '${error}'.`,
 );
 
 export const optionProjectCannotBeMixedWithSourceFilesOnACommandLine = createCommandLineError(
     5042,
-    () => "Option 'project' cannot be mixed with source files on a command line."
+    () => "Option 'project' cannot be mixed with source files on a command line.",
 );
 
 export const cannotFindATsconfigJsonAtTheSpecifiedDirectory = createCommandLineError(
     5057,
-    (dir: string) => `Cannot find a tsconfig.json file at the specified directory: '${dir}'.`
+    (dir: string) => `Cannot find a tsconfig.json file at the specified directory: '${dir}'.`,
 );
 
 export const theSpecifiedPathDoesNotExist = createCommandLineError(
     5058,
-    (dir: string) => `The specified path does not exist: '${dir}'.`
+    (dir: string) => `The specified path does not exist: '${dir}'.`,
 );
 
 export const compilerOptionExpectsAnArgument = createCommandLineError(
     6044,
-    (name: string) => `Compiler option '${name}' expects an argument.`
+    (name: string) => `Compiler option '${name}' expects an argument.`,
 );
 
 export const argumentForOptionMustBe = createCommandLineError(
     6046,
-    (name: string, values: string) => `Argument for '${name}' option must be: ${values}.`
+    (name: string, values: string) => `Argument for '${name}' option must be: ${values}.`,
 );
 
 export const optionCanOnlyBeSpecifiedInTsconfigJsonFile = createCommandLineError(
     6064,
-    (name: string) => `Option '${name}' can only be specified in 'tsconfig.json' file.`
+    (name: string) => `Option '${name}' can only be specified in 'tsconfig.json' file.`,
 );
 
 export const optionBuildMustBeFirstCommandLineArgument = createCommandLineError(
     6369,
-    () => "Option '--build' must be the first command line argument."
+    () => "Option '--build' must be the first command line argument.",
 );

--- a/src/cli/parse.ts
+++ b/src/cli/parse.ts
@@ -162,7 +162,7 @@ function updateParsedCommandLine(parsedCommandLine: ts.ParsedCommandLine, args: 
             parsedCommandLine.errors = parsedCommandLine.errors.filter(
                 // TS5023: Unknown compiler option '{0}'.
                 // TS5025: Unknown compiler option '{0}'. Did you mean '{1}'?
-                e => !((e.code === 5023 || e.code === 5025) && String(e.messageText).includes(`'${args[i]}'.`))
+                e => !((e.code === 5023 || e.code === 5025) && String(e.messageText).includes(`'${args[i]}'.`)),
             );
 
             const { error, value, consumed } = readCommandLineArgument(option, args[i + 1]);

--- a/src/cli/tsconfig.ts
+++ b/src/cli/tsconfig.ts
@@ -39,7 +39,7 @@ export function locateConfigFile(commandLine: ParsedCommandLine): ts.Diagnostic 
 export function parseConfigFileWithSystem(
     configFileName: string,
     commandLineOptions?: CompilerOptions,
-    system = ts.sys
+    system = ts.sys,
 ): ParsedCommandLine {
     const configRootDir = path.dirname(configFileName);
     const parsedConfigFile = ts.parseJsonSourceFileConfigFileContent(
@@ -47,7 +47,7 @@ export function parseConfigFileWithSystem(
         system,
         configRootDir,
         commandLineOptions,
-        configFileName
+        configFileName,
     );
 
     const cycleCache = new Set<string>();
@@ -61,7 +61,7 @@ export function parseConfigFileWithSystem(
 function resolveNpmModuleConfig(
     moduleName: string,
     configRootDir: string,
-    host: ts.ModuleResolutionHost
+    host: ts.ModuleResolutionHost,
 ): string | undefined {
     const resolved = ts.nodeNextJsonConfigResolver(moduleName, path.join(configRootDir, "tsconfig.json"), host);
     if (resolved.resolvedModule) {
@@ -73,13 +73,13 @@ function getExtendedTstlOptions(
     configFilePath: string,
     configRootDir: string,
     cycleCache: Set<string>,
-    system: ts.System
+    system: ts.System,
 ): TypeScriptToLuaOptions {
     const absolutePath = ts.pathIsAbsolute(configFilePath)
         ? configFilePath
         : ts.pathIsRelative(configFilePath)
-        ? path.resolve(configRootDir, configFilePath)
-        : resolveNpmModuleConfig(configFilePath, configRootDir, system); // if a path is neither relative nor absolute, it is probably a npm module
+          ? path.resolve(configRootDir, configFilePath)
+          : resolveNpmModuleConfig(configFilePath, configRootDir, system); // if a path is neither relative nor absolute, it is probably a npm module
 
     if (!absolutePath) {
         return {};
@@ -112,7 +112,7 @@ function getExtendedTstlOptions(
                 for (const extendedConfigFile of parsedConfig.extends) {
                     Object.assign(
                         options,
-                        getExtendedTstlOptions(extendedConfigFile, newConfigRoot, cycleCache, system)
+                        getExtendedTstlOptions(extendedConfigFile, newConfigRoot, cycleCache, system),
                     );
                 }
             } else {
@@ -129,7 +129,7 @@ function getExtendedTstlOptions(
 }
 
 export function createConfigFileUpdater(
-    optionsToExtend: CompilerOptions
+    optionsToExtend: CompilerOptions,
 ): (options: ts.CompilerOptions) => ts.Diagnostic[] {
     const configFileMap = new WeakMap<ts.TsConfigSourceFile, ts.ParsedCommandLine>();
     return options => {

--- a/src/lualib-build/plugin.ts
+++ b/src/lualib-build/plugin.ts
@@ -45,7 +45,7 @@ class LuaLibPlugin implements tstl.Plugin {
         emitHost.writeFile(
             path.join(tstl.getEmitOutDir(program), luaLibModulesInfoFileName),
             JSON.stringify(luaLibModuleInfo, null, 2),
-            emitBOM
+            emitBOM,
         );
 
         // Flatten the output folder structure; we do not want to keep the target-specific directories
@@ -110,7 +110,7 @@ class LuaLibPlugin implements tstl.Plugin {
 
         const filteredStatements = fileResult.statements
             .filter(
-                s => !isExportTableDeclaration(s) && !isRequire(s) && !isImport(s, importNames) && !isExportsReturn(s)
+                s => !isExportTableDeclaration(s) && !isRequire(s) && !isImport(s, importNames) && !isExportsReturn(s),
             )
             .map(statement => {
                 if (isExportAlias(statement)) {
@@ -131,14 +131,14 @@ class LuaLibPlugin implements tstl.Plugin {
             const bodyStatements = filteredStatements.map(s =>
                 isExportAssignment(s)
                     ? tstl.createAssignmentStatement(tstl.createIdentifier(s.left[0].index.value), s.right[0])
-                    : s
+                    : s,
             );
 
             fileResult.statements = [exports, tstl.createDoStatement(bodyStatements)];
         } else {
             // transform export assignments to local variable declarations
             fileResult.statements = filteredStatements.map(s =>
-                tstl.createVariableDeclarationStatement(tstl.createIdentifier(s.left[0].index.value), s.right[0])
+                tstl.createVariableDeclarationStatement(tstl.createIdentifier(s.left[0].index.value), s.right[0]),
             );
         }
 

--- a/src/lualib-build/util.ts
+++ b/src/lualib-build/util.ts
@@ -14,7 +14,7 @@ export function isExportTableIndex(node: tstl.Node): node is ExportTableIndex {
 }
 
 export function isExportAlias(
-    node: tstl.Node
+    node: tstl.Node,
 ): node is tstl.VariableDeclarationStatement & { right: [ExportTableIndex] } {
     return tstl.isVariableDeclarationStatement(node) && node.right !== undefined && isExportTableIndex(node.right[0]);
 }

--- a/src/lualib/ArrayEvery.ts
+++ b/src/lualib/ArrayEvery.ts
@@ -1,7 +1,7 @@
 export function __TS__ArrayEvery<T>(
     this: T[],
     callbackfn: (value: T, index?: number, array?: any[]) => boolean,
-    thisArg?: any
+    thisArg?: any,
 ): boolean {
     for (const i of $range(1, this.length)) {
         if (!callbackfn.call(thisArg, this[i - 1], i - 1, this)) {

--- a/src/lualib/ArrayFilter.ts
+++ b/src/lualib/ArrayFilter.ts
@@ -1,7 +1,7 @@
 export function __TS__ArrayFilter<T>(
     this: T[],
     callbackfn: (value: T, index?: number, array?: any[]) => boolean,
-    thisArg?: any
+    thisArg?: any,
 ): T[] {
     const result: T[] = [];
     let len = 0;

--- a/src/lualib/ArrayFind.ts
+++ b/src/lualib/ArrayFind.ts
@@ -2,7 +2,7 @@
 export function __TS__ArrayFind<T>(
     this: T[],
     predicate: (value: T, index: number, obj: T[]) => unknown,
-    thisArg?: any
+    thisArg?: any,
 ): T | undefined {
     for (const i of $range(1, this.length)) {
         const elem = this[i - 1];

--- a/src/lualib/ArrayFindIndex.ts
+++ b/src/lualib/ArrayFindIndex.ts
@@ -1,7 +1,7 @@
 export function __TS__ArrayFindIndex<T>(
     this: T[],
     callbackFn: (element: T, index?: number, array?: T[]) => boolean,
-    thisArg?: any
+    thisArg?: any,
 ): number {
     for (const i of $range(1, this.length)) {
         if (callbackFn.call(thisArg, this[i - 1], i - 1, this)) {

--- a/src/lualib/ArrayFlatMap.ts
+++ b/src/lualib/ArrayFlatMap.ts
@@ -1,7 +1,7 @@
 export function __TS__ArrayFlatMap<T, U>(
     this: T[],
     callback: (value: T, index: number, array: T[]) => U | readonly U[],
-    thisArg?: any
+    thisArg?: any,
 ): U[] {
     const result: U[] = [];
     let len = 0;

--- a/src/lualib/ArrayForEach.ts
+++ b/src/lualib/ArrayForEach.ts
@@ -1,7 +1,7 @@
 export function __TS__ArrayForEach<T>(
     this: T[],
     callbackFn: (value: T, index?: number, array?: any[]) => any,
-    thisArg?: any
+    thisArg?: any,
 ): void {
     for (const i of $range(1, this.length)) {
         callbackFn.call(thisArg, this[i - 1], i - 1, this);

--- a/src/lualib/ArrayFrom.ts
+++ b/src/lualib/ArrayFrom.ts
@@ -10,7 +10,7 @@ function arrayLikeStep(this: ArrayLike<unknown>, index: number): LuaMultiReturn<
 
 const arrayLikeIterator: (
     this: void,
-    arr: ArrayLike<unknown> | Iterable<unknown>
+    arr: ArrayLike<unknown> | Iterable<unknown>,
 ) => LuaIterable<LuaMultiReturn<[number, unknown]>> = ((arr: any) => {
     if (typeof arr.length === "number") return $multi(arrayLikeStep, arr, 0);
     return __TS__Iterator(arr);
@@ -20,7 +20,7 @@ export function __TS__ArrayFrom(
     this: void,
     arrayLike: ArrayLike<unknown> | Iterable<unknown>,
     mapFn?: (this: unknown, element: unknown, index: number) => unknown,
-    thisArg?: unknown
+    thisArg?: unknown,
 ): unknown[] {
     const result = [];
     if (mapFn === undefined) {

--- a/src/lualib/ArrayMap.ts
+++ b/src/lualib/ArrayMap.ts
@@ -1,7 +1,7 @@
 export function __TS__ArrayMap<T, U>(
     this: T[],
     callbackfn: (value: T, index?: number, array?: T[]) => U,
-    thisArg?: any
+    thisArg?: any,
 ): U[] {
     const result: U[] = [];
     for (const i of $range(1, this.length)) {

--- a/src/lualib/ArraySome.ts
+++ b/src/lualib/ArraySome.ts
@@ -1,7 +1,7 @@
 export function __TS__ArraySome<T>(
     this: T[],
     callbackfn: (value: T, index?: number, array?: any[]) => boolean,
-    thisArg?: any
+    thisArg?: any,
 ): boolean {
     for (const i of $range(1, this.length)) {
         if (callbackfn.call(thisArg, this[i - 1], i - 1, this)) {

--- a/src/lualib/CloneDescriptor.ts
+++ b/src/lualib/CloneDescriptor.ts
@@ -1,6 +1,6 @@
 export function __TS__CloneDescriptor(
     this: void,
-    { enumerable, configurable, get, set, writable, value }: PropertyDescriptor
+    { enumerable, configurable, get, set, writable, value }: PropertyDescriptor,
 ): PropertyDescriptor {
     const descriptor: PropertyDescriptor = {
         enumerable: enumerable === true,

--- a/src/lualib/Decorate.ts
+++ b/src/lualib/Decorate.ts
@@ -7,7 +7,7 @@ export function __TS__Decorate<TClass, TTarget>(
     this: TClass,
     originalValue: TTarget,
     decorators: Array<Decorator<TTarget>>,
-    context: DecoratorContext
+    context: DecoratorContext,
 ): TTarget {
     let result = originalValue;
 

--- a/src/lualib/DecorateLegacy.ts
+++ b/src/lualib/DecorateLegacy.ts
@@ -7,7 +7,7 @@ import { __TS__SetDescriptor } from "./SetDescriptor";
 export type LegacyDecorator<TTarget extends AnyTable, TKey extends keyof TTarget> = (
     target: TTarget,
     key?: TKey,
-    descriptor?: PropertyDescriptor
+    descriptor?: PropertyDescriptor,
 ) => TTarget;
 
 export function __TS__DecorateLegacy<TTarget extends AnyTable, TKey extends keyof TTarget>(
@@ -15,7 +15,7 @@ export function __TS__DecorateLegacy<TTarget extends AnyTable, TKey extends keyo
     decorators: Array<LegacyDecorator<TTarget, TKey>>,
     target: TTarget,
     key?: TKey,
-    desc?: any
+    desc?: any,
 ): TTarget {
     let result = target;
 

--- a/src/lualib/DecorateParam.ts
+++ b/src/lualib/DecorateParam.ts
@@ -3,12 +3,12 @@ import type { LegacyDecorator } from "./DecorateLegacy";
 type ParamDecorator<TTarget extends AnyTable, TKey extends keyof TTarget> = (
     target: TTarget,
     key: TKey | undefined,
-    index: number
+    index: number,
 ) => TTarget;
 export function __TS__DecorateParam<TTarget extends AnyTable, TKey extends keyof TTarget>(
     this: void,
     paramIndex: number,
-    decorator: ParamDecorator<TTarget, TKey>
+    decorator: ParamDecorator<TTarget, TKey>,
 ): LegacyDecorator<TTarget, TKey> {
     return (target: TTarget, key?: TKey) => decorator(target, key, paramIndex);
 }

--- a/src/lualib/Error.ts
+++ b/src/lualib/Error.ts
@@ -67,7 +67,7 @@ export const Error: ErrorConstructor = initErrorClass(
             return this.message !== "" ? `${this.name}: ${this.message}` : this.name;
         }
     },
-    "Error"
+    "Error",
 );
 
 function createErrorClass(name: string) {
@@ -75,7 +75,7 @@ function createErrorClass(name: string) {
         class extends Error {
             public name = name;
         },
-        name
+        name,
     );
 }
 

--- a/src/lualib/Iterator.ts
+++ b/src/lualib/Iterator.ts
@@ -24,7 +24,7 @@ function iteratorStringStep(this: string, index: number): LuaMultiReturn<[number
 
 export function __TS__Iterator<T>(
     this: void,
-    iterable: string | GeneratorIterator | Iterable<T> | readonly T[]
+    iterable: string | GeneratorIterator | Iterable<T> | readonly T[],
 ): LuaMultiReturn<[(...args: any[]) => [any, any] | [], ...any[]]> | LuaIterable<LuaMultiReturn<[number, T]>> {
     if (typeof iterable === "string") {
         return $multi(iteratorStringStep, iterable, 0);

--- a/src/lualib/LuaIteratorSpread.ts
+++ b/src/lualib/LuaIteratorSpread.ts
@@ -1,7 +1,7 @@
 export function __TS__LuaIteratorSpread<TKey, TValue, TState>(
     this: (this: void, state: TState, key: TKey) => LuaMultiReturn<[TKey, TValue]>,
     state: TState,
-    firstKey: TKey
+    firstKey: TKey,
 ): LuaMultiReturn<Array<[TKey, TValue]>> {
     const results = [];
     let [key, value] = this(state, firstKey);

--- a/src/lualib/MapGroupBy.ts
+++ b/src/lualib/MapGroupBy.ts
@@ -1,7 +1,7 @@
 export function __TS__MapGroupBy<K, T>(
     this: void,
     items: Iterable<T>,
-    keySelector: (item: T, index: number) => K
+    keySelector: (item: T, index: number) => K,
 ): Map<K, T[]> {
     const result = new Map<K, T[]>();
 

--- a/src/lualib/ObjectDefineProperty.ts
+++ b/src/lualib/ObjectDefineProperty.ts
@@ -6,7 +6,7 @@ export function __TS__ObjectDefineProperty<T extends object>(
     this: void,
     target: T,
     key: any,
-    desc: PropertyDescriptor
+    desc: PropertyDescriptor,
 ): T {
     const luaKey = typeof key === "number" ? key + 1 : key;
     const value = rawget(target, luaKey);

--- a/src/lualib/ObjectEntries.ts
+++ b/src/lualib/ObjectEntries.ts
@@ -1,6 +1,6 @@
 export function __TS__ObjectEntries<TKey extends string | number, TValue>(
     this: void,
-    obj: Record<TKey, TValue>
+    obj: Record<TKey, TValue>,
 ): Array<[TKey, TValue]> {
     const result: Array<[TKey, TValue]> = [];
     let len = 0;

--- a/src/lualib/ObjectFromEntries.ts
+++ b/src/lualib/ObjectFromEntries.ts
@@ -1,6 +1,6 @@
 export function __TS__ObjectFromEntries<T>(
     this: void,
-    entries: ReadonlyArray<[string, T]> | Iterable<[string, T]>
+    entries: ReadonlyArray<[string, T]> | Iterable<[string, T]>,
 ): Record<string, T> {
     const obj: Record<string, T> = {};
 

--- a/src/lualib/ObjectGetOwnPropertyDescriptor.ts
+++ b/src/lualib/ObjectGetOwnPropertyDescriptor.ts
@@ -1,7 +1,7 @@
 export function __TS__ObjectGetOwnPropertyDescriptor(
     this: void,
     object: any,
-    key: any
+    key: any,
 ): PropertyDescriptor | undefined {
     const metatable = getmetatable(object);
     if (!metatable) return;

--- a/src/lualib/ObjectGetOwnPropertyDescriptors.ts
+++ b/src/lualib/ObjectGetOwnPropertyDescriptors.ts
@@ -1,6 +1,6 @@
 export function __TS__ObjectGetOwnPropertyDescriptors(
     this: void,
-    object: any
+    object: any,
 ): Record<any, PropertyDescriptor | undefined> {
     const metatable = getmetatable(object);
     if (!metatable) return {};

--- a/src/lualib/ObjectGroupBy.ts
+++ b/src/lualib/ObjectGroupBy.ts
@@ -1,7 +1,7 @@
 export function __TS__ObjectGroupBy<K extends PropertyKey, T>(
     this: void,
     items: Iterable<T>,
-    keySelector: (item: T, index: number) => K
+    keySelector: (item: T, index: number) => K,
 ): Partial<Record<K, T[]>> {
     const result: Partial<Record<K, T[]>> = {};
 

--- a/src/lualib/ObjectRest.ts
+++ b/src/lualib/ObjectRest.ts
@@ -1,7 +1,7 @@
 export function __TS__ObjectRest<K extends keyof any, V>(
     this: void,
     target: Record<K, V>,
-    usedProperties: Partial<Record<K, true>>
+    usedProperties: Partial<Record<K, true>>,
 ): Partial<Record<K, V>> {
     const result: Partial<Record<K, V>> = {};
     for (const property in target) {

--- a/src/lualib/Promise.ts
+++ b/src/lualib/Promise.ts
@@ -77,7 +77,7 @@ export class __TS__Promise<T> implements Promise<T> {
             executor,
             undefined,
             v => this.resolve(v),
-            err => this.reject(err)
+            err => this.reject(err),
         );
         if (!success) {
             // When a promise executor throws, the promise should be rejected with the thrown object as reason
@@ -88,7 +88,7 @@ export class __TS__Promise<T> implements Promise<T> {
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then
     public then<TResult1 = T, TResult2 = never>(
         onFulfilled?: PromiseResolveCallback<T, TResult1>,
-        onRejected?: PromiseRejectCallback<TResult2>
+        onRejected?: PromiseRejectCallback<TResult2>,
     ): Promise<TResult1 | TResult2> {
         const [promise, resolve, reject] = makeDeferredPromise<T | TResult1 | TResult2>();
 
@@ -96,7 +96,7 @@ export class __TS__Promise<T> implements Promise<T> {
             // We always want to resolve our child promise if this promise is resolved, even if we have no handler
             onFulfilled ? this.createPromiseResolvingCallback(onFulfilled, resolve, reject) : resolve,
             // We always want to reject our child promise if this promise is rejected, even if we have no handler
-            onRejected ? this.createPromiseResolvingCallback(onRejected, resolve, reject) : reject
+            onRejected ? this.createPromiseResolvingCallback(onRejected, resolve, reject) : reject,
         );
 
         return promise as Promise<TResult1 | TResult2>;
@@ -141,7 +141,7 @@ export class __TS__Promise<T> implements Promise<T> {
             // Tail call return is important!
             return (value as __TS__Promise<T>).addCallbacks(
                 v => this.resolve(v),
-                err => this.reject(err)
+                err => this.reject(err),
             );
         }
 
@@ -193,7 +193,7 @@ export class __TS__Promise<T> implements Promise<T> {
     private createPromiseResolvingCallback<TResult1, TResult2>(
         f: PromiseResolveCallback<T, TResult1> | PromiseRejectCallback<TResult2>,
         resolve: (data: TResult1 | TResult2) => void,
-        reject: (reason: any) => void
+        reject: (reason: any) => void,
     ) {
         return (value: T): void => {
             const [success, resultOrError] = pcall<
@@ -213,7 +213,7 @@ export class __TS__Promise<T> implements Promise<T> {
     private handleCallbackValue<TResult1, TResult2, TResult extends TResult1 | TResult2>(
         value: TResult | PromiseLike<TResult>,
         resolve: (data: TResult1 | TResult2) => void,
-        reject: (reason: any) => void
+        reject: (reason: any) => void,
     ): void {
         if (isPromiseLike<TResult>(value)) {
             const nextpromise = value as __TS__Promise<TResult>;

--- a/src/lualib/PromiseAll.ts
+++ b/src/lualib/PromiseAll.ts
@@ -49,7 +49,7 @@ export function __TS__PromiseAll<T>(this: void, iterable: Iterable<T | PromiseLi
                 reason => {
                     // When rejected, immediately reject the returned promise
                     reject(reason);
-                }
+                },
             );
         }
     });

--- a/src/lualib/PromiseAllSettled.ts
+++ b/src/lualib/PromiseAllSettled.ts
@@ -4,7 +4,7 @@ import { __TS__Promise, PromiseState } from "./Promise";
 // eslint-disable-next-line @typescript-eslint/promise-function-async
 export function __TS__PromiseAllSettled<T>(
     this: void,
-    iterable: Iterable<T>
+    iterable: Iterable<T>,
 ): Promise<Array<PromiseSettledResult<T extends PromiseLike<infer U> ? U : T>>> {
     const results: Array<PromiseSettledResult<T extends PromiseLike<infer U> ? U : T>> = [];
 
@@ -57,7 +57,7 @@ export function __TS__PromiseAllSettled<T>(
                         // If there are no more promises to resolve, resolve with our filled results array
                         resolve(results);
                     }
-                }
+                },
             );
         }
     });

--- a/src/lualib/PromiseAny.ts
+++ b/src/lualib/PromiseAny.ts
@@ -50,7 +50,7 @@ export function __TS__PromiseAny<T>(this: void, iterable: Iterable<T | PromiseLi
                             errors: rejections,
                         });
                     }
-                }
+                },
             );
         }
     });

--- a/src/lualib/PromiseRace.ts
+++ b/src/lualib/PromiseRace.ts
@@ -29,7 +29,7 @@ export function __TS__PromiseRace<T>(this: void, iterable: Iterable<T | PromiseL
         for (const promise of pending) {
             promise.then(
                 value => resolve(value),
-                reason => reject(reason)
+                reason => reject(reason),
             );
         }
     });

--- a/src/lualib/SetDescriptor.ts
+++ b/src/lualib/SetDescriptor.ts
@@ -18,7 +18,7 @@ export function __TS__SetDescriptor(
     target: any,
     key: any,
     desc: PropertyDescriptor,
-    isPrototype = false
+    isPrototype = false,
 ): void {
     let metatable = isPrototype ? target : getmetatable(target);
     if (!metatable) {

--- a/src/lualib/SourceMapTraceBack.ts
+++ b/src/lualib/SourceMapTraceBack.ts
@@ -50,7 +50,7 @@ export function __TS__SourceMapTraceBack(this: void, fileName: string, sourceMap
             };
 
             let [result] = string.gsub(trace, "(%S+)%.lua:(%d+)", (file, line) =>
-                replacer(`${file}.lua`, `${file}.ts`, line)
+                replacer(`${file}.lua`, `${file}.ts`, line),
             );
 
             const stringReplacer = (file: string, line: string) => {

--- a/src/lualib/StringReplace.ts
+++ b/src/lualib/StringReplace.ts
@@ -3,7 +3,7 @@ export function __TS__StringReplace(
     this: void,
     source: string,
     searchValue: string,
-    replaceValue: string | ((match: string, offset: number, string: string) => string)
+    replaceValue: string | ((match: string, offset: number, string: string) => string),
 ): string {
     const [startPos, endPos] = string.find(source, searchValue, undefined, true);
     if (!startPos) {

--- a/src/lualib/StringReplaceAll.ts
+++ b/src/lualib/StringReplaceAll.ts
@@ -4,7 +4,7 @@ export function __TS__StringReplaceAll(
     this: void,
     source: string,
     searchValue: string,
-    replaceValue: string | ((match: string, offset: number, string: string) => string)
+    replaceValue: string | ((match: string, offset: number, string: string) => string),
 ): string {
     if (typeof replaceValue === "string") {
         const concat = table.concat(source.split(searchValue), replaceValue);

--- a/src/lualib/Using.ts
+++ b/src/lualib/Using.ts
@@ -6,7 +6,7 @@ export function __TS__Using<TArgs extends Disposable[], TReturn>(
     let thrownError;
     const [ok, result] = xpcall(
         () => cb(...args),
-        err => (thrownError = err)
+        err => (thrownError = err),
     );
 
     const argArray = [...args];

--- a/src/lualib/UsingAsync.ts
+++ b/src/lualib/UsingAsync.ts
@@ -6,7 +6,7 @@ export async function __TS__UsingAsync<TArgs extends Array<Disposable | AsyncDis
     let thrownError;
     const [ok, result] = xpcall(
         () => cb(...args),
-        err => (thrownError = err)
+        err => (thrownError = err),
     );
 
     const argArray = [...args];

--- a/src/transformation/builtins/array.ts
+++ b/src/transformation/builtins/array.ts
@@ -12,7 +12,7 @@ import { isUnpackCall, wrapInTable } from "../utils/lua-ast";
 export function transformArrayConstructorCall(
     context: TransformationContext,
     node: ts.CallExpression,
-    calledMethod: ts.PropertyAccessExpression
+    calledMethod: ts.PropertyAccessExpression,
 ): lua.Expression | undefined {
     const signature = context.checker.getResolvedSignature(node);
     const params = transformArguments(context, node.arguments, signature);
@@ -34,7 +34,7 @@ function createTableLengthExpression(context: TransformationContext, expression:
     if (context.luaTarget === LuaTarget.Lua50) {
         const tableGetn = lua.createTableIndexExpression(
             lua.createIdentifier("table"),
-            lua.createStringLiteral("getn")
+            lua.createStringLiteral("getn"),
         );
         return lua.createCallExpression(tableGetn, [expression], node);
     } else {
@@ -52,7 +52,7 @@ function transformSingleElementArrayPush(
     context: TransformationContext,
     node: ts.CallExpression,
     caller: lua.Expression,
-    param: lua.Expression
+    param: lua.Expression,
 ): lua.Expression {
     const arrayIdentifier = lua.isIdentifier(caller) ? caller : moveToPrecedingTemp(context, caller);
 
@@ -60,7 +60,7 @@ function transformSingleElementArrayPush(
     let lengthExpression: lua.Expression = lua.createBinaryExpression(
         createTableLengthExpression(context, arrayIdentifier),
         lua.createNumericLiteral(1),
-        lua.SyntaxKind.AdditionOperator
+        lua.SyntaxKind.AdditionOperator,
     );
 
     const expressionIsUsed = expressionResultIsUsed(node);
@@ -72,7 +72,7 @@ function transformSingleElementArrayPush(
     const pushStatement = lua.createAssignmentStatement(
         lua.createTableIndexExpression(arrayIdentifier, lengthExpression),
         param,
-        node
+        node,
     );
     context.addPrecedingStatements(pushStatement);
     return expressionIsUsed ? lengthExpression : lua.createNilLiteral();
@@ -81,7 +81,7 @@ function transformSingleElementArrayPush(
 export function transformArrayPrototypeCall(
     context: TransformationContext,
     node: ts.CallExpression,
-    calledMethod: ts.PropertyAccessExpression
+    calledMethod: ts.PropertyAccessExpression,
 ): lua.Expression | undefined {
     const signature = context.checker.getResolvedSignature(node);
     const [caller, params] = transformCallAndArguments(context, calledMethod.expression, node.arguments, signature);
@@ -105,7 +105,7 @@ export function transformArrayPrototypeCall(
                         LuaLibFeature.ArrayPushArray,
                         node,
                         caller,
-                        (param as lua.CallExpression).params[0] ?? lua.createNilLiteral()
+                        (param as lua.CallExpression).params[0] ?? lua.createNilLiteral(),
                     );
                 }
                 if (!lua.isDotsLiteral(param)) {
@@ -120,7 +120,7 @@ export function transformArrayPrototypeCall(
             return lua.createCallExpression(
                 lua.createTableIndexExpression(lua.createIdentifier("table"), lua.createStringLiteral("remove")),
                 [caller, lua.createNumericLiteral(1)],
-                node
+                node,
             );
         case "unshift":
             return transformLuaLibFunction(context, LuaLibFeature.ArrayUnshift, node, caller, ...params);
@@ -130,7 +130,7 @@ export function transformArrayPrototypeCall(
             return lua.createCallExpression(
                 lua.createTableIndexExpression(lua.createIdentifier("table"), lua.createStringLiteral("remove")),
                 [caller],
-                node
+                node,
             );
         case "forEach":
             return transformLuaLibFunction(context, LuaLibFeature.ArrayForEach, node, caller, ...params);
@@ -172,14 +172,14 @@ export function transformArrayPrototypeCall(
                     node.arguments.length === 0
                         ? defaultSeparatorLiteral
                         : lua.isStringLiteral(param)
-                        ? param
-                        : lua.createBinaryExpression(param, defaultSeparatorLiteral, lua.SyntaxKind.OrOperator),
+                          ? param
+                          : lua.createBinaryExpression(param, defaultSeparatorLiteral, lua.SyntaxKind.OrOperator),
                 ];
 
                 return lua.createCallExpression(
                     lua.createTableIndexExpression(lua.createIdentifier("table"), lua.createStringLiteral("concat")),
                     parameters,
-                    node
+                    node,
                 );
             }
 
@@ -203,7 +203,7 @@ export function transformArrayPrototypeCall(
 
 export function transformArrayProperty(
     context: TransformationContext,
-    node: ts.PropertyAccessExpression
+    node: ts.PropertyAccessExpression,
 ): lua.Expression | undefined {
     switch (node.name.text) {
         case "length":

--- a/src/transformation/builtins/console.ts
+++ b/src/transformation/builtins/console.ts
@@ -9,7 +9,7 @@ const isStringFormatTemplate = (node: ts.Expression) => ts.isStringLiteral(node)
 export function transformConsoleCall(
     context: TransformationContext,
     node: ts.CallExpression,
-    calledMethod: ts.PropertyAccessExpression
+    calledMethod: ts.PropertyAccessExpression,
 ): lua.Expression | undefined {
     const methodName = calledMethod.name.text;
     const signature = context.checker.getResolvedSignature(node);
@@ -24,7 +24,7 @@ export function transformConsoleCall(
                 // print(string.format([arguments]))
                 const stringFormatCall = lua.createCallExpression(
                     lua.createTableIndexExpression(lua.createIdentifier("string"), lua.createStringLiteral("format")),
-                    parameters
+                    parameters,
                 );
                 return lua.createCallExpression(lua.createIdentifier("print"), [stringFormatCall]);
             }
@@ -35,7 +35,7 @@ export function transformConsoleCall(
                 // assert([condition], string.format([arguments]))
                 const stringFormatCall = lua.createCallExpression(
                     lua.createTableIndexExpression(lua.createIdentifier("string"), lua.createStringLiteral("format")),
-                    parameters.slice(1)
+                    parameters.slice(1),
                 );
                 return lua.createCallExpression(lua.createIdentifier("assert"), [parameters[0], stringFormatCall]);
             }
@@ -46,18 +46,18 @@ export function transformConsoleCall(
                 // print(debug.traceback(string.format([arguments])))
                 const stringFormatCall = lua.createCallExpression(
                     lua.createTableIndexExpression(lua.createIdentifier("string"), lua.createStringLiteral("format")),
-                    parameters
+                    parameters,
                 );
                 const debugTracebackCall = lua.createCallExpression(
                     lua.createTableIndexExpression(lua.createIdentifier("debug"), lua.createStringLiteral("traceback")),
-                    [stringFormatCall]
+                    [stringFormatCall],
                 );
                 return lua.createCallExpression(lua.createIdentifier("print"), [debugTracebackCall]);
             }
             // print(debug.traceback([arguments])))
             const debugTracebackCall = lua.createCallExpression(
                 lua.createTableIndexExpression(lua.createIdentifier("debug"), lua.createStringLiteral("traceback")),
-                parameters
+                parameters,
             );
             return lua.createCallExpression(lua.createIdentifier("print"), [debugTracebackCall]);
         default:

--- a/src/transformation/builtins/function.ts
+++ b/src/transformation/builtins/function.ts
@@ -11,7 +11,7 @@ import { createUnpackCall } from "../utils/lua-ast";
 export function transformFunctionPrototypeCall(
     context: TransformationContext,
     node: ts.CallExpression,
-    calledMethod: ts.PropertyAccessExpression
+    calledMethod: ts.PropertyAccessExpression,
 ): lua.CallExpression | undefined {
     const callerType = context.checker.getTypeAtLocation(calledMethod.expression);
     if (getFunctionContextType(context, callerType) === ContextType.Void) {
@@ -36,7 +36,7 @@ export function transformFunctionPrototypeCall(
 
 export function transformFunctionProperty(
     context: TransformationContext,
-    node: ts.PropertyAccessExpression
+    node: ts.PropertyAccessExpression,
 ): lua.Expression | undefined {
     switch (node.name.text) {
         case "length":
@@ -51,7 +51,7 @@ export function transformFunctionProperty(
             // debug.getinfo(fn)
             const getInfoCall = lua.createCallExpression(
                 lua.createTableIndexExpression(lua.createIdentifier("debug"), lua.createStringLiteral("getinfo")),
-                [context.transformExpression(node.expression)]
+                [context.transformExpression(node.expression)],
             );
 
             const nparams = lua.createTableIndexExpression(getInfoCall, lua.createStringLiteral("nparams"));

--- a/src/transformation/builtins/global.ts
+++ b/src/transformation/builtins/global.ts
@@ -8,7 +8,7 @@ import { transformArguments } from "../visitors/call";
 export function tryTransformBuiltinGlobalCall(
     context: TransformationContext,
     node: ts.CallExpression,
-    expressionType: ts.Type
+    expressionType: ts.Type,
 ): lua.Expression | undefined {
     function getParameters() {
         const signature = context.checker.getResolvedSignature(node);
@@ -31,7 +31,7 @@ export function tryTransformBuiltinGlobalCall(
                 context,
                 name === "isNaN" ? LuaLibFeature.NumberIsNaN : LuaLibFeature.NumberIsFinite,
                 node,
-                ...numberParameters
+                ...numberParameters,
             );
         case "parseFloat":
             return transformLuaLibFunction(context, LuaLibFeature.ParseFloat, node, ...getParameters());

--- a/src/transformation/builtins/index.ts
+++ b/src/transformation/builtins/index.ts
@@ -22,7 +22,7 @@ import { transformMapConstructorCall } from "./map";
 
 export function transformBuiltinPropertyAccessExpression(
     context: TransformationContext,
-    node: ts.PropertyAccessExpression
+    node: ts.PropertyAccessExpression,
 ): lua.Expression | undefined {
     const ownerType = context.checker.getTypeAtLocation(node.expression);
 
@@ -52,7 +52,7 @@ export function transformBuiltinPropertyAccessExpression(
 
 export function transformBuiltinCallExpression(
     context: TransformationContext,
-    node: ts.CallExpression
+    node: ts.CallExpression,
 ): lua.Expression | undefined {
     const expressionType = context.checker.getTypeAtLocation(node.expression);
     if (ts.isIdentifier(node.expression) && isStandardLibraryType(context, expressionType, undefined)) {
@@ -80,7 +80,7 @@ export function transformBuiltinCallExpression(
 function tryTransformBuiltinGlobalMethodCall(
     context: TransformationContext,
     node: ts.CallExpression,
-    calledMethod: ts.PropertyAccessExpression
+    calledMethod: ts.PropertyAccessExpression,
 ) {
     const ownerType = context.checker.getTypeAtLocation(calledMethod.expression);
     const ownerSymbol = tryGetStandardLibrarySymbolOfType(context, ownerType);
@@ -126,7 +126,7 @@ function tryTransformBuiltinGlobalMethodCall(
 function tryTransformBuiltinPropertyCall(
     context: TransformationContext,
     node: ts.CallExpression,
-    calledMethod: ts.PropertyAccessExpression
+    calledMethod: ts.PropertyAccessExpression,
 ) {
     const functionType = context.checker.getTypeAtLocation(node.expression);
     const callSymbol = tryGetStandardLibrarySymbolOfType(context, functionType);
@@ -152,7 +152,7 @@ function tryTransformBuiltinPropertyCall(
 export function transformBuiltinIdentifierExpression(
     context: TransformationContext,
     node: ts.Identifier,
-    symbol: ts.Symbol | undefined
+    symbol: ts.Symbol | undefined,
 ): lua.Expression | undefined {
     switch (node.text) {
         case "NaN":

--- a/src/transformation/builtins/map.ts
+++ b/src/transformation/builtins/map.ts
@@ -8,7 +8,7 @@ import { LuaLibFeature, transformLuaLibFunction } from "../utils/lualib";
 export function transformMapConstructorCall(
     context: TransformationContext,
     node: ts.CallExpression,
-    calledMethod: ts.PropertyAccessExpression
+    calledMethod: ts.PropertyAccessExpression,
 ): lua.Expression | undefined {
     const args = transformArguments(context, node.arguments);
     const methodName = calledMethod.name.text;

--- a/src/transformation/builtins/math.ts
+++ b/src/transformation/builtins/math.ts
@@ -8,7 +8,7 @@ import { transformArguments } from "../visitors/call";
 
 export function transformMathProperty(
     context: TransformationContext,
-    node: ts.PropertyAccessExpression
+    node: ts.PropertyAccessExpression,
 ): lua.Expression | undefined {
     const name = node.name.text;
     switch (name) {
@@ -34,7 +34,7 @@ export function transformMathProperty(
 export function transformMathCall(
     context: TransformationContext,
     node: ts.CallExpression,
-    calledMethod: ts.PropertyAccessExpression
+    calledMethod: ts.PropertyAccessExpression,
 ): lua.Expression | undefined {
     const signature = context.checker.getResolvedSignature(node);
     const params = transformArguments(context, node.arguments, signature);
@@ -69,7 +69,7 @@ export function transformMathCall(
             const add = lua.createBinaryExpression(
                 one,
                 params[0] ?? lua.createNilLiteral(),
-                lua.SyntaxKind.AdditionOperator
+                lua.SyntaxKind.AdditionOperator,
             );
             return lua.createCallExpression(lua.createTableIndexExpression(math, log), [add], node);
         }
@@ -80,7 +80,7 @@ export function transformMathCall(
                 params[0] ?? lua.createNilLiteral(),
                 params[1] ?? lua.createNilLiteral(),
                 lua.SyntaxKind.PowerOperator,
-                node
+                node,
             );
         }
 
@@ -91,7 +91,7 @@ export function transformMathCall(
             const add = lua.createBinaryExpression(
                 params[0] ?? lua.createNilLiteral(),
                 half,
-                lua.SyntaxKind.AdditionOperator
+                lua.SyntaxKind.AdditionOperator,
             );
             return lua.createCallExpression(lua.createTableIndexExpression(math, floor), [add], node);
         }

--- a/src/transformation/builtins/number.ts
+++ b/src/transformation/builtins/number.ts
@@ -10,7 +10,7 @@ import { LuaTarget } from "../../CompilerOptions";
 export function transformNumberPrototypeCall(
     context: TransformationContext,
     node: ts.CallExpression,
-    calledMethod: ts.PropertyAccessExpression
+    calledMethod: ts.PropertyAccessExpression,
 ): lua.Expression | undefined {
     const signature = context.checker.getResolvedSignature(node);
     const params = transformArguments(context, node.arguments, signature);
@@ -31,7 +31,7 @@ export function transformNumberPrototypeCall(
 
 export function transformNumberProperty(
     context: TransformationContext,
-    node: ts.PropertyAccessExpression
+    node: ts.PropertyAccessExpression,
 ): lua.Expression | undefined {
     const name = node.name.text;
 
@@ -57,14 +57,14 @@ export function transformNumberProperty(
                 const zero = lua.createNumericLiteral(0);
                 return lua.createUnaryExpression(
                     lua.createBinaryExpression(one, zero, lua.SyntaxKind.DivisionOperator),
-                    lua.SyntaxKind.NegationOperator
+                    lua.SyntaxKind.NegationOperator,
                 );
             } else {
                 const math = lua.createIdentifier("math");
                 const huge = lua.createStringLiteral("huge");
                 return lua.createUnaryExpression(
                     lua.createTableIndexExpression(math, huge, node),
-                    lua.SyntaxKind.NegationOperator
+                    lua.SyntaxKind.NegationOperator,
                 );
             }
         case "NaN":
@@ -74,35 +74,35 @@ export function transformNumberProperty(
                 lua.createNumericLiteral(2),
                 lua.createNumericLiteral(-52),
                 lua.SyntaxKind.PowerOperator,
-                node
+                node,
             );
         case "MIN_VALUE":
             return lua.createBinaryExpression(
                 lua.createNumericLiteral(-2),
                 lua.createNumericLiteral(1074),
                 lua.SyntaxKind.PowerOperator,
-                node
+                node,
             );
         case "MIN_SAFE_INTEGER":
             return lua.createBinaryExpression(
                 lua.createNumericLiteral(-2),
                 lua.createNumericLiteral(1074),
                 lua.SyntaxKind.PowerOperator,
-                node
+                node,
             );
         case "MAX_SAFE_INTEGER":
             return lua.createBinaryExpression(
                 lua.createNumericLiteral(2),
                 lua.createNumericLiteral(1024),
                 lua.SyntaxKind.PowerOperator,
-                node
+                node,
             );
         case "MAX_VALUE":
             return lua.createBinaryExpression(
                 lua.createNumericLiteral(2),
                 lua.createNumericLiteral(1024),
                 lua.SyntaxKind.PowerOperator,
-                node
+                node,
             );
 
         default:
@@ -113,7 +113,7 @@ export function transformNumberProperty(
 export function transformNumberConstructorCall(
     context: TransformationContext,
     node: ts.CallExpression,
-    calledMethod: ts.PropertyAccessExpression
+    calledMethod: ts.PropertyAccessExpression,
 ): lua.CallExpression | undefined {
     const parameters = transformArguments(context, node.arguments);
     const methodName = calledMethod.name.text;

--- a/src/transformation/builtins/object.ts
+++ b/src/transformation/builtins/object.ts
@@ -8,7 +8,7 @@ import { transformArguments } from "../visitors/call";
 export function transformObjectConstructorCall(
     context: TransformationContext,
     node: ts.CallExpression,
-    calledMethod: ts.PropertyAccessExpression
+    calledMethod: ts.PropertyAccessExpression,
 ): lua.Expression | undefined {
     const args = transformArguments(context, node.arguments);
     const methodName = calledMethod.name.text;
@@ -40,7 +40,7 @@ export function transformObjectConstructorCall(
 export function tryTransformObjectPrototypeCall(
     context: TransformationContext,
     node: ts.CallExpression,
-    calledMethod: ts.PropertyAccessExpression
+    calledMethod: ts.PropertyAccessExpression,
 ): lua.Expression | undefined {
     const name = calledMethod.name.text;
     switch (name) {
@@ -49,7 +49,7 @@ export function tryTransformObjectPrototypeCall(
             return lua.createCallExpression(
                 toStringIdentifier,
                 [context.transformExpression(calledMethod.expression)],
-                node
+                node,
             );
         case "hasOwnProperty":
             const expr = context.transformExpression(calledMethod.expression);
@@ -61,7 +61,7 @@ export function tryTransformObjectPrototypeCall(
                 rawGetCall,
                 lua.createNilLiteral(),
                 lua.SyntaxKind.InequalityOperator,
-                node
+                node,
             );
     }
 }

--- a/src/transformation/builtins/promise.ts
+++ b/src/transformation/builtins/promise.ts
@@ -19,7 +19,7 @@ export function createPromiseIdentifier(original: ts.Node) {
 export function transformPromiseConstructorCall(
     context: TransformationContext,
     node: ts.CallExpression,
-    calledMethod: ts.PropertyAccessExpression
+    calledMethod: ts.PropertyAccessExpression,
 ): lua.Expression | undefined {
     const signature = context.checker.getResolvedSignature(node);
     const params = transformArguments(context, node.arguments, signature);
@@ -49,6 +49,6 @@ export function createStaticPromiseFunctionAccessor(functionName: string, node: 
     return lua.createTableIndexExpression(
         lua.createIdentifier("__TS__Promise"),
         lua.createStringLiteral(functionName),
-        node
+        node,
     );
 }

--- a/src/transformation/builtins/string.ts
+++ b/src/transformation/builtins/string.ts
@@ -12,14 +12,14 @@ function createStringCall(methodName: string, tsOriginal: ts.Node, ...params: lu
     return lua.createCallExpression(
         lua.createTableIndexExpression(stringIdentifier, lua.createStringLiteral(methodName)),
         params,
-        tsOriginal
+        tsOriginal,
     );
 }
 
 export function transformStringPrototypeCall(
     context: TransformationContext,
     node: ts.CallExpression,
-    calledMethod: ts.PropertyAccessExpression
+    calledMethod: ts.PropertyAccessExpression,
 ): lua.Expression | undefined {
     const signature = context.checker.getResolvedSignature(node);
     const [caller, params] = transformCallAndArguments(context, calledMethod.expression, node.arguments, signature);
@@ -34,7 +34,7 @@ export function transformStringPrototypeCall(
             return lua.createCallExpression(
                 lua.createTableIndexExpression(lua.createIdentifier("table"), lua.createStringLiteral("concat")),
                 [wrapInTable(caller, ...params)],
-                node
+                node,
             );
 
         case "indexOf": {
@@ -47,17 +47,17 @@ export function transformStringPrototypeCall(
                     ? // string.find handles negative indexes by making it relative to string end, but for indexOf it's the same as 0
                       lua.createCallExpression(
                           lua.createTableIndexExpression(lua.createIdentifier("math"), lua.createStringLiteral("max")),
-                          [addToNumericExpression(params[1], 1), lua.createNumericLiteral(1)]
+                          [addToNumericExpression(params[1], 1), lua.createNumericLiteral(1)],
                       )
                     : lua.createNilLiteral(),
-                lua.createBooleanLiteral(true)
+                lua.createBooleanLiteral(true),
             );
 
             return lua.createBinaryExpression(
                 lua.createBinaryExpression(stringExpression, lua.createNumericLiteral(0), lua.SyntaxKind.OrOperator),
                 lua.createNumericLiteral(1),
                 lua.SyntaxKind.SubtractionOperator,
-                node
+                node,
             );
         }
 
@@ -126,10 +126,10 @@ export function transformStringPrototypeCall(
                         "byte",
                         node,
                         caller,
-                        addToNumericExpression(params[0] ?? lua.createNilLiteral(), 1)
+                        addToNumericExpression(params[0] ?? lua.createNilLiteral(), 1),
                     ),
                     createNaN(),
-                    lua.SyntaxKind.OrOperator
+                    lua.SyntaxKind.OrOperator,
                 );
             }
 
@@ -163,7 +163,7 @@ export function transformStringPrototypeCall(
 export function transformStringConstructorCall(
     context: TransformationContext,
     node: ts.CallExpression,
-    calledMethod: ts.PropertyAccessExpression
+    calledMethod: ts.PropertyAccessExpression,
 ): lua.Expression | undefined {
     const signature = context.checker.getResolvedSignature(node);
     const params = transformArguments(context, node.arguments, signature);
@@ -174,7 +174,7 @@ export function transformStringConstructorCall(
             return lua.createCallExpression(
                 lua.createTableIndexExpression(lua.createIdentifier("string"), lua.createStringLiteral("char")),
                 params,
-                node
+                node,
             );
 
         default:
@@ -184,7 +184,7 @@ export function transformStringConstructorCall(
 
 export function transformStringProperty(
     context: TransformationContext,
-    node: ts.PropertyAccessExpression
+    node: ts.PropertyAccessExpression,
 ): lua.Expression | undefined {
     switch (node.name.text) {
         case "length":
@@ -192,7 +192,7 @@ export function transformStringProperty(
             if (context.luaTarget === LuaTarget.Lua50) {
                 const stringLen = lua.createTableIndexExpression(
                     lua.createIdentifier("string"),
-                    lua.createStringLiteral("len")
+                    lua.createStringLiteral("len"),
                 );
                 return lua.createCallExpression(stringLen, [expression], node);
             } else {

--- a/src/transformation/builtins/symbol.ts
+++ b/src/transformation/builtins/symbol.ts
@@ -8,7 +8,7 @@ import { transformArguments } from "../visitors/call";
 export function transformSymbolConstructorCall(
     context: TransformationContext,
     node: ts.CallExpression,
-    calledMethod: ts.PropertyAccessExpression
+    calledMethod: ts.PropertyAccessExpression,
 ): lua.CallExpression | undefined {
     const signature = context.checker.getResolvedSignature(node);
     const parameters = transformArguments(context, node.arguments, signature);

--- a/src/transformation/context/context.ts
+++ b/src/transformation/context/context.ts
@@ -43,7 +43,11 @@ export class TransformationContext {
         (this.options.alwaysStrict ?? this.options.strict) ||
         (this.isModule && this.options.target !== undefined && this.options.target >= ts.ScriptTarget.ES2015);
 
-    constructor(public program: ts.Program, public sourceFile: ts.SourceFile, private visitorMap: VisitorMap) {
+    constructor(
+        public program: ts.Program,
+        public sourceFile: ts.SourceFile,
+        private visitorMap: VisitorMap,
+    ) {
         // Use `getParseTreeNode` to get original SourceFile node, before it was substituted by custom transformers.
         // It's required because otherwise `getEmitResolver` won't use cached diagnostics, produced in `emitWorker`
         // and would try to re-analyze the file, which would fail because of replaced nodes.

--- a/src/transformation/context/visitors.ts
+++ b/src/transformation/context/visitors.ts
@@ -142,10 +142,10 @@ export type StatementLikeNode = ts.Statement;
 export type VisitorResult<T extends ts.Node> = T extends ExpressionLikeNode
     ? lua.Expression
     : T extends StatementLikeNode
-    ? OneToManyVisitorResult<lua.Statement>
-    : T extends ts.SourceFile
-    ? lua.File
-    : OneToManyVisitorResult<lua.Node>;
+      ? OneToManyVisitorResult<lua.Statement>
+      : T extends ts.SourceFile
+        ? lua.File
+        : OneToManyVisitorResult<lua.Node>;
 
 export type Visitor<T extends ts.Node> = FunctionVisitor<T> | ObjectVisitor<T>;
 export type FunctionVisitor<T extends ts.Node> = (node: T, context: TransformationContext) => VisitorResult<T>;

--- a/src/transformation/index.ts
+++ b/src/transformation/index.ts
@@ -25,7 +25,7 @@ export function createVisitorMap(customVisitors: Visitors[]): VisitorMap {
     for (const [kind, nodeVisitors] of objectVisitorMap) {
         result.set(
             kind,
-            nodeVisitors.sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0)).map(visitor => visitor.transform)
+            nodeVisitors.sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0)).map(visitor => visitor.transform),
         );
     }
     return result;

--- a/src/transformation/pre-transformers/using-transformer.ts
+++ b/src/transformation/pre-transformers/using-transformer.ts
@@ -40,7 +40,7 @@ function isUsingDeclarationList(node: ts.Node): node is ts.VariableStatement {
 function transformBlockWithUsing(
     context: TransformationContext,
     statements: ts.NodeArray<ts.Statement> | ts.Statement[],
-    block: ts.Block
+    block: ts.Block,
 ): [true, ts.Statement[]] | [false] {
     const newStatements: ts.Statement[] = [];
 
@@ -57,7 +57,7 @@ function transformBlockWithUsing(
 
             // Make declared using variables callback function parameters
             const variableNames = statement.declarationList.declarations.map(d =>
-                ts.factory.createParameterDeclaration(undefined, undefined, d.name)
+                ts.factory.createParameterDeclaration(undefined, undefined, d.name),
             );
             // Add this: void as first parameter
             variableNames.unshift(createThisVoidParameter(context.checker));
@@ -67,10 +67,10 @@ function transformBlockWithUsing(
             const [followingHasUsings, replacedFollowingStatements] = transformBlockWithUsing(
                 context,
                 followingStatements,
-                block
+                block,
             );
             const callbackBody = ts.factory.createBlock(
-                followingHasUsings ? replacedFollowingStatements : followingStatements
+                followingHasUsings ? replacedFollowingStatements : followingStatements,
             );
 
             const callback = ts.factory.createFunctionExpression(
@@ -81,7 +81,7 @@ function transformBlockWithUsing(
                 undefined,
                 variableNames,
                 ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword), // Required for TS to not freak out trying to infer the type of synthetic nodes
-                callbackBody
+                callbackBody,
             );
 
             // Replace using variable list with call to lualib function with callback and followed by all variable initializers
@@ -92,9 +92,9 @@ function transformBlockWithUsing(
                 [
                     callback,
                     ...statement.declarationList.declarations.map(
-                        d => d.initializer ?? ts.factory.createIdentifier("unidentified")
+                        d => d.initializer ?? ts.factory.createIdentifier("unidentified"),
                     ),
-                ]
+                ],
             );
 
             // If this is an 'await using ...', add an await statement here
@@ -124,6 +124,6 @@ function createThisVoidParameter(checker: ts.TypeChecker) {
         undefined,
         ts.factory.createIdentifier("this"),
         undefined,
-        voidType
+        voidType,
     );
 }

--- a/src/transformation/utils/assignment-validation.ts
+++ b/src/transformation/utils/assignment-validation.ts
@@ -16,7 +16,7 @@ export function validateAssignment(
     node: ts.Node,
     fromType: ts.Type,
     toType: ts.Type,
-    toName?: string
+    toName?: string,
 ): void {
     if (toType === fromType) {
         return;
@@ -84,7 +84,7 @@ export function validateAssignment(
             node,
             fromMemberType,
             toMemberType,
-            toName ? `${toName}.${memberName}` : memberName
+            toName ? `${toName}.${memberName}` : memberName,
         );
     }
 }
@@ -94,7 +94,7 @@ function validateFunctionAssignment(
     node: ts.Node,
     fromType: ts.Type,
     toType: ts.Type,
-    toName?: string
+    toName?: string,
 ): void {
     const fromContext = getFunctionContextType(context, fromType);
     const toContext = getFunctionContextType(context, toType);
@@ -105,7 +105,7 @@ function validateFunctionAssignment(
         context.diagnostics.push(
             toContext === ContextType.Void
                 ? unsupportedNoSelfFunctionConversion(node, toName)
-                : unsupportedSelfFunctionConversion(node, toName)
+                : unsupportedSelfFunctionConversion(node, toName),
         );
     }
 }

--- a/src/transformation/utils/diagnostics.ts
+++ b/src/transformation/utils/diagnostics.ts
@@ -8,7 +8,7 @@ type MessageProvider<TArgs extends any[]> = string | ((...args: TArgs) => string
 
 const createDiagnosticFactory = <TArgs extends any[]>(
     category: ts.DiagnosticCategory,
-    message: MessageProvider<TArgs>
+    message: MessageProvider<TArgs>,
 ) =>
     createSerialDiagnosticFactory((node: ts.Node, ...args: TArgs) => ({
         file: ts.getOriginalNode(node).getSourceFile(),
@@ -24,7 +24,7 @@ const createWarningDiagnosticFactory = <TArgs extends any[]>(message: MessagePro
     createDiagnosticFactory(ts.DiagnosticCategory.Warning, message);
 
 export const unsupportedNodeKind = createErrorDiagnosticFactory(
-    (kind: ts.SyntaxKind) => `Unsupported node kind ${ts.SyntaxKind[kind]}`
+    (kind: ts.SyntaxKind) => `Unsupported node kind ${ts.SyntaxKind[kind]}`,
 );
 
 export const forbiddenForIn = createErrorDiagnosticFactory("Iterating over arrays with 'for ... in' is not allowed.");
@@ -56,119 +56,120 @@ export const unsupportedOverloadAssignment = createErrorDiagnosticFactory((name?
 export const decoratorInvalidContext = createErrorDiagnosticFactory("Decorator function cannot have 'this: void'.");
 
 export const annotationInvalidArgumentCount = createErrorDiagnosticFactory(
-    (kind: AnnotationKind, got: number, expected: number) => `'@${kind}' expects ${expected} arguments, but got ${got}.`
+    (kind: AnnotationKind, got: number, expected: number) =>
+        `'@${kind}' expects ${expected} arguments, but got ${got}.`,
 );
 
 export const invalidRangeUse = createErrorDiagnosticFactory("$range can only be used in a for...of loop.");
 
 export const invalidVarargUse = createErrorDiagnosticFactory(
-    "$vararg can only be used in a spread element ('...$vararg') in global scope."
+    "$vararg can only be used in a spread element ('...$vararg') in global scope.",
 );
 
 export const invalidRangeControlVariable = createErrorDiagnosticFactory(
-    "For loop using $range must declare a single control variable."
+    "For loop using $range must declare a single control variable.",
 );
 
 export const invalidMultiIterableWithoutDestructuring = createErrorDiagnosticFactory(
-    "LuaIterable with a LuaMultiReturn return value type must be destructured."
+    "LuaIterable with a LuaMultiReturn return value type must be destructured.",
 );
 
 export const invalidPairsIterableWithoutDestructuring = createErrorDiagnosticFactory(
-    "LuaPairsIterable type must be destructured in a for...of statement."
+    "LuaPairsIterable type must be destructured in a for...of statement.",
 );
 
 export const unsupportedAccessorInObjectLiteral = createErrorDiagnosticFactory(
-    "Accessors in object literal are not supported."
+    "Accessors in object literal are not supported.",
 );
 
 export const unsupportedRightShiftOperator = createErrorDiagnosticFactory(
-    "Right shift operator is not supported for target Lua 5.3. Use `>>>` instead."
+    "Right shift operator is not supported for target Lua 5.3. Use `>>>` instead.",
 );
 
 const getLuaTargetName = (version: LuaTarget) => (version === LuaTarget.LuaJIT ? "LuaJIT" : `Lua ${version}`);
 export const unsupportedForTarget = createErrorDiagnosticFactory(
     (functionality: string, version: LuaTarget) =>
-        `${functionality} is/are not supported for target ${getLuaTargetName(version)}.`
+        `${functionality} is/are not supported for target ${getLuaTargetName(version)}.`,
 );
 
 export const unsupportedForTargetButOverrideAvailable = createErrorDiagnosticFactory(
     (functionality: string, version: LuaTarget, optionName: keyof TypeScriptToLuaOptions) =>
         `As a precaution, ${functionality} is/are not supported for target ${getLuaTargetName(
-            version
+            version,
         )} due to language features/limitations. ` +
         `However "--${optionName}" can be used to bypass this precaution. ` +
-        "See https://typescripttolua.github.io/docs/configuration for more information."
+        "See https://typescripttolua.github.io/docs/configuration for more information.",
 );
 
 export const unsupportedProperty = createErrorDiagnosticFactory(
-    (parentName: string, property: string) => `${parentName}.${property} is unsupported.`
+    (parentName: string, property: string) => `${parentName}.${property} is unsupported.`,
 );
 
 export const invalidAmbientIdentifierName = createErrorDiagnosticFactory(
-    (text: string) => `Invalid ambient identifier name '${text}'. Ambient identifiers must be valid lua identifiers.`
+    (text: string) => `Invalid ambient identifier name '${text}'. Ambient identifiers must be valid lua identifiers.`,
 );
 
 export const unsupportedVarDeclaration = createErrorDiagnosticFactory(
-    "`var` declarations are not supported. Use `let` or `const` instead."
+    "`var` declarations are not supported. Use `let` or `const` instead.",
 );
 
 export const invalidMultiFunctionUse = createErrorDiagnosticFactory(
-    "The $multi function must be called in a return statement."
+    "The $multi function must be called in a return statement.",
 );
 
 export const invalidMultiFunctionReturnType = createErrorDiagnosticFactory(
-    "The $multi function cannot be cast to a non-LuaMultiReturn type."
+    "The $multi function cannot be cast to a non-LuaMultiReturn type.",
 );
 
 export const invalidMultiReturnAccess = createErrorDiagnosticFactory(
-    "The LuaMultiReturn type can only be accessed via an element access expression of a numeric type."
+    "The LuaMultiReturn type can only be accessed via an element access expression of a numeric type.",
 );
 
 export const invalidCallExtensionUse = createErrorDiagnosticFactory(
-    "This function must be called directly and cannot be referred to."
+    "This function must be called directly and cannot be referred to.",
 );
 export const annotationDeprecated = createWarningDiagnosticFactory(
     (kind: AnnotationKind) =>
         `'@${kind}' is deprecated and will be removed in a future update. Please update your code before upgrading to the next release, otherwise your project will no longer compile. ` +
-        `See https://typescripttolua.github.io/docs/advanced/compiler-annotations#${kind.toLowerCase()} for more information.`
+        `See https://typescripttolua.github.io/docs/advanced/compiler-annotations#${kind.toLowerCase()} for more information.`,
 );
 
 export const truthyOnlyConditionalValue = createWarningDiagnosticFactory(
-    "Only false and nil evaluate to 'false' in Lua, everything else is considered 'true'. Explicitly compare the value with ===."
+    "Only false and nil evaluate to 'false' in Lua, everything else is considered 'true'. Explicitly compare the value with ===.",
 );
 
 export const notAllowedOptionalAssignment = createErrorDiagnosticFactory(
-    "The left-hand side of an assignment expression may not be an optional property access."
+    "The left-hand side of an assignment expression may not be an optional property access.",
 );
 
 export const awaitMustBeInAsyncFunction = createErrorDiagnosticFactory(
-    "Await can only be used inside async functions."
+    "Await can only be used inside async functions.",
 );
 
 export const unsupportedBuiltinOptionalCall = createErrorDiagnosticFactory(
-    "Optional calls are not supported for builtin or language extension functions."
+    "Optional calls are not supported for builtin or language extension functions.",
 );
 
 export const unsupportedOptionalCompileMembersOnly = createErrorDiagnosticFactory(
-    "Optional calls are not supported on enums marked with @compileMembersOnly."
+    "Optional calls are not supported on enums marked with @compileMembersOnly.",
 );
 
 export const undefinedInArrayLiteral = createErrorDiagnosticFactory(
-    "Array literals may not contain undefined or null."
+    "Array literals may not contain undefined or null.",
 );
 
 export const invalidMethodCallExtensionUse = createErrorDiagnosticFactory(
-    "This language extension must be called as a method."
+    "This language extension must be called as a method.",
 );
 
 export const invalidSpreadInCallExtension = createErrorDiagnosticFactory(
-    "Spread elements are not supported in call extensions."
+    "Spread elements are not supported in call extensions.",
 );
 
 export const cannotAssignToNodeOfKind = createErrorDiagnosticFactory(
-    (kind: lua.SyntaxKind) => `Cannot create assignment assigning to a node of type ${lua.SyntaxKind[kind]}.`
+    (kind: lua.SyntaxKind) => `Cannot create assignment assigning to a node of type ${lua.SyntaxKind[kind]}.`,
 );
 
 export const incompleteFieldDecoratorWarning = createWarningDiagnosticFactory(
-    "You are using a class field decorator, note that tstl ignores returned value initializers!"
+    "You are using a class field decorator, note that tstl ignores returned value initializers!",
 );

--- a/src/transformation/utils/export.ts
+++ b/src/transformation/utils/export.ts
@@ -32,7 +32,7 @@ export function getExportedSymbolDeclaration(symbol: ts.Symbol): ts.Declaration 
 
 export function getSymbolFromIdentifier(
     context: TransformationContext,
-    identifier: lua.Identifier
+    identifier: lua.Identifier,
 ): ts.Symbol | undefined {
     if (identifier.symbolId !== undefined) {
         const symbolInfo = getSymbolInfo(context, identifier.symbolId);
@@ -44,7 +44,7 @@ export function getSymbolFromIdentifier(
 
 export function getIdentifierExportScope(
     context: TransformationContext,
-    identifier: lua.Identifier
+    identifier: lua.Identifier,
 ): ts.SourceFile | ts.ModuleDeclaration | undefined {
     const symbol = getSymbolFromIdentifier(context, identifier);
     if (!symbol) {
@@ -60,7 +60,7 @@ function isGlobalAugmentation(module: ts.ModuleDeclaration): boolean {
 
 export function getSymbolExportScope(
     context: TransformationContext,
-    symbol: ts.Symbol
+    symbol: ts.Symbol,
 ): ts.SourceFile | ts.ModuleDeclaration | undefined {
     const exportedDeclaration = getExportedSymbolDeclaration(symbol);
     if (!exportedDeclaration) {
@@ -69,7 +69,7 @@ export function getSymbolExportScope(
 
     const scope = findFirstNodeAbove(
         exportedDeclaration,
-        (n): n is ts.SourceFile | ts.ModuleDeclaration => ts.isSourceFile(n) || ts.isModuleDeclaration(n)
+        (n): n is ts.SourceFile | ts.ModuleDeclaration => ts.isSourceFile(n) || ts.isModuleDeclaration(n),
     );
     if (!scope) {
         return undefined;
@@ -88,7 +88,7 @@ export function getSymbolExportScope(
 
 export function getExportedSymbolsFromScope(
     context: TransformationContext,
-    scope: ts.SourceFile | ts.ModuleDeclaration
+    scope: ts.SourceFile | ts.ModuleDeclaration,
 ): ts.Symbol[] {
     const scopeSymbol = context.checker.getSymbolAtLocation(ts.isSourceFile(scope) ? scope : scope.name);
     if (scopeSymbol?.exports === undefined) {
@@ -105,7 +105,7 @@ export function getDependenciesOfSymbol(context: TransformationContext, original
         exportSymbol.declarations
             ?.filter(ts.isExportSpecifier)
             .map(context.checker.getExportSpecifierLocalTargetSymbol)
-            .includes(originalSymbol)
+            .includes(originalSymbol),
     );
 }
 
@@ -120,14 +120,14 @@ export function isSymbolExported(context: TransformationContext, symbol: ts.Symb
 export function isSymbolExportedFromScope(
     context: TransformationContext,
     symbol: ts.Symbol,
-    scope: ts.SourceFile | ts.ModuleDeclaration
+    scope: ts.SourceFile | ts.ModuleDeclaration,
 ): boolean {
     return getExportedSymbolsFromScope(context, scope).includes(symbol);
 }
 
 export function addExportToIdentifier(
     context: TransformationContext,
-    identifier: lua.Identifier
+    identifier: lua.Identifier,
 ): lua.AssignmentLeftHandSideExpression {
     const exportScope = getIdentifierExportScope(context, identifier);
     return exportScope ? createExportedIdentifier(context, identifier, exportScope) : identifier;
@@ -136,7 +136,7 @@ export function addExportToIdentifier(
 export function createExportedIdentifier(
     context: TransformationContext,
     identifier: lua.Identifier,
-    exportScope?: ts.SourceFile | ts.ModuleDeclaration
+    exportScope?: ts.SourceFile | ts.ModuleDeclaration,
 ): lua.AssignmentLeftHandSideExpression {
     if (!identifier.exportable) {
         return identifier;

--- a/src/transformation/utils/function-context.ts
+++ b/src/transformation/utils/function-context.ts
@@ -14,7 +14,7 @@ export enum ContextType {
 function hasNoSelfAncestor(declaration: ts.Declaration): boolean {
     const scopeDeclaration = findFirstNodeAbove(
         declaration,
-        (node): node is ts.SourceFile | ts.ModuleDeclaration => ts.isSourceFile(node) || ts.isModuleDeclaration(node)
+        (node): node is ts.SourceFile | ts.ModuleDeclaration => ts.isSourceFile(node) || ts.isModuleDeclaration(node),
     );
 
     if (!scopeDeclaration) {
@@ -55,8 +55,8 @@ export function getCallContextType(context: TransformationContext, callExpressio
         contextType = declarations.some(d => getFileAnnotations(d.getSourceFile()).has(AnnotationKind.NoSelfInFile))
             ? ContextType.Void
             : context.options.noImplicitSelf
-            ? ContextType.Void
-            : ContextType.NonVoid;
+              ? ContextType.Void
+              : ContextType.NonVoid;
     }
 
     callContextTypes.set(callExpression, contextType);
@@ -67,7 +67,7 @@ const signatureDeclarationContextTypes = new WeakMap<ts.SignatureDeclaration, Co
 
 function getSignatureContextType(
     context: TransformationContext,
-    signatureDeclaration: ts.SignatureDeclaration
+    signatureDeclaration: ts.SignatureDeclaration,
 ): ContextType {
     const known = signatureDeclarationContextTypes.get(signatureDeclaration);
     if (known !== undefined) return known;
@@ -80,12 +80,12 @@ function findRootDeclarations(context: TransformationContext, callExpression: ts
     const calledExpression = ts.isTaggedTemplateExpression(callExpression)
         ? callExpression.tag
         : ts.isJsxSelfClosingElement(callExpression)
-        ? callExpression.tagName
-        : ts.isJsxOpeningElement(callExpression)
-        ? callExpression.tagName
-        : ts.isCallExpression(callExpression)
-        ? callExpression.expression
-        : undefined;
+          ? callExpression.tagName
+          : ts.isJsxOpeningElement(callExpression)
+            ? callExpression.tagName
+            : ts.isCallExpression(callExpression)
+              ? callExpression.expression
+              : undefined;
 
     if (!calledExpression) return [];
 
@@ -130,7 +130,7 @@ function computeDeclarationContextType(context: TransformationContext, signature
         const scopeDeclaration = findFirstNodeAbove(
             signatureDeclaration,
             (n): n is ts.ClassLikeDeclaration | ts.InterfaceDeclaration =>
-                ts.isClassDeclaration(n) || ts.isClassExpression(n) || ts.isInterfaceDeclaration(n)
+                ts.isClassDeclaration(n) || ts.isClassExpression(n) || ts.isInterfaceDeclaration(n),
         );
 
         if (scopeDeclaration !== undefined && getNodeAnnotations(scopeDeclaration).has(AnnotationKind.NoSelf)) {
@@ -232,6 +232,6 @@ function computeFunctionContextType(context: TransformationContext, type: ts.Typ
     }
 
     return reduceContextTypes(
-        signatures.flatMap(s => getSignatureDeclarations(context, s)).map(s => getSignatureContextType(context, s))
+        signatures.flatMap(s => getSignatureDeclarations(context, s)).map(s => getSignatureContextType(context, s)),
     );
 }

--- a/src/transformation/utils/language-extensions.ts
+++ b/src/transformation/utils/language-extensions.ts
@@ -90,7 +90,7 @@ export function getExtensionKindForNode(context: TransformationContext, node: ts
 
 export function getExtensionKindForSymbol(
     context: TransformationContext,
-    symbol: ts.Symbol
+    symbol: ts.Symbol,
 ): ExtensionKind | undefined {
     const type = context.checker.getTypeOfSymbolAtLocation(symbol, context.sourceFile);
     return getExtensionKindForType(context, type);
@@ -108,7 +108,7 @@ export function isLuaIterable(context: TransformationContext, type: ts.Type): bo
 
 export function getIterableExtensionTypeForType(
     context: TransformationContext,
-    type: ts.Type
+    type: ts.Type,
 ): IterableExtensionKind | undefined {
     const value = getPropertyValue(context, type, "__tstlIterable");
     if (value && value in IterableExtensionKind) {
@@ -118,21 +118,21 @@ export function getIterableExtensionTypeForType(
 
 export function getIterableExtensionKindForNode(
     context: TransformationContext,
-    node: ts.Node
+    node: ts.Node,
 ): IterableExtensionKind | undefined {
     const type = context.checker.getTypeAtLocation(node);
     return getIterableExtensionTypeForType(context, type);
 }
 
 export const methodExtensionKinds: ReadonlySet<ExtensionKind> = new Set<ExtensionKind>(
-    Object.values(ExtensionKind).filter(key => key.endsWith("Method"))
+    Object.values(ExtensionKind).filter(key => key.endsWith("Method")),
 );
 
 export function getNaryCallExtensionArgs(
     context: TransformationContext,
     node: ts.CallExpression,
     kind: ExtensionKind,
-    numArgs: number
+    numArgs: number,
 ): readonly ts.Expression[] | undefined {
     let expressions: readonly ts.Expression[];
     if (node.arguments.some(ts.isSpreadElement)) {
@@ -162,7 +162,7 @@ export function getNaryCallExtensionArgs(
 export function getUnaryCallExtensionArg(
     context: TransformationContext,
     node: ts.CallExpression,
-    kind: ExtensionKind
+    kind: ExtensionKind,
 ): ts.Expression | undefined {
     return getNaryCallExtensionArgs(context, node, kind, 1)?.[0];
 }
@@ -170,7 +170,7 @@ export function getUnaryCallExtensionArg(
 export function getBinaryCallExtensionArgs(
     context: TransformationContext,
     node: ts.CallExpression,
-    kind: ExtensionKind
+    kind: ExtensionKind,
 ): readonly [ts.Expression, ts.Expression] | undefined {
     const expressions = getNaryCallExtensionArgs(context, node, kind, 2);
     if (expressions === undefined) return undefined;

--- a/src/transformation/utils/lua-ast.ts
+++ b/src/transformation/utils/lua-ast.ts
@@ -65,7 +65,7 @@ export function getNumberLiteralValue(expression?: lua.Expression) {
 export function createUnpackCall(
     context: TransformationContext,
     expression: lua.Expression,
-    tsOriginal?: ts.Node
+    tsOriginal?: ts.Node,
 ): lua.Expression {
     if (context.luaTarget === LuaTarget.Universal) {
         return transformLuaLibFunction(context, LuaLibFeature.Unpack, tsOriginal, expression);
@@ -106,7 +106,7 @@ export function createHoistableVariableDeclarationStatement(
     context: TransformationContext,
     identifier: lua.Identifier,
     initializer?: lua.Expression,
-    tsOriginal?: ts.Node
+    tsOriginal?: ts.Node,
 ): lua.AssignmentStatement | lua.VariableDeclarationStatement {
     const declaration = lua.createVariableDeclarationStatement(identifier, initializer, tsOriginal);
     if (identifier.symbolId !== undefined) {
@@ -134,7 +134,7 @@ export function createLocalOrExportedOrGlobalDeclaration(
     lhs: lua.Identifier | lua.Identifier[],
     rhs?: lua.Expression | lua.Expression[],
     tsOriginal?: ts.Node,
-    overrideExportScope?: ts.SourceFile | ts.ModuleDeclaration
+    overrideExportScope?: ts.SourceFile | ts.ModuleDeclaration,
 ): lua.Statement[] {
     let declaration: lua.VariableDeclarationStatement | undefined;
     let assignment: lua.AssignmentStatement | undefined;
@@ -157,7 +157,7 @@ export function createLocalOrExportedOrGlobalDeclaration(
             assignment = lua.createAssignmentStatement(
                 identifiers.map(identifier => createExportedIdentifier(context, identifier, exportScope)),
                 rhs,
-                tsOriginal
+                tsOriginal,
             );
         }
     } else {
@@ -227,7 +227,7 @@ function setJSDocComments(
     context: TransformationContext,
     tsOriginal: ts.Node | undefined,
     declaration: lua.VariableDeclarationStatement | undefined,
-    assignment: lua.AssignmentStatement | undefined
+    assignment: lua.AssignmentStatement | undefined,
 ) {
     // Respect the vanilla TypeScript option of "removeComments":
     // https://www.typescriptlang.org/tsconfig#removeComments
@@ -251,7 +251,7 @@ function setJSDocComments(
 
 function getJSDocCommentFromTSNode(
     context: TransformationContext,
-    tsOriginal: ts.Node | undefined
+    tsOriginal: ts.Node | undefined,
 ): string[] | undefined {
     if (tsOriginal === undefined) {
         return undefined;
@@ -323,5 +323,5 @@ export const createNaN = (tsOriginal?: ts.Node) =>
         lua.createNumericLiteral(0),
         lua.createNumericLiteral(0),
         lua.SyntaxKind.DivisionOperator,
-        tsOriginal
+        tsOriginal,
     );

--- a/src/transformation/utils/preceding-statements.ts
+++ b/src/transformation/utils/preceding-statements.ts
@@ -2,14 +2,14 @@ import * as lua from "../../LuaAST";
 import { TransformationContext } from "../context";
 
 export interface WithPrecedingStatements<
-    T extends lua.Statement | lua.Statement[] | lua.Expression | lua.Expression[]
+    T extends lua.Statement | lua.Statement[] | lua.Expression | lua.Expression[],
 > {
     precedingStatements: lua.Statement[];
     result: T;
 }
 
 export function transformInPrecedingStatementScope<
-    TReturn extends lua.Statement | lua.Statement[] | lua.Expression | lua.Expression[]
+    TReturn extends lua.Statement | lua.Statement[] | lua.Expression | lua.Expression[],
 >(context: TransformationContext, transformer: () => TReturn): WithPrecedingStatements<TReturn> {
     context.pushPrecedingStatements();
     const statementOrStatements = transformer();

--- a/src/transformation/utils/safe-names.ts
+++ b/src/transformation/utils/safe-names.ts
@@ -80,7 +80,7 @@ function checkName(context: TransformationContext, name: string, node: ts.Node):
 export function hasUnsafeSymbolName(
     context: TransformationContext,
     symbol: ts.Symbol,
-    tsOriginal: ts.Identifier
+    tsOriginal: ts.Identifier,
 ): boolean {
     const isAmbient = symbol.declarations?.some(d => isAmbientNode(d)) ?? false;
 
@@ -96,7 +96,7 @@ export function hasUnsafeSymbolName(
 export function hasUnsafeIdentifierName(
     context: TransformationContext,
     identifier: ts.Identifier,
-    symbol: ts.Symbol | undefined
+    symbol: ts.Symbol | undefined,
 ): boolean {
     if (symbol) {
         return hasUnsafeSymbolName(context, symbol, identifier);

--- a/src/transformation/utils/scope.ts
+++ b/src/transformation/utils/scope.ts
@@ -56,7 +56,7 @@ export function* walkScopesUp(context: TransformationContext): IterableIterator<
 export function markSymbolAsReferencedInCurrentScopes(
     context: TransformationContext,
     symbolId: lua.SymbolId,
-    identifier: ts.Identifier
+    identifier: ts.Identifier,
 ): void {
     for (const scope of context.scopeStack) {
         if (!scope.referencedSymbols) {
@@ -94,7 +94,7 @@ export function addScopeVariableDeclaration(scope: Scope, declaration: lua.Varia
 
 function isHoistableFunctionDeclaredInScope(symbol: ts.Symbol, scopeNode: ts.Node) {
     return symbol?.declarations?.some(
-        d => ts.isFunctionDeclaration(d) && findFirstNodeAbove(d, (n): n is ts.Node => n === scopeNode)
+        d => ts.isFunctionDeclaration(d) && findFirstNodeAbove(d, (n): n is ts.Node => n === scopeNode),
     );
 }
 
@@ -141,7 +141,7 @@ export function separateHoistedStatements(context: TransformationContext, statem
     let { unhoistedStatements, hoistedStatements, hoistedIdentifiers } = hoistFunctionDefinitions(
         context,
         scope,
-        statements
+        statements,
     );
     allHoistedStatments.push(...hoistedStatements);
     allHoistedIdentifiers.push(...hoistedIdentifiers);
@@ -213,7 +213,7 @@ function shouldHoistSymbol(context: TransformationContext, symbolId: lua.SymbolI
 function hoistVariableDeclarations(
     context: TransformationContext,
     scope: Scope,
-    statements: lua.Statement[]
+    statements: lua.Statement[],
 ): { unhoistedStatements: lua.Statement[]; hoistedIdentifiers: lua.Identifier[] } {
     if (!scope.variableDeclarations) {
         return { unhoistedStatements: statements, hoistedIdentifiers: [] };
@@ -247,7 +247,7 @@ function hoistVariableDeclarations(
 function hoistFunctionDefinitions(
     context: TransformationContext,
     scope: Scope,
-    statements: lua.Statement[]
+    statements: lua.Statement[],
 ): { unhoistedStatements: lua.Statement[]; hoistedStatements: lua.Statement[]; hoistedIdentifiers: lua.Identifier[] } {
     if (!scope.functionDefinitions) {
         return { unhoistedStatements: statements, hoistedStatements: [], hoistedIdentifiers: [] };
@@ -273,8 +273,8 @@ function hoistFunctionDefinitions(
                 hoistedStatements.push(
                     lua.createAssignmentStatement(
                         functionDefinition.definition.left,
-                        functionDefinition.definition.right
-                    )
+                        functionDefinition.definition.right,
+                    ),
                 );
             } else {
                 hoistedStatements.push(functionDefinition.definition);
@@ -287,7 +287,7 @@ function hoistFunctionDefinitions(
 
 function hoistImportStatements(
     scope: Scope,
-    statements: lua.Statement[]
+    statements: lua.Statement[],
 ): { unhoistedStatements: lua.Statement[]; hoistedStatements: lua.Statement[] } {
     return { unhoistedStatements: statements, hoistedStatements: scope.importStatements ?? [] };
 }

--- a/src/transformation/utils/symbols.ts
+++ b/src/transformation/utils/symbols.ts
@@ -20,7 +20,7 @@ export function getSymbolIdOfSymbol(context: TransformationContext, symbol: ts.S
 export function trackSymbolReference(
     context: TransformationContext,
     symbol: ts.Symbol,
-    identifier: ts.Identifier
+    identifier: ts.Identifier,
 ): lua.SymbolId | undefined {
     // Track first time symbols are seen
     let symbolId = context.symbolIdMaps.get(symbol);
@@ -43,7 +43,7 @@ export function trackSymbolReference(
 export function getIdentifierSymbolId(
     context: TransformationContext,
     identifier: ts.Identifier,
-    symbol: ts.Symbol | undefined
+    symbol: ts.Symbol | undefined,
 ): lua.SymbolId | undefined {
     if (symbol) {
         return trackSymbolReference(context, symbol, identifier);

--- a/src/transformation/utils/typescript/index.ts
+++ b/src/transformation/utils/typescript/index.ts
@@ -56,7 +56,7 @@ export function isStandardLibraryDeclaration(context: TransformationContext, dec
 export function isStandardLibraryType(
     context: TransformationContext,
     type: ts.Type,
-    name: string | undefined
+    name: string | undefined,
 ): boolean {
     const symbol = type.getSymbol();
     if (!symbol || (name ? symbol.name !== name : symbol.name === "__type")) {
@@ -74,7 +74,7 @@ export function isStandardLibraryType(
 
 export function hasStandardLibrarySignature(
     context: TransformationContext,
-    callExpression: ts.CallExpression
+    callExpression: ts.CallExpression,
 ): boolean {
     const signature = context.checker.getResolvedSignature(callExpression);
     return signature?.declaration ? isStandardLibraryDeclaration(context, signature.declaration) : false;
@@ -118,6 +118,6 @@ export function isConstIdentifier(context: TransformationContext, node: ts.Node)
         return false;
     }
     return symbol.declarations.some(
-        d => ts.isVariableDeclarationList(d.parent) && (d.parent.flags & ts.NodeFlags.Const) !== 0
+        d => ts.isVariableDeclarationList(d.parent) && (d.parent.flags & ts.NodeFlags.Const) !== 0,
     );
 }

--- a/src/transformation/utils/typescript/types.ts
+++ b/src/transformation/utils/typescript/types.ts
@@ -92,7 +92,7 @@ function isAlwaysExplicitArrayType(context: TransformationContext, type: ts.Type
 export function forTypeOrAnySupertype(
     context: TransformationContext,
     type: ts.Type,
-    predicate: (type: ts.Type) => boolean
+    predicate: (type: ts.Type) => boolean,
 ): boolean {
     if (predicate(type)) {
         return true;

--- a/src/transformation/visitors/access.ts
+++ b/src/transformation/visitors/access.ts
@@ -29,7 +29,7 @@ import { getSymbolExportScope, isSymbolExported } from "../utils/export";
 function addOneToArrayAccessArgument(
     context: TransformationContext,
     node: ts.ElementAccessExpression,
-    index: lua.Expression
+    index: lua.Expression,
 ): lua.Expression {
     const type = context.checker.getTypeAtLocation(node.expression);
     const argumentType = context.checker.getTypeAtLocation(node.argumentExpression);
@@ -41,7 +41,7 @@ function addOneToArrayAccessArgument(
 
 export function transformElementAccessArgument(
     context: TransformationContext,
-    node: ts.ElementAccessExpression
+    node: ts.ElementAccessExpression,
 ): lua.Expression {
     const index = context.transformExpression(node.argumentExpression);
     return addOneToArrayAccessArgument(context, node, index);
@@ -52,7 +52,7 @@ export const transformElementAccessExpression: FunctionVisitor<ts.ElementAccessE
 export function transformElementAccessExpressionWithCapture(
     context: TransformationContext,
     node: ts.ElementAccessExpression,
-    thisValueCapture: lua.Identifier | undefined
+    thisValueCapture: lua.Identifier | undefined,
 ): ExpressionWithThisValue {
     const constEnumValue = tryGetConstEnumValue(context, node);
     if (constEnumValue) {
@@ -108,7 +108,7 @@ export const transformPropertyAccessExpression: FunctionVisitor<ts.PropertyAcces
 export function transformPropertyAccessExpressionWithCapture(
     context: TransformationContext,
     node: ts.PropertyAccessExpression,
-    thisValueCapture: lua.Identifier | undefined
+    thisValueCapture: lua.Identifier | undefined,
 ): ExpressionWithThisValue {
     const type = context.checker.getTypeAtLocation(node.expression);
     const isOptionalLeft = isOptionalContinuation(node.expression);
@@ -145,7 +145,7 @@ export function transformPropertyAccessExpressionWithCapture(
             const expression = lua.createTableIndexExpression(
                 context.transformExpression(node.expression.expression),
                 lua.createStringLiteral(property),
-                node
+                node,
             );
             return { expression };
         } else {
@@ -158,7 +158,7 @@ export function transformPropertyAccessExpressionWithCapture(
                     expression: lua.createTableIndexExpression(
                         createExportsIdentifier(),
                         lua.createStringLiteral(property),
-                        node
+                        node,
                     ),
                 };
             } else {
@@ -207,7 +207,7 @@ export function transformPropertyAccessExpressionWithCapture(
                     node,
                     lua.createIdentifier("self"),
                     table,
-                    lua.createStringLiteral(property)
+                    lua.createStringLiteral(property),
                 ),
             };
         }

--- a/src/transformation/visitors/async-await.ts
+++ b/src/transformation/visitors/async-await.ts
@@ -22,7 +22,7 @@ export function isAsyncFunction(declaration: ts.FunctionLikeDeclaration): boolea
 export function wrapInAsyncAwaiter(
     context: TransformationContext,
     statements: lua.Statement[],
-    includeResolveParameter = true
+    includeResolveParameter = true,
 ): lua.CallExpression {
     importLuaLibFeature(context, LuaLibFeature.Await);
 

--- a/src/transformation/visitors/binary-expression/assignments.ts
+++ b/src/transformation/visitors/binary-expression/assignments.ts
@@ -17,7 +17,7 @@ import { transformInPrecedingStatementScope } from "../../utils/preceding-statem
 export function transformAssignmentLeftHandSideExpression(
     context: TransformationContext,
     node: ts.Expression,
-    rightHasPrecedingStatements?: boolean
+    rightHasPrecedingStatements?: boolean,
 ): lua.AssignmentLeftHandSideExpression {
     // Access expressions need the components of the left side cached in temps before the right side's preceding statements
     if (rightHasPrecedingStatements && (ts.isElementAccessExpression(node) || ts.isPropertyAccessExpression(node))) {
@@ -55,7 +55,7 @@ export function transformAssignment(
     lhs: ts.Expression,
     right: lua.Expression,
     rightHasPrecedingStatements?: boolean,
-    parent?: ts.Expression
+    parent?: ts.Expression,
 ): lua.Statement[] {
     if (ts.isOptionalChain(lhs)) {
         context.diagnostics.push(notAllowedOptionalAssignment(lhs));
@@ -69,8 +69,8 @@ export function transformAssignment(
                 LuaLibFeature.ArraySetLength,
                 parent,
                 context.transformExpression(lhs.expression),
-                right
-            )
+                right,
+            ),
         );
 
         return [arrayLengthAssignment];
@@ -91,8 +91,8 @@ export function transformAssignment(
                             ts.isPropertyAccessExpression(lhs)
                                 ? lua.createStringLiteral(lhs.name.text)
                                 : context.transformExpression(lhs.argumentExpression),
-                            right
-                        )
+                            right,
+                        ),
                     ),
                 ];
             }
@@ -125,7 +125,7 @@ export function transformAssignmentWithRightPrecedingStatements(
     lhs: ts.Expression,
     right: lua.Expression,
     rightPrecedingStatements: lua.Statement[],
-    parent?: ts.Expression
+    parent?: ts.Expression,
 ): lua.Statement[] {
     return [
         ...rightPrecedingStatements,
@@ -135,11 +135,11 @@ export function transformAssignmentWithRightPrecedingStatements(
 
 function transformDestructuredAssignmentExpression(
     context: TransformationContext,
-    expression: ts.DestructuringAssignment
+    expression: ts.DestructuringAssignment,
 ) {
     let { precedingStatements: rightPrecedingStatements, result: right } = transformInPrecedingStatementScope(
         context,
-        () => context.transformExpression(expression.right)
+        () => context.transformExpression(expression.right),
     );
     context.addPrecedingStatements(rightPrecedingStatements);
     if (isMultiReturnCall(context, expression.right)) {
@@ -151,7 +151,7 @@ function transformDestructuredAssignmentExpression(
         context,
         expression,
         rightExpr,
-        rightPrecedingStatements.length > 0
+        rightPrecedingStatements.length > 0,
     );
 
     return { statements, result: rightExpr };
@@ -159,7 +159,7 @@ function transformDestructuredAssignmentExpression(
 
 export function transformAssignmentExpression(
     context: TransformationContext,
-    expression: ts.AssignmentExpression<ts.EqualsToken>
+    expression: ts.AssignmentExpression<ts.EqualsToken>,
 ): lua.Expression {
     // Validate assignment
     const rightType = context.checker.getTypeAtLocation(expression.right);
@@ -173,7 +173,7 @@ export function transformAssignmentExpression(
             LuaLibFeature.ArraySetLength,
             expression,
             context.transformExpression(expression.left.expression),
-            context.transformExpression(expression.right)
+            context.transformExpression(expression.right),
         );
     }
 
@@ -185,13 +185,13 @@ export function transformAssignmentExpression(
 
     if (ts.isPropertyAccessExpression(expression.left) || ts.isElementAccessExpression(expression.left)) {
         const { precedingStatements, result: right } = transformInPrecedingStatementScope(context, () =>
-            context.transformExpression(expression.right)
+            context.transformExpression(expression.right),
         );
 
         const left = transformAssignmentLeftHandSideExpression(
             context,
             expression.left,
-            precedingStatements.length > 0
+            precedingStatements.length > 0,
         );
 
         context.addPrecedingStatements(precedingStatements);
@@ -210,7 +210,7 @@ export function transformAssignmentExpression(
 
 const canBeTransformedToLuaAssignmentStatement = (
     context: TransformationContext,
-    node: ts.DestructuringAssignment
+    node: ts.DestructuringAssignment,
 ): node is ts.ArrayDestructuringAssignment =>
     ts.isArrayLiteralExpression(node.left) &&
     node.left.elements.every(element => {
@@ -235,7 +235,7 @@ const canBeTransformedToLuaAssignmentStatement = (
 
 export function transformAssignmentStatement(
     context: TransformationContext,
-    expression: ts.AssignmentExpression<ts.EqualsToken>
+    expression: ts.AssignmentExpression<ts.EqualsToken>,
 ): lua.Statement[] {
     // Validate assignment
     const rightType = context.checker.getTypeAtLocation(expression.right);
@@ -265,7 +265,7 @@ export function transformAssignmentStatement(
         return statements;
     } else {
         const { precedingStatements, result: right } = transformInPrecedingStatementScope(context, () =>
-            context.transformExpression(expression.right)
+            context.transformExpression(expression.right),
         );
         return transformAssignmentWithRightPrecedingStatements(context, expression.left, right, precedingStatements);
     }

--- a/src/transformation/visitors/binary-expression/bit.ts
+++ b/src/transformation/visitors/binary-expression/bit.ts
@@ -23,20 +23,20 @@ function transformBinaryBitLibOperation(
     left: lua.Expression,
     right: lua.Expression,
     operator: BitOperator,
-    lib: string
+    lib: string,
 ): lua.Expression {
     const functionName = bitOperatorToLibOperation[operator];
     return lua.createCallExpression(
         lua.createTableIndexExpression(lua.createIdentifier(lib), lua.createStringLiteral(functionName)),
         [left, right],
-        node
+        node,
     );
 }
 
 function transformBitOperatorToLuaOperator(
     context: TransformationContext,
     node: ts.Node,
-    operator: BitOperator
+    operator: BitOperator,
 ): lua.BinaryOperator {
     switch (operator) {
         case ts.SyntaxKind.BarToken:
@@ -60,7 +60,7 @@ export function transformBinaryBitOperation(
     node: ts.Node,
     left: lua.Expression,
     right: lua.Expression,
-    operator: BitOperator
+    operator: BitOperator,
 ): lua.Expression {
     switch (context.luaTarget) {
         case LuaTarget.Universal:
@@ -84,7 +84,7 @@ function transformUnaryBitLibOperation(
     node: ts.Node,
     expression: lua.Expression,
     operator: lua.UnaryBitwiseOperator,
-    lib: string
+    lib: string,
 ): lua.Expression {
     let bitFunction: string;
     switch (operator) {
@@ -98,7 +98,7 @@ function transformUnaryBitLibOperation(
     return lua.createCallExpression(
         lua.createTableIndexExpression(lua.createIdentifier(lib), lua.createStringLiteral(bitFunction)),
         [expression],
-        node
+        node,
     );
 }
 
@@ -106,7 +106,7 @@ export function transformUnaryBitOperation(
     context: TransformationContext,
     node: ts.Node,
     expression: lua.Expression,
-    operator: lua.UnaryBitwiseOperator
+    operator: lua.UnaryBitwiseOperator,
 ): lua.Expression {
     switch (context.luaTarget) {
         case LuaTarget.Universal:

--- a/src/transformation/visitors/binary-expression/index.ts
+++ b/src/transformation/visitors/binary-expression/index.ts
@@ -58,7 +58,7 @@ function transformBinaryOperationWithNoPrecedingStatements(
     left: lua.Expression,
     right: lua.Expression,
     operator: BitOperator | SimpleOperator | ts.SyntaxKind.QuestionQuestionToken,
-    node: ts.Node
+    node: ts.Node,
 ): lua.Expression {
     if (isBitOperator(operator)) {
         return transformBinaryBitOperation(context, node, left, right, operator);
@@ -99,7 +99,7 @@ export function createShortCircuitBinaryExpressionPrecedingStatements(
     rhs: lua.Expression,
     rightPrecedingStatements: lua.Statement[],
     operator: ShortCircuitOperator,
-    node?: ts.BinaryExpression
+    node?: ts.BinaryExpression,
 ): WithPrecedingStatements<lua.Expression> {
     const conditionIdentifier = context.createTempNameForLuaExpression(lhs);
     const assignmentStatement = lua.createVariableDeclarationStatement(conditionIdentifier, lhs, node?.left);
@@ -110,7 +110,7 @@ export function createShortCircuitBinaryExpressionPrecedingStatements(
             condition = lua.createUnaryExpression(
                 lua.cloneIdentifier(conditionIdentifier),
                 lua.SyntaxKind.NotOperator,
-                node
+                node,
             );
             break;
         case ts.SyntaxKind.AmpersandAmpersandToken:
@@ -121,7 +121,7 @@ export function createShortCircuitBinaryExpressionPrecedingStatements(
                 lua.cloneIdentifier(conditionIdentifier),
                 lua.createNilLiteral(),
                 lua.SyntaxKind.EqualityOperator,
-                node
+                node,
             );
             break;
     }
@@ -130,7 +130,7 @@ export function createShortCircuitBinaryExpressionPrecedingStatements(
         condition,
         lua.createBlock([...rightPrecedingStatements, lua.createAssignmentStatement(conditionIdentifier, rhs)]),
         undefined,
-        node?.left
+        node?.left,
     );
     return { precedingStatements: [assignmentStatement, ifStatement], result: conditionIdentifier };
 }
@@ -138,11 +138,11 @@ export function createShortCircuitBinaryExpressionPrecedingStatements(
 function transformShortCircuitBinaryExpression(
     context: TransformationContext,
     node: ts.BinaryExpression,
-    operator: ShortCircuitOperator
+    operator: ShortCircuitOperator,
 ): WithPrecedingStatements<lua.Expression> {
     const lhs = context.transformExpression(node.left);
     const { precedingStatements, result } = transformInPrecedingStatementScope(context, () =>
-        context.transformExpression(node.right)
+        context.transformExpression(node.right),
     );
     return transformBinaryOperation(context, lhs, result, precedingStatements, operator, node);
 }
@@ -153,7 +153,7 @@ export function transformBinaryOperation(
     right: lua.Expression,
     rightPrecedingStatements: lua.Statement[],
     operator: BitOperator | SimpleOperator | ts.SyntaxKind.QuestionQuestionToken,
-    node: ts.Node
+    node: ts.Node,
 ): WithPrecedingStatements<lua.Expression> {
     if (rightPrecedingStatements.length > 0 && isShortCircuitOperator(operator)) {
         assert(ts.isBinaryExpression(node));
@@ -163,7 +163,7 @@ export function transformBinaryOperation(
             right,
             rightPrecedingStatements,
             operator,
-            node
+            node,
         );
     }
 
@@ -198,7 +198,7 @@ export const transformBinaryExpression: FunctionVisitor<ts.BinaryExpression> = (
                 indexExpression,
                 lua.createNilLiteral(),
                 lua.SyntaxKind.InequalityOperator,
-                node
+                node,
             );
         }
 
@@ -217,7 +217,7 @@ export const transformBinaryExpression: FunctionVisitor<ts.BinaryExpression> = (
         case ts.SyntaxKind.CommaToken: {
             const statements = context.transformStatements(ts.factory.createExpressionStatement(node.left));
             const { precedingStatements, result } = transformInPrecedingStatementScope(context, () =>
-                context.transformExpression(node.right)
+                context.transformExpression(node.right),
             );
             statements.push(...precedingStatements);
             context.addPrecedingStatements(statements);
@@ -237,7 +237,7 @@ export const transformBinaryExpression: FunctionVisitor<ts.BinaryExpression> = (
         precedingStatements: orderedExpressionPrecedingStatements,
         result: [lhs, rhs],
     } = transformInPrecedingStatementScope(context, () =>
-        transformOrderedExpressions(context, [node.left, node.right])
+        transformOrderedExpressions(context, [node.left, node.right]),
     );
 
     const { precedingStatements, result } = transformBinaryOperation(
@@ -246,7 +246,7 @@ export const transformBinaryExpression: FunctionVisitor<ts.BinaryExpression> = (
         rhs,
         orderedExpressionPrecedingStatements,
         operator,
-        node
+        node,
     );
     context.addPrecedingStatements(precedingStatements);
     return result;
@@ -254,7 +254,7 @@ export const transformBinaryExpression: FunctionVisitor<ts.BinaryExpression> = (
 
 export function transformBinaryExpressionStatement(
     context: TransformationContext,
-    node: ts.ExpressionStatement
+    node: ts.ExpressionStatement,
 ): lua.Statement[] | lua.Statement | undefined {
     const expression = node.expression;
     if (!ts.isBinaryExpression(expression)) return;
@@ -280,7 +280,7 @@ function transformNullishCoalescingOperationNoPrecedingStatements(
     context: TransformationContext,
     node: ts.BinaryExpression,
     transformedLeft: lua.Expression,
-    transformedRight: lua.Expression
+    transformedRight: lua.Expression,
 ): lua.Expression {
     const lhsType = context.checker.getTypeAtLocation(node.left);
 
@@ -293,7 +293,7 @@ function transformNullishCoalescingOperationNoPrecedingStatements(
             transformedRight,
             [],
             ts.SyntaxKind.QuestionQuestionToken,
-            node
+            node,
         );
         context.addPrecedingStatements(precedingStatements);
         return result;

--- a/src/transformation/visitors/block.ts
+++ b/src/transformation/visitors/block.ts
@@ -10,7 +10,7 @@ export function transformBlockOrStatement(context: TransformationContext, statem
 export function transformScopeBlock(
     context: TransformationContext,
     node: ts.Block,
-    scopeType: ScopeType
+    scopeType: ScopeType,
 ): [lua.Block, Scope] {
     context.pushScope(scopeType);
     const statements = performHoisting(context, context.transformStatements(node.statements));

--- a/src/transformation/visitors/call.ts
+++ b/src/transformation/visitors/call.ts
@@ -20,7 +20,7 @@ import { getCustomNameFromSymbol } from "./identifier";
 export function validateArguments(
     context: TransformationContext,
     params: readonly ts.Expression[],
-    signature?: ts.Signature
+    signature?: ts.Signature,
 ) {
     if (!signature || signature.parameters.length < params.length) {
         return;
@@ -39,7 +39,7 @@ export function transformArguments(
     context: TransformationContext,
     params: readonly ts.Expression[],
     signature?: ts.Signature,
-    callContext?: ts.Expression
+    callContext?: ts.Expression,
 ): lua.Expression[] {
     validateArguments(context, params, signature);
     return transformExpressionList(context, callContext ? [callContext, ...params] : params);
@@ -50,7 +50,7 @@ function transformCallWithArguments(
     callExpression: ts.Expression,
     transformedArguments: lua.Expression[],
     argPrecedingStatements: lua.Statement[],
-    callContext?: ts.Expression
+    callContext?: ts.Expression,
 ): [lua.Expression, lua.Expression[]] {
     let call = context.transformExpression(callExpression);
 
@@ -79,7 +79,7 @@ export function transformCallAndArguments(
     callExpression: ts.Expression,
     params: readonly ts.Expression[],
     signature?: ts.Signature,
-    callContext?: ts.Expression
+    callContext?: ts.Expression,
 ): [lua.Expression, lua.Expression[]] {
     const { precedingStatements: argPrecedingStatements, result: transformedArguments } =
         transformInPrecedingStatementScope(context, () => transformArguments(context, params, signature, callContext));
@@ -90,7 +90,7 @@ function transformElementAccessCall(
     context: TransformationContext,
     left: ts.PropertyAccessExpression | ts.ElementAccessExpression,
     transformedArguments: lua.Expression[],
-    argPrecedingStatements: lua.Statement[]
+    argPrecedingStatements: lua.Statement[],
 ) {
     // Cache left-side if it has effects
     // local ____self = context; return ____self[argument](parameters);
@@ -117,7 +117,7 @@ function transformElementAccessCall(
 export function transformContextualCallExpression(
     context: TransformationContext,
     node: ts.CallExpression | ts.TaggedTemplateExpression,
-    args: ts.Expression[] | ts.NodeArray<ts.Expression>
+    args: ts.Expression[] | ts.NodeArray<ts.Expression>,
 ): lua.Expression {
     if (ts.isOptionalChain(node)) {
         return transformOptionalChain(context, node);
@@ -155,7 +155,7 @@ export function transformContextualCallExpression(
                 left,
                 transformedArguments,
                 argPrecedingStatements,
-                left.expression
+                left.expression,
             );
             return lua.createCallExpression(expression, transformedArguments, node);
         }
@@ -167,7 +167,7 @@ export function transformContextualCallExpression(
             left,
             transformedArguments,
             argPrecedingStatements,
-            callContext
+            callContext,
         );
         return lua.createCallExpression(expression, transformedArguments, node);
     } else {
@@ -178,7 +178,7 @@ export function transformContextualCallExpression(
 function transformPropertyCall(
     context: TransformationContext,
     node: ts.CallExpression,
-    calledMethod: ts.PropertyAccessExpression
+    calledMethod: ts.PropertyAccessExpression,
 ): lua.Expression {
     const signature = context.checker.getResolvedSignature(node);
 
@@ -254,10 +254,10 @@ export const transformCallExpression: FunctionVisitor<ts.CallExpression> = (node
         return lua.createCallExpression(
             lua.createTableIndexExpression(
                 context.transformExpression(ts.factory.createSuper()),
-                lua.createStringLiteral("____constructor")
+                lua.createStringLiteral("____constructor"),
             ),
             parameters,
-            node
+            node,
         );
     }
 
@@ -277,7 +277,7 @@ export const transformCallExpression: FunctionVisitor<ts.CallExpression> = (node
             calledExpression,
             node.arguments,
             signature,
-            callContext
+            callContext,
         );
     }
 

--- a/src/transformation/visitors/class/decorators.ts
+++ b/src/transformation/visitors/class/decorators.ts
@@ -23,7 +23,7 @@ export function transformDecoratorExpression(context: TransformationContext, dec
 export function createClassDecoratingExpression(
     context: TransformationContext,
     classDeclaration: ts.ClassDeclaration | ts.ClassExpression,
-    className: lua.Expression
+    className: lua.Expression,
 ): lua.Expression {
     const classDecorators =
         ts.getDecorators(classDeclaration)?.map(d => transformDecoratorExpression(context, d)) ?? [];
@@ -44,7 +44,7 @@ export function createClassMethodDecoratingExpression(
     context: TransformationContext,
     methodDeclaration: ts.MethodDeclaration,
     originalMethod: lua.Expression,
-    className: lua.Identifier
+    className: lua.Identifier,
 ): lua.Expression {
     const parameterDecorators = getParameterDecorators(context, methodDeclaration);
     const methodDecorators =
@@ -60,7 +60,7 @@ export function createClassMethodDecoratingExpression(
             methodDeclaration.kind,
             [...methodDecorators, ...parameterDecorators],
             methodTable,
-            methodName
+            methodName,
         );
     }
 
@@ -77,7 +77,7 @@ export function createClassAccessorDecoratingExpression(
     context: TransformationContext,
     accessor: ts.AccessorDeclaration,
     originalAccessor: lua.Expression,
-    className: lua.Identifier
+    className: lua.Identifier,
 ): lua.Expression {
     const accessorDecorators = ts.getDecorators(accessor)?.map(d => transformDecoratorExpression(context, d)) ?? [];
     const propertyName = transformPropertyName(context, accessor.name);
@@ -91,7 +91,7 @@ export function createClassAccessorDecoratingExpression(
             accessor.kind,
             accessorDecorators,
             propertyOwnerTable,
-            propertyName
+            propertyName,
         );
     }
 
@@ -107,7 +107,7 @@ export function createClassAccessorDecoratingExpression(
 export function createClassPropertyDecoratingExpression(
     context: TransformationContext,
     property: ts.PropertyDeclaration,
-    className: lua.Identifier
+    className: lua.Identifier,
 ): lua.Expression {
     const decorators = ts.getDecorators(property) ?? [];
     const propertyDecorators = decorators.map(d => transformDecoratorExpression(context, d));
@@ -122,7 +122,7 @@ export function createClassPropertyDecoratingExpression(
             property.kind,
             propertyDecorators,
             propertyOwnerTable,
-            propertyName
+            propertyName,
         );
     }
 
@@ -151,7 +151,7 @@ function createDecoratingExpression<TValue extends lua.Expression>(
     className: lua.Expression,
     originalValue: TValue,
     decorators: lua.Expression[],
-    decoratorContext: Record<string, lua.Expression>
+    decoratorContext: Record<string, lua.Expression>,
 ): lua.Expression {
     const decoratorTable = lua.createTableExpression(decorators.map(d => lua.createTableFieldExpression(d)));
     const decoratorContextTable = objectToLuaTableLiteral(decoratorContext);
@@ -163,13 +163,13 @@ function createDecoratingExpression<TValue extends lua.Expression>(
         className,
         originalValue,
         decoratorTable,
-        decoratorContextTable
+        decoratorContextTable,
     );
 }
 
 function objectToLuaTableLiteral(obj: Record<string, lua.Expression>): lua.Expression {
     return lua.createTableExpression(
-        Object.entries(obj).map(([key, value]) => lua.createTableFieldExpression(value, lua.createStringLiteral(key)))
+        Object.entries(obj).map(([key, value]) => lua.createTableFieldExpression(value, lua.createStringLiteral(key))),
     );
 }
 
@@ -179,7 +179,7 @@ function createLegacyDecoratingExpression(
     kind: ts.SyntaxKind,
     decorators: lua.Expression[],
     targetTableName: lua.Expression,
-    targetFieldExpression?: lua.Expression
+    targetFieldExpression?: lua.Expression,
 ): lua.Expression {
     const decoratorTable = lua.createTableExpression(decorators.map(e => lua.createTableFieldExpression(e)));
     const trailingExpressions = [decoratorTable, targetTableName];
@@ -198,7 +198,7 @@ function createLegacyDecoratingExpression(
 
 function getParameterDecorators(
     context: TransformationContext,
-    node: ts.FunctionLikeDeclarationBase
+    node: ts.FunctionLikeDeclarationBase,
 ): lua.CallExpression[] {
     return node.parameters
         .flatMap((parameter, index) =>
@@ -210,9 +210,9 @@ function getParameterDecorators(
                         LuaLibFeature.DecorateParam,
                         node,
                         lua.createNumericLiteral(index),
-                        transformDecoratorExpression(context, decorator)
-                    )
-                )
+                        transformDecoratorExpression(context, decorator),
+                    ),
+                ),
         )
         .filter(isNonNull);
 }
@@ -220,7 +220,7 @@ function getParameterDecorators(
 export function createConstructorDecoratingExpression(
     context: TransformationContext,
     node: ts.ConstructorDeclaration,
-    className: lua.Identifier
+    className: lua.Identifier,
 ): lua.Statement | undefined {
     const parameterDecorators = getParameterDecorators(context, node);
 

--- a/src/transformation/visitors/class/index.ts
+++ b/src/transformation/visitors/class/index.ts
@@ -42,7 +42,7 @@ export const transformThisExpression: FunctionVisitor<ts.ThisExpression> = node 
 
 export function transformClassAsExpression(
     expression: ts.ClassLikeDeclaration,
-    context: TransformationContext
+    context: TransformationContext,
 ): lua.Expression {
     const { statements, name } = transformClassLikeDeclaration(expression, context);
     context.addPrecedingStatements(statements);
@@ -58,7 +58,7 @@ export interface ClassSuperInfo {
 function transformClassLikeDeclaration(
     classDeclaration: ts.ClassLikeDeclaration,
     context: TransformationContext,
-    nameOverride?: lua.Identifier
+    nameOverride?: lua.Identifier,
 ): { statements: lua.Statement[]; name: lua.Identifier } {
     let className: lua.Identifier;
     if (nameOverride !== undefined) {
@@ -89,7 +89,7 @@ function transformClassLikeDeclaration(
             createSafeName(className.text),
             undefined,
             className.symbolId,
-            className.text
+            className.text,
         );
         lua.setNodePosition(localClassName, className);
     } else {
@@ -100,7 +100,7 @@ function transformClassLikeDeclaration(
 
     // Find first constructor with body
     const constructor = classDeclaration.members.find(
-        (n): n is ts.ConstructorDeclaration => ts.isConstructorDeclaration(n) && n.body !== undefined
+        (n): n is ts.ConstructorDeclaration => ts.isConstructorDeclaration(n) && n.body !== undefined,
     );
 
     if (constructor) {
@@ -110,7 +110,7 @@ function transformClassLikeDeclaration(
             constructor,
             localClassName,
             instanceFields,
-            classDeclaration
+            classDeclaration,
         );
 
         if (constructorResult) result.push(constructorResult);
@@ -125,7 +125,7 @@ function transformClassLikeDeclaration(
             ts.factory.createConstructorDeclaration([], [], ts.factory.createBlock([], true)),
             localClassName,
             instanceFields,
-            classDeclaration
+            classDeclaration,
         );
 
         if (constructorResult) result.push(constructorResult);
@@ -143,20 +143,20 @@ function transformClassLikeDeclaration(
             lua.createCallExpression(
                 lua.createTableIndexExpression(
                     context.transformExpression(ts.factory.createSuper()),
-                    lua.createStringLiteral("____constructor")
+                    lua.createStringLiteral("____constructor"),
                 ),
-                [createSelfIdentifier(), argsExpression]
-            )
+                [createSelfIdentifier(), argsExpression],
+            ),
         );
         constructorBody.unshift(superCall);
         const constructorFunction = lua.createFunctionExpression(
             lua.createBlock(constructorBody),
             [createSelfIdentifier()],
             lua.createDotsLiteral(),
-            lua.NodeFlags.Declaration
+            lua.NodeFlags.Declaration,
         );
         result.push(
-            lua.createAssignmentStatement(createConstructorName(localClassName), constructorFunction, classDeclaration)
+            lua.createAssignmentStatement(createConstructorName(localClassName), constructorFunction, classDeclaration),
         );
     }
 
@@ -193,7 +193,7 @@ function transformClassLikeDeclaration(
 
             if (ts.getDecorators(member)?.length) {
                 result.push(
-                    lua.createExpressionStatement(createClassPropertyDecoratingExpression(context, member, className))
+                    lua.createExpressionStatement(createClassPropertyDecoratingExpression(context, member, className)),
                 );
             }
         } else if (ts.isClassStaticBlockDeclaration(member)) {
@@ -232,15 +232,15 @@ function transformClassLikeDeclaration(
 function getAllAccessorDeclarations(
     classDeclaration: ts.ClassLikeDeclaration,
     symbol: ts.Symbol,
-    context: TransformationContext
+    context: TransformationContext,
 ): AllAccessorDeclarations {
     const getAccessor = classDeclaration.members.find(
         (m): m is ts.GetAccessorDeclaration =>
-            ts.isGetAccessor(m) && context.checker.getSymbolAtLocation(m.name) === symbol
+            ts.isGetAccessor(m) && context.checker.getSymbolAtLocation(m.name) === symbol,
     );
     const setAccessor = classDeclaration.members.find(
         (m): m is ts.SetAccessorDeclaration =>
-            ts.isSetAccessor(m) && context.checker.getSymbolAtLocation(m.name) === symbol
+            ts.isSetAccessor(m) && context.checker.getSymbolAtLocation(m.name) === symbol,
     );
 
     // Get the first of the two (that is not undefined)

--- a/src/transformation/visitors/class/members/accessors.ts
+++ b/src/transformation/visitors/class/members/accessors.ts
@@ -12,7 +12,7 @@ import { createClassAccessorDecoratingExpression } from "../decorators";
 function transformAccessor(
     context: TransformationContext,
     node: ts.AccessorDeclaration,
-    className: lua.Identifier
+    className: lua.Identifier,
 ): lua.Expression {
     const [params, dot, restParam] = transformParameters(context, node.parameters, createSelfIdentifier());
     const body = node.body ? transformFunctionBody(context, node.parameters, node.body, restParam)[0] : [];
@@ -20,7 +20,7 @@ function transformAccessor(
         lua.createBlock(body),
         params,
         dot,
-        lua.NodeFlags.Declaration
+        lua.NodeFlags.Declaration,
     );
 
     if (ts.getDecorators(node)?.length) {
@@ -33,7 +33,7 @@ function transformAccessor(
 export function transformAccessorDeclarations(
     context: TransformationContext,
     { firstAccessor, getAccessor, setAccessor }: AllAccessorDeclarations,
-    className: lua.Identifier
+    className: lua.Identifier,
 ): lua.Statement | undefined {
     const propertyName = transformPropertyName(context, firstAccessor.name);
     const descriptor = lua.createTableExpression([]);

--- a/src/transformation/visitors/class/members/constructor.ts
+++ b/src/transformation/visitors/class/members/constructor.ts
@@ -20,7 +20,7 @@ export function transformConstructorDeclaration(
     statement: ts.ConstructorDeclaration,
     className: lua.Identifier,
     instanceFields: ts.PropertyDeclaration[],
-    classDeclaration: ts.ClassLikeDeclaration
+    classDeclaration: ts.ClassLikeDeclaration,
 ): lua.Statement | undefined {
     // Don't transform methods without body (overload declarations)
     if (!statement.body) {
@@ -34,7 +34,7 @@ export function transformConstructorDeclaration(
     const [params, dotsLiteral, restParamName] = transformParameters(
         context,
         statement.parameters,
-        createSelfIdentifier()
+        createSelfIdentifier(),
     );
 
     // Make sure default parameters are assigned before fields are initialized
@@ -56,7 +56,7 @@ export function transformConstructorDeclaration(
             s =>
                 ts.isExpressionStatement(s) &&
                 ts.isCallExpression(s.expression) &&
-                s.expression.expression.kind === ts.SyntaxKind.SuperKeyword
+                s.expression.expression.kind === ts.SyntaxKind.SuperKeyword,
         );
 
         if (superIndex !== -1) {
@@ -70,7 +70,7 @@ export function transformConstructorDeclaration(
             // self.declarationName = declarationName
             const assignment = lua.createAssignmentStatement(
                 lua.createTableIndexExpression(createSelfIdentifier(), lua.createStringLiteral(declaration.name.text)),
-                transformIdentifier(context, declaration.name)
+                transformIdentifier(context, declaration.name),
             );
             bodyWithFieldInitializers.push(assignment);
         }
@@ -90,6 +90,6 @@ export function transformConstructorDeclaration(
     return lua.createAssignmentStatement(
         createConstructorName(className),
         lua.createFunctionExpression(block, params, dotsLiteral, lua.NodeFlags.Declaration),
-        constructorWasGenerated ? classDeclaration : statement
+        constructorWasGenerated ? classDeclaration : statement,
     );
 }

--- a/src/transformation/visitors/class/members/fields.ts
+++ b/src/transformation/visitors/class/members/fields.ts
@@ -7,7 +7,7 @@ import { transformPropertyName } from "../../literal";
 
 export function transformClassInstanceFields(
     context: TransformationContext,
-    instanceFields: ts.PropertyDeclaration[]
+    instanceFields: ts.PropertyDeclaration[],
 ): lua.Statement[] {
     const statements: lua.Statement[] = [];
 
@@ -36,7 +36,7 @@ export function transformClassInstanceFields(
 export function transformStaticPropertyDeclaration(
     context: TransformationContext,
     field: ts.PropertyDeclaration,
-    className: lua.Identifier
+    className: lua.Identifier,
 ): lua.AssignmentStatement | undefined {
     if (!field.initializer) return;
     const fieldName = transformPropertyName(context, field.name);

--- a/src/transformation/visitors/class/members/method.ts
+++ b/src/transformation/visitors/class/members/method.ts
@@ -9,7 +9,7 @@ import { createClassMethodDecoratingExpression } from "../decorators";
 
 export function transformMemberExpressionOwnerName(
     node: ts.PropertyDeclaration | ts.MethodDeclaration | ts.AccessorDeclaration,
-    className: lua.Identifier
+    className: lua.Identifier,
 ): lua.Expression {
     return isStaticNode(node) ? lua.cloneIdentifier(className) : createPrototypeName(className);
 }
@@ -25,7 +25,7 @@ export function transformMethodName(context: TransformationContext, node: ts.Met
 export function transformMethodDeclaration(
     context: TransformationContext,
     node: ts.MethodDeclaration,
-    className: lua.Identifier
+    className: lua.Identifier,
 ): lua.Statement[] {
     // Don't transform methods without body (overload declarations)
     if (!node.body) return [];
@@ -43,10 +43,10 @@ export function transformMethodDeclaration(
             return [
                 lua.createAssignmentStatement(
                     lua.createTableIndexExpression(methodTable, methodName),
-                    functionExpression
+                    functionExpression,
                 ),
                 lua.createExpressionStatement(
-                    createClassMethodDecoratingExpression(context, node, functionExpression, className)
+                    createClassMethodDecoratingExpression(context, node, functionExpression, className),
                 ),
             ];
         } else {
@@ -54,7 +54,7 @@ export function transformMethodDeclaration(
                 lua.createAssignmentStatement(
                     lua.createTableIndexExpression(methodTable, methodName),
                     createClassMethodDecoratingExpression(context, node, functionExpression, className),
-                    node
+                    node,
                 ),
             ];
         }
@@ -63,7 +63,7 @@ export function transformMethodDeclaration(
             lua.createAssignmentStatement(
                 lua.createTableIndexExpression(methodTable, methodName),
                 functionExpression,
-                node
+                node,
             ),
         ];
     }

--- a/src/transformation/visitors/class/new.ts
+++ b/src/transformation/visitors/class/new.ts
@@ -23,7 +23,7 @@ export const transformNewExpression: FunctionVisitor<ts.NewExpression> = (node, 
             return lua.createCallExpression(
                 lua.createIdentifier(customConstructorAnnotation.args[0]),
                 transformArguments(context, node.arguments ?? []),
-                node
+                node,
             );
         } else {
             context.diagnostics.push(
@@ -31,8 +31,8 @@ export const transformNewExpression: FunctionVisitor<ts.NewExpression> = (node, 
                     node,
                     AnnotationKind.CustomConstructor,
                     customConstructorAnnotation.args.length,
-                    1
-                )
+                    1,
+                ),
             );
         }
     }

--- a/src/transformation/visitors/class/setup.ts
+++ b/src/transformation/visitors/class/setup.ts
@@ -17,7 +17,7 @@ export function createClassSetup(
     statement: ts.ClassLikeDeclarationBase,
     className: lua.Identifier,
     localClassName: lua.Identifier,
-    extendsType?: ts.Type
+    extendsType?: ts.Type,
 ): lua.Statement[] {
     const result: lua.Statement[] = [];
 
@@ -45,8 +45,8 @@ export function createClassSetup(
             result.push(
                 lua.createVariableDeclarationStatement(
                     localClassName,
-                    createExportedIdentifier(context, lua.cloneIdentifier(className), exportScope)
-                )
+                    createExportedIdentifier(context, lua.cloneIdentifier(className), exportScope),
+                ),
             );
         }
     }
@@ -56,8 +56,8 @@ export function createClassSetup(
         lua.createAssignmentStatement(
             lua.createTableIndexExpression(lua.cloneIdentifier(localClassName), lua.createStringLiteral("name")),
             getReflectionClassName(statement, className),
-            statement
-        )
+            statement,
+        ),
     );
 
     if (extendsType) {
@@ -70,9 +70,9 @@ export function createClassSetup(
                     LuaLibFeature.ClassExtends,
                     getExtendsClause(statement),
                     lua.cloneIdentifier(localClassName),
-                    context.transformExpression(extendedNode.expression)
-                )
-            )
+                    context.transformExpression(extendedNode.expression),
+                ),
+            ),
         );
     }
 
@@ -81,7 +81,7 @@ export function createClassSetup(
 
 export function getReflectionClassName(
     declaration: ts.ClassLikeDeclarationBase,
-    className: lua.Identifier
+    className: lua.Identifier,
 ): lua.Expression {
     if (declaration.name) {
         return lua.createStringLiteral(declaration.name.text);

--- a/src/transformation/visitors/class/utils.ts
+++ b/src/transformation/visitors/class/utils.ts
@@ -22,7 +22,7 @@ export function getExtendedNode(node: ts.ClassLikeDeclarationBase): ts.Expressio
 
 export function getExtendedType(
     context: TransformationContext,
-    node: ts.ClassLikeDeclarationBase
+    node: ts.ClassLikeDeclarationBase,
 ): ts.Type | undefined {
     const extendedNode = getExtendedNode(node);
     return extendedNode && context.checker.getTypeAtLocation(extendedNode);

--- a/src/transformation/visitors/conditional.ts
+++ b/src/transformation/visitors/conditional.ts
@@ -12,16 +12,16 @@ function transformProtectedConditionalExpression(
     expression: ts.ConditionalExpression,
     condition: WithPrecedingStatements<lua.Expression>,
     whenTrue: WithPrecedingStatements<lua.Expression>,
-    whenFalse: WithPrecedingStatements<lua.Expression>
+    whenFalse: WithPrecedingStatements<lua.Expression>,
 ): lua.Expression {
     const tempVar = context.createTempNameForNode(expression.condition);
 
     const trueStatements = whenTrue.precedingStatements.concat(
-        lua.createAssignmentStatement(lua.cloneIdentifier(tempVar), whenTrue.result, expression.whenTrue)
+        lua.createAssignmentStatement(lua.cloneIdentifier(tempVar), whenTrue.result, expression.whenTrue),
     );
 
     const falseStatements = whenFalse.precedingStatements.concat(
-        lua.createAssignmentStatement(lua.cloneIdentifier(tempVar), whenFalse.result, expression.whenFalse)
+        lua.createAssignmentStatement(lua.cloneIdentifier(tempVar), whenFalse.result, expression.whenFalse),
     );
 
     context.addPrecedingStatements([
@@ -31,7 +31,7 @@ function transformProtectedConditionalExpression(
             condition.result,
             lua.createBlock(trueStatements, expression.whenTrue),
             lua.createBlock(falseStatements, expression.whenFalse),
-            expression
+            expression,
         ),
     ]);
     return lua.cloneIdentifier(tempVar);
@@ -42,13 +42,13 @@ export const transformConditionalExpression: FunctionVisitor<ts.ConditionalExpre
     checkOnlyTruthyCondition(expression.condition, context);
 
     const condition = transformInPrecedingStatementScope(context, () =>
-        context.transformExpression(expression.condition)
+        context.transformExpression(expression.condition),
     );
     const whenTrue = transformInPrecedingStatementScope(context, () =>
-        context.transformExpression(expression.whenTrue)
+        context.transformExpression(expression.whenTrue),
     );
     const whenFalse = transformInPrecedingStatementScope(context, () =>
-        context.transformExpression(expression.whenFalse)
+        context.transformExpression(expression.whenFalse),
     );
     if (
         whenTrue.precedingStatements.length > 0 ||
@@ -79,7 +79,7 @@ export function transformIfStatement(statement: ts.IfStatement, context: Transfo
         if (ts.isIfStatement(statement.elseStatement)) {
             const tsElseStatement = statement.elseStatement;
             const { precedingStatements, result: elseStatement } = transformInPrecedingStatementScope(context, () =>
-                transformIfStatement(tsElseStatement, context)
+                transformIfStatement(tsElseStatement, context),
             );
             // If else-if condition generates preceding statements, we can't use elseif, we have to break it down:
             // if conditionA then
@@ -99,7 +99,7 @@ export function transformIfStatement(statement: ts.IfStatement, context: Transfo
             context.pushScope(ScopeType.Conditional);
             const elseStatements = performHoisting(
                 context,
-                transformBlockOrStatement(context, statement.elseStatement)
+                transformBlockOrStatement(context, statement.elseStatement),
             );
             context.popScope();
             const elseBlock = lua.createBlock(elseStatements);

--- a/src/transformation/visitors/enum.ts
+++ b/src/transformation/visitors/enum.ts
@@ -10,7 +10,7 @@ import { transformPropertyName } from "./literal";
 
 export function tryGetConstEnumValue(
     context: TransformationContext,
-    node: ts.EnumMember | ts.PropertyAccessExpression | ts.ElementAccessExpression
+    node: ts.EnumMember | ts.PropertyAccessExpression | ts.ElementAccessExpression,
 ): lua.Expression | undefined {
     const value = context.checker.getConstantValue(node);
     if (typeof value === "string") {
@@ -34,7 +34,7 @@ export const transformEnumDeclaration: FunctionVisitor<ts.EnumDeclaration> = (no
         const table = lua.createBinaryExpression(
             lua.cloneIdentifier(name),
             lua.createTableExpression(),
-            lua.SyntaxKind.OrOperator
+            lua.SyntaxKind.OrOperator,
         );
         result.push(...createLocalOrExportedOrGlobalDeclaration(context, name, table, node));
     }
@@ -79,8 +79,8 @@ export const transformEnumDeclaration: FunctionVisitor<ts.EnumDeclaration> = (no
                         : lua.createIdentifier(member.name.getText(), member.name),
                     valueExpression,
                     node,
-                    exportScope
-                )
+                    exportScope,
+                ),
             );
         } else {
             const memberAccessor = lua.createTableIndexExpression(enumReference, memberName);

--- a/src/transformation/visitors/errors.ts
+++ b/src/transformation/visitors/errors.ts
@@ -25,8 +25,8 @@ const transformAsyncTry: FunctionVisitor<ts.TryStatement> = (statement, context)
                 statement,
                 "try/catch inside async functions",
                 LuaTarget.Lua51,
-                "lua51AllowTryCatchInAsyncAwait"
-            )
+                "lua51AllowTryCatchInAsyncAwait",
+            ),
         );
         return tryBlock.statements;
     }
@@ -42,12 +42,12 @@ const transformAsyncTry: FunctionVisitor<ts.TryStatement> = (statement, context)
     if (statement.finallyBlock) {
         const awaiterFinally = lua.createTableIndexExpression(awaiterIdentifier, lua.createStringLiteral("finally"));
         const finallyFunction = lua.createFunctionExpression(
-            lua.createBlock(context.transformStatements(statement.finallyBlock.statements))
+            lua.createBlock(context.transformStatements(statement.finallyBlock.statements)),
         );
         const finallyCall = lua.createCallExpression(
             awaiterFinally,
             [awaiterIdentifier, finallyFunction],
-            statement.finallyBlock
+            statement.finallyBlock,
         );
         // ____try.finally(<finally function>)
         result.push(lua.createExpressionStatement(finallyCall));
@@ -87,7 +87,7 @@ export const transformTryStatement: FunctionVisitor<ts.TryStatement> = (statemen
         isInGeneratorFunction(statement)
     ) {
         context.diagnostics.push(
-            unsupportedForTarget(statement, "try/catch inside generator functions", LuaTarget.Lua51)
+            unsupportedForTarget(statement, "try/catch inside generator functions", LuaTarget.Lua51),
         );
         return tryBlock.statements;
     }
@@ -123,12 +123,12 @@ export const transformTryStatement: FunctionVisitor<ts.TryStatement> = (statemen
 
         const catchCall = lua.createCallExpression(
             catchIdentifier,
-            statement.catchClause.variableDeclaration ? [lua.cloneIdentifier(returnedIdentifier)] : []
+            statement.catchClause.variableDeclaration ? [lua.cloneIdentifier(returnedIdentifier)] : [],
         );
         const catchCallStatement = hasReturn
             ? lua.createAssignmentStatement(
                   [lua.cloneIdentifier(returnedIdentifier), lua.cloneIdentifier(returnValueIdentifier)],
-                  catchCall
+                  catchCall,
               )
             : lua.createExpressionStatement(catchCall);
 
@@ -144,7 +144,7 @@ export const transformTryStatement: FunctionVisitor<ts.TryStatement> = (statemen
         returnCondition = lua.createBinaryExpression(
             lua.cloneIdentifier(tryResultIdentifier),
             returnedIdentifier,
-            lua.SyntaxKind.AndOperator
+            lua.SyntaxKind.AndOperator,
         );
     } else {
         // try without return or catch
@@ -182,13 +182,13 @@ export const transformThrowStatement: FunctionVisitor<ts.ThrowStatement> = (stat
 
     return lua.createExpressionStatement(
         lua.createCallExpression(lua.createIdentifier("error"), parameters),
-        statement
+        statement,
     );
 };
 
 function transformCatchClause(
     context: TransformationContext,
-    catchClause: ts.CatchClause
+    catchClause: ts.CatchClause,
 ): [lua.FunctionExpression, Scope] {
     const [catchBlock, catchScope] = transformScopeBlock(context, catchClause.block, ScopeType.Catch);
 
@@ -197,7 +197,7 @@ function transformCatchClause(
         : undefined;
     const catchFunction = lua.createFunctionExpression(
         catchBlock,
-        catchParameter ? [lua.cloneIdentifier(catchParameter)] : []
+        catchParameter ? [lua.cloneIdentifier(catchParameter)] : [],
     );
 
     return [catchFunction, catchScope];

--- a/src/transformation/visitors/expression-list.ts
+++ b/src/transformation/visitors/expression-list.ts
@@ -24,7 +24,7 @@ export function shouldMoveToTemp(context: TransformationContext, expression: lua
 export function moveToPrecedingTemp(
     context: TransformationContext,
     expression: lua.Expression,
-    tsOriginal?: ts.Node
+    tsOriginal?: ts.Node,
 ): lua.Expression {
     if (!shouldMoveToTemp(context, expression, tsOriginal)) {
         return expression;
@@ -37,7 +37,7 @@ export function moveToPrecedingTemp(
 
 function transformExpressions(
     context: TransformationContext,
-    expressions: readonly ts.Expression[]
+    expressions: readonly ts.Expression[],
 ): {
     transformedExpressions: lua.Expression[];
     precedingStatements: lua.Statement[][];
@@ -63,7 +63,7 @@ function transformExpressionsUsingTemps(
     expressions: readonly ts.Expression[],
     transformedExpressions: lua.Expression[],
     precedingStatements: lua.Statement[][],
-    lastPrecedingStatementsIndex: number
+    lastPrecedingStatementsIndex: number,
 ) {
     for (let i = 0; i < transformedExpressions.length; ++i) {
         context.addPrecedingStatements(precedingStatements[i]);
@@ -77,7 +77,7 @@ function transformExpressionsUsingTemps(
 function pushToSparseArray(
     context: TransformationContext,
     arrayIdentifier: lua.Identifier | undefined,
-    expressions: lua.Expression[]
+    expressions: lua.Expression[],
 ) {
     if (!arrayIdentifier) {
         arrayIdentifier = lua.createIdentifier(context.createTempName("array"));
@@ -90,7 +90,7 @@ function pushToSparseArray(
             LuaLibFeature.SparseArrayPush,
             undefined,
             arrayIdentifier,
-            ...expressions
+            ...expressions,
         );
         context.addPrecedingStatements(lua.createExpressionStatement(libCall));
     }
@@ -101,7 +101,7 @@ function transformExpressionsUsingSparseArray(
     context: TransformationContext,
     expressions: readonly ts.Expression[],
     transformedExpressions: lua.Expression[],
-    precedingStatements: lua.Statement[][]
+    precedingStatements: lua.Statement[][],
 ) {
     let arrayIdentifier: lua.Identifier | undefined;
 
@@ -135,7 +135,7 @@ function countNeededTemps(
     context: TransformationContext,
     expressions: readonly ts.Expression[],
     transformedExpressions: lua.Expression[],
-    lastPrecedingStatementsIndex: number
+    lastPrecedingStatementsIndex: number,
 ) {
     if (lastPrecedingStatementsIndex < 0) {
         return 0;
@@ -148,11 +148,11 @@ function countNeededTemps(
 // Transforms a list of expressions while flattening spreads and maintaining execution order
 export function transformExpressionList(
     context: TransformationContext,
-    expressions: readonly ts.Expression[]
+    expressions: readonly ts.Expression[],
 ): lua.Expression[] {
     const { transformedExpressions, precedingStatements, lastPrecedingStatementsIndex } = transformExpressions(
         context,
-        expressions
+        expressions,
     );
 
     // If more than this number of temps are required to preserve execution order, we'll fall back to using the
@@ -173,7 +173,7 @@ export function transformExpressionList(
             expressions,
             transformedExpressions,
             precedingStatements,
-            lastPrecedingStatementsIndex
+            lastPrecedingStatementsIndex,
         );
     }
 }
@@ -181,17 +181,17 @@ export function transformExpressionList(
 // Transforms a series of expressions while maintaining execution order
 export function transformOrderedExpressions(
     context: TransformationContext,
-    expressions: readonly ts.Expression[]
+    expressions: readonly ts.Expression[],
 ): lua.Expression[] {
     const { transformedExpressions, precedingStatements, lastPrecedingStatementsIndex } = transformExpressions(
         context,
-        expressions
+        expressions,
     );
     return transformExpressionsUsingTemps(
         context,
         expressions,
         transformedExpressions,
         precedingStatements,
-        lastPrecedingStatementsIndex
+        lastPrecedingStatementsIndex,
     );
 }

--- a/src/transformation/visitors/identifier.ts
+++ b/src/transformation/visitors/identifier.ts
@@ -47,7 +47,7 @@ export function getCustomNameFromSymbol(symbol?: ts.Symbol): undefined | string 
 function transformNonValueIdentifier(
     context: TransformationContext,
     identifier: ts.Identifier,
-    symbol: ts.Symbol | undefined
+    symbol: ts.Symbol | undefined,
 ) {
     if (isOptionalContinuation(identifier)) {
         const result = lua.createIdentifier(identifier.text, undefined, tempSymbolId);
@@ -92,7 +92,7 @@ function transformNonValueIdentifier(
 export function transformIdentifierWithSymbol(
     context: TransformationContext,
     node: ts.Identifier,
-    symbol: ts.Symbol | undefined
+    symbol: ts.Symbol | undefined,
 ): lua.Expression {
     if (symbol) {
         const exportScope = getSymbolExportScope(context, symbol);

--- a/src/transformation/visitors/language-extensions/call-extension.ts
+++ b/src/transformation/visitors/language-extensions/call-extension.ts
@@ -15,7 +15,7 @@ tableNewExtensions.forEach(kind => callExtensions.add(kind));
 export type LanguageExtensionCallTransformer = (
     context: TransformationContext,
     node: ts.CallExpression,
-    extensionKind: ExtensionKind
+    extensionKind: ExtensionKind,
 ) => lua.Expression;
 
 export type LanguageExtensionCallTransformerMap = {
@@ -23,7 +23,7 @@ export type LanguageExtensionCallTransformerMap = {
 };
 export function transformLanguageExtensionCallExpression(
     context: TransformationContext,
-    node: ts.CallExpression
+    node: ts.CallExpression,
 ): lua.Expression | undefined {
     const extensionKind = getExtensionKindForNode(context, node.expression);
     if (!extensionKind) return;

--- a/src/transformation/visitors/language-extensions/identifier.ts
+++ b/src/transformation/visitors/language-extensions/identifier.ts
@@ -15,7 +15,7 @@ export function isIdentifierExtensionValue(symbol: ts.Symbol | undefined, extens
 export function reportInvalidExtensionValue(
     context: TransformationContext,
     identifier: ts.Identifier,
-    extensionKind: ExtensionKind
+    extensionKind: ExtensionKind,
 ): void {
     if (extensionKind === ExtensionKind.MultiFunction) {
         context.diagnostics.push(invalidMultiFunctionUse(identifier));

--- a/src/transformation/visitors/language-extensions/iterable.ts
+++ b/src/transformation/visitors/language-extensions/iterable.ts
@@ -15,7 +15,7 @@ function transformForOfMultiIterableStatement(
     statement: ts.ForOfStatement,
     block: lua.Block,
     luaIterator: lua.Expression,
-    invalidMultiUseDiagnostic: (node: ts.Node) => ts.Diagnostic
+    invalidMultiUseDiagnostic: (node: ts.Node) => ts.Diagnostic,
 ): lua.Statement {
     context.pushPrecedingStatements();
     let identifiers: lua.Identifier[] = [];
@@ -38,10 +38,10 @@ function transformForOfMultiIterableStatement(
             block.statements.unshift(
                 lua.createAssignmentStatement(
                     statement.initializer.elements.map(e =>
-                        cast(context.transformExpression(e), lua.isAssignmentLeftHandSideExpression)
+                        cast(context.transformExpression(e), lua.isAssignmentLeftHandSideExpression),
                     ),
-                    identifiers
-                )
+                    identifiers,
+                ),
             );
         }
     } else {
@@ -60,7 +60,7 @@ function transformForOfMultiIterableStatement(
 export function transformForOfIterableStatement(
     context: TransformationContext,
     statement: ts.ForOfStatement,
-    block: lua.Block
+    block: lua.Block,
 ): lua.Statement {
     const type = context.checker.getTypeAtLocation(statement.expression);
     if (type.aliasTypeArguments?.length === 2 && isMultiReturnType(type.aliasTypeArguments[0])) {
@@ -70,7 +70,7 @@ export function transformForOfIterableStatement(
             statement,
             block,
             luaIterator,
-            invalidMultiIterableWithoutDestructuring
+            invalidMultiIterableWithoutDestructuring,
         );
     }
 
@@ -82,7 +82,7 @@ export function transformForOfIterableStatement(
 export function transformForOfPairsIterableStatement(
     context: TransformationContext,
     statement: ts.ForOfStatement,
-    block: lua.Block
+    block: lua.Block,
 ): lua.Statement {
     const pairsCall = lua.createCallExpression(lua.createIdentifier("pairs"), [
         context.transformExpression(statement.expression),
@@ -92,14 +92,14 @@ export function transformForOfPairsIterableStatement(
         statement,
         block,
         pairsCall,
-        invalidPairsIterableWithoutDestructuring
+        invalidPairsIterableWithoutDestructuring,
     );
 }
 
 export function transformForOfPairsKeyIterableStatement(
     context: TransformationContext,
     statement: ts.ForOfStatement,
-    block: lua.Block
+    block: lua.Block,
 ): lua.Statement {
     const pairsCall = lua.createCallExpression(lua.createIdentifier("pairs"), [
         context.transformExpression(statement.expression),

--- a/src/transformation/visitors/language-extensions/range.ts
+++ b/src/transformation/visitors/language-extensions/range.ts
@@ -39,7 +39,7 @@ function getControlVariable(context: TransformationContext, statement: ts.ForOfS
 export function transformRangeStatement(
     context: TransformationContext,
     statement: ts.ForOfStatement,
-    block: lua.Block
+    block: lua.Block,
 ): lua.Statement {
     assert(ts.isCallExpression(statement.expression));
     const controlVariable =
@@ -47,7 +47,7 @@ export function transformRangeStatement(
     const [start = lua.createNumericLiteral(0), limit = lua.createNumericLiteral(0), step] = transformArguments(
         context,
         statement.expression.arguments,
-        context.checker.getResolvedSignature(statement.expression)
+        context.checker.getResolvedSignature(statement.expression),
     );
     return lua.createForStatement(block, controlVariable, start, limit, step, statement);
 }

--- a/src/transformation/visitors/language-extensions/table.ts
+++ b/src/transformation/visitors/language-extensions/table.ts
@@ -35,7 +35,7 @@ export const tableExtensionTransformers: LanguageExtensionCallTransformerMap = {
 function transformTableDeleteExpression(
     context: TransformationContext,
     node: ts.CallExpression,
-    extensionKind: ExtensionKind
+    extensionKind: ExtensionKind,
 ): lua.Expression {
     const args = getBinaryCallExtensionArgs(context, node, extensionKind);
     if (!args) {
@@ -45,7 +45,7 @@ function transformTableDeleteExpression(
     const [table, key] = transformOrderedExpressions(context, args);
     // arg0[arg1] = nil
     context.addPrecedingStatements(
-        lua.createAssignmentStatement(lua.createTableIndexExpression(table, key), lua.createNilLiteral(), node)
+        lua.createAssignmentStatement(lua.createTableIndexExpression(table, key), lua.createNilLiteral(), node),
     );
     return lua.createBooleanLiteral(true);
 }
@@ -53,7 +53,7 @@ function transformTableDeleteExpression(
 function transformTableGetExpression(
     context: TransformationContext,
     node: ts.CallExpression,
-    extensionKind: ExtensionKind
+    extensionKind: ExtensionKind,
 ): lua.Expression {
     const args = getBinaryCallExtensionArgs(context, node, extensionKind);
     if (!args) {
@@ -68,7 +68,7 @@ function transformTableGetExpression(
 function transformTableHasExpression(
     context: TransformationContext,
     node: ts.CallExpression,
-    extensionKind: ExtensionKind
+    extensionKind: ExtensionKind,
 ): lua.Expression {
     const args = getBinaryCallExtensionArgs(context, node, extensionKind);
     if (!args) {
@@ -84,14 +84,14 @@ function transformTableHasExpression(
         tableIndexExpression,
         lua.createNilLiteral(),
         lua.SyntaxKind.InequalityOperator,
-        node
+        node,
     );
 }
 
 function transformTableSetExpression(
     context: TransformationContext,
     node: ts.CallExpression,
-    extensionKind: ExtensionKind
+    extensionKind: ExtensionKind,
 ): lua.Expression {
     const args = getNaryCallExtensionArgs(context, node, extensionKind, 3);
     if (!args) {
@@ -101,7 +101,7 @@ function transformTableSetExpression(
     const [table, key, value] = transformOrderedExpressions(context, args);
     // arg0[arg1] = arg2
     context.addPrecedingStatements(
-        lua.createAssignmentStatement(lua.createTableIndexExpression(table, key), value, node)
+        lua.createAssignmentStatement(lua.createTableIndexExpression(table, key), value, node),
     );
     return lua.createNilLiteral();
 }
@@ -109,7 +109,7 @@ function transformTableSetExpression(
 function transformTableAddKeyExpression(
     context: TransformationContext,
     node: ts.CallExpression,
-    extensionKind: ExtensionKind
+    extensionKind: ExtensionKind,
 ): lua.Expression {
     const args = getNaryCallExtensionArgs(context, node, extensionKind, 2);
     if (!args) {
@@ -119,7 +119,7 @@ function transformTableAddKeyExpression(
     const [table, key] = transformOrderedExpressions(context, args);
     // arg0[arg1] = true
     context.addPrecedingStatements(
-        lua.createAssignmentStatement(lua.createTableIndexExpression(table, key), lua.createBooleanLiteral(true), node)
+        lua.createAssignmentStatement(lua.createTableIndexExpression(table, key), lua.createBooleanLiteral(true), node),
     );
     return lua.createNilLiteral();
 }
@@ -127,7 +127,7 @@ function transformTableAddKeyExpression(
 function transformTableIsEmptyExpression(
     context: TransformationContext,
     node: ts.CallExpression,
-    extensionKind: ExtensionKind
+    extensionKind: ExtensionKind,
 ): lua.Expression {
     const args = getUnaryCallExtensionArg(context, node, extensionKind);
     if (!args) {
@@ -140,6 +140,6 @@ function transformTableIsEmptyExpression(
         lua.createCallExpression(lua.createIdentifier("next"), [table], node),
         lua.createNilLiteral(),
         lua.SyntaxKind.EqualityOperator,
-        node
+        node,
     );
 }

--- a/src/transformation/visitors/literal.ts
+++ b/src/transformation/visitors/literal.ts
@@ -27,7 +27,7 @@ export function transformPropertyName(context: TransformationContext, node: ts.P
 export function createShorthandIdentifier(
     context: TransformationContext,
     valueSymbol: ts.Symbol | undefined,
-    propertyIdentifier: ts.Identifier
+    propertyIdentifier: ts.Identifier,
 ): lua.Expression {
     return transformIdentifierWithSymbol(context, propertyIdentifier, valueSymbol);
 }
@@ -97,7 +97,7 @@ const transformObjectLiteralExpression: FunctionVisitor<ts.ObjectLiteralExpressi
                     context,
                     LuaLibFeature.ArrayToObject,
                     element.expression,
-                    context.transformExpression(element.expression)
+                    context.transformExpression(element.expression),
                 );
             } else {
                 tableExpression = context.transformExpression(element.expression);
@@ -180,7 +180,7 @@ const transformArrayLiteralExpression: FunctionVisitor<ts.ArrayLiteralExpression
     checkForUndefinedOrNullInArrayLiteral(expression, context);
 
     const filteredElements = expression.elements.map(e =>
-        ts.isOmittedExpression(e) ? ts.factory.createIdentifier("undefined") : e
+        ts.isOmittedExpression(e) ? ts.factory.createIdentifier("undefined") : e,
     );
     const values = transformExpressionList(context, filteredElements).map(e => lua.createTableFieldExpression(e));
 

--- a/src/transformation/visitors/loops/do-while.ts
+++ b/src/transformation/visitors/loops/do-while.ts
@@ -13,7 +13,7 @@ export const transformWhileStatement: FunctionVisitor<ts.WhileStatement> = (stat
 
     let { precedingStatements: conditionPrecedingStatements, result: condition } = transformInPrecedingStatementScope(
         context,
-        () => context.transformExpression(statement.expression)
+        () => context.transformExpression(statement.expression),
     );
 
     // If condition has preceding statements, ensure they are executed every iteration by using the form:
@@ -31,8 +31,8 @@ export const transformWhileStatement: FunctionVisitor<ts.WhileStatement> = (stat
                 invertCondition(condition),
                 lua.createBlock([lua.createBreakStatement()]),
                 undefined,
-                statement.expression
-            )
+                statement.expression,
+            ),
         );
         body.unshift(...conditionPrecedingStatements);
         condition = lua.createBooleanLiteral(true);
@@ -49,7 +49,7 @@ export const transformDoStatement: FunctionVisitor<ts.DoStatement> = (statement,
 
     let { precedingStatements: conditionPrecedingStatements, result: condition } = transformInPrecedingStatementScope(
         context,
-        () => invertCondition(context.transformExpression(statement.expression))
+        () => invertCondition(context.transformExpression(statement.expression)),
     );
 
     // If condition has preceding statements, ensure they are executed every iteration by using the form:
@@ -67,8 +67,8 @@ export const transformDoStatement: FunctionVisitor<ts.DoStatement> = (statement,
                 condition,
                 lua.createBlock([lua.createBreakStatement()]),
                 undefined,
-                statement.expression
-            )
+                statement.expression,
+            ),
         );
         condition = lua.createBooleanLiteral(false);
     }

--- a/src/transformation/visitors/loops/for-of.ts
+++ b/src/transformation/visitors/loops/for-of.ts
@@ -16,7 +16,7 @@ import { assertNever } from "../../../utils";
 function transformForOfArrayStatement(
     context: TransformationContext,
     statement: ts.ForOfStatement,
-    block: lua.Block
+    block: lua.Block,
 ): lua.Statement {
     const valueVariable = transformForInitializer(context, statement.initializer, block);
     const ipairsCall = lua.createCallExpression(lua.createIdentifier("ipairs"), [
@@ -29,14 +29,14 @@ function transformForOfArrayStatement(
 function transformForOfIteratorStatement(
     context: TransformationContext,
     statement: ts.ForOfStatement,
-    block: lua.Block
+    block: lua.Block,
 ): lua.Statement {
     const valueVariable = transformForInitializer(context, statement.initializer, block);
     const iterable = transformLuaLibFunction(
         context,
         LuaLibFeature.Iterator,
         statement.expression,
-        context.transformExpression(statement.expression)
+        context.transformExpression(statement.expression),
     );
 
     return lua.createForInStatement(block, [lua.createAnonymousIdentifier(), valueVariable], [iterable], statement);

--- a/src/transformation/visitors/loops/for.ts
+++ b/src/transformation/visitors/loops/for.ts
@@ -25,7 +25,7 @@ export const transformForStatement: FunctionVisitor<ts.ForStatement> = (statemen
         const tsCondition = statement.condition;
         const { precedingStatements: conditionPrecedingStatements, result } = transformInPrecedingStatementScope(
             context,
-            () => context.transformExpression(tsCondition)
+            () => context.transformExpression(tsCondition),
         );
         condition = result;
 
@@ -44,8 +44,8 @@ export const transformForStatement: FunctionVisitor<ts.ForStatement> = (statemen
                     invertCondition(condition),
                     lua.createBlock([lua.createBreakStatement()]),
                     undefined,
-                    statement.condition
-                )
+                    statement.condition,
+                ),
             );
             body.unshift(...conditionPrecedingStatements);
             condition = lua.createBooleanLiteral(true);

--- a/src/transformation/visitors/loops/utils.ts
+++ b/src/transformation/visitors/loops/utils.ts
@@ -12,7 +12,7 @@ import { checkVariableDeclarationList, transformBindingPattern } from "../variab
 
 export function transformLoopBody(
     context: TransformationContext,
-    loop: ts.WhileStatement | ts.DoStatement | ts.ForStatement | ts.ForOfStatement | ts.ForInOrOfStatement
+    loop: ts.WhileStatement | ts.DoStatement | ts.ForStatement | ts.ForOfStatement | ts.ForInOrOfStatement,
 ): lua.Statement[] {
     context.pushScope(ScopeType.Loop);
     const body = performHoisting(context, transformBlockOrStatement(context, loop.statement));
@@ -35,11 +35,11 @@ export function transformLoopBody(
                     lua.createVariableDeclarationStatement(identifier),
                     lua.createRepeatStatement(
                         lua.createBlock([...body, lua.createAssignmentStatement(identifier, literalTrue)]),
-                        literalTrue
+                        literalTrue,
                     ),
                     lua.createIfStatement(
                         lua.createUnaryExpression(identifier, lua.SyntaxKind.NotOperator),
-                        lua.createBlock([lua.createBreakStatement()])
+                        lua.createBlock([lua.createBreakStatement()]),
                     ),
                 ]),
             ];
@@ -48,7 +48,7 @@ export function transformLoopBody(
 
 export function getVariableDeclarationBinding(
     context: TransformationContext,
-    node: ts.VariableDeclarationList
+    node: ts.VariableDeclarationList,
 ): ts.BindingName {
     checkVariableDeclarationList(context, node);
 
@@ -62,7 +62,7 @@ export function getVariableDeclarationBinding(
 export function transformForInitializer(
     context: TransformationContext,
     initializer: ts.ForInitializer,
-    block: lua.Block
+    block: lua.Block,
 ): lua.Identifier {
     const valueVariable = lua.createIdentifier("____value");
 
@@ -74,7 +74,7 @@ export function transformForInitializer(
         const binding = getVariableDeclarationBinding(context, initializer);
         if (ts.isArrayBindingPattern(binding) || ts.isObjectBindingPattern(binding)) {
             const { precedingStatements, result: bindings } = transformInPrecedingStatementScope(context, () =>
-                transformBindingPattern(context, binding, valueVariable)
+                transformBindingPattern(context, binding, valueVariable),
             );
             block.statements.unshift(...precedingStatements, ...bindings);
         } else {
@@ -88,7 +88,7 @@ export function transformForInitializer(
         block.statements.unshift(
             ...(isAssignmentPattern(initializer)
                 ? transformAssignmentPattern(context, initializer, valueVariable, false)
-                : transformAssignment(context, initializer, valueVariable))
+                : transformAssignment(context, initializer, valueVariable)),
         );
     }
 

--- a/src/transformation/visitors/modules/export.ts
+++ b/src/transformation/visitors/modules/export.ts
@@ -26,7 +26,7 @@ export const transformExportAssignment: FunctionVisitor<ts.ExportAssignment> = (
         return lua.createAssignmentStatement(
             lua.createTableIndexExpression(createExportsIdentifier(), createDefaultExportStringLiteral(node)),
             exportedValue,
-            node
+            node,
         );
     }
 };
@@ -42,9 +42,9 @@ function transformExportAll(context: TransformationContext, node: ts.ExportDecla
         const assignToExports = lua.createAssignmentStatement(
             lua.createTableIndexExpression(
                 createExportsIdentifier(),
-                lua.createStringLiteral(node.exportClause.name.text)
+                lua.createStringLiteral(node.exportClause.name.text),
             ),
-            moduleRequire
+            moduleRequire,
         );
         return assignToExports;
     }
@@ -63,7 +63,7 @@ function transformExportAll(context: TransformationContext, node: ts.ExportDecla
     const forValue = lua.createIdentifier("____exportValue");
     const leftAssignment = lua.createAssignmentStatement(
         lua.createTableIndexExpression(createExportsIdentifier(), forKey),
-        forValue
+        forValue,
     );
 
     // if key ~= "default" then
@@ -74,9 +74,9 @@ function transformExportAll(context: TransformationContext, node: ts.ExportDecla
         lua.createBinaryExpression(
             lua.cloneIdentifier(forKey),
             lua.createStringLiteral("default"),
-            lua.SyntaxKind.InequalityOperator
+            lua.SyntaxKind.InequalityOperator,
         ),
-        ifBody
+        ifBody,
     );
 
     // for ____exportKey, ____exportValue in ____export do
@@ -86,7 +86,7 @@ function transformExportAll(context: TransformationContext, node: ts.ExportDecla
     const forIn = lua.createForInStatement(
         lua.createBlock([ifStatement]),
         [lua.cloneIdentifier(forKey), lua.cloneIdentifier(forValue)],
-        [lua.createCallExpression(pairsIdentifier, [lua.cloneIdentifier(tempModuleIdentifier)])]
+        [lua.createCallExpression(pairsIdentifier, [lua.cloneIdentifier(tempModuleIdentifier)])],
     );
 
     result.push(forIn);
@@ -122,7 +122,7 @@ function transformExportSpecifier(context: TransformationContext, node: ts.Expor
         const lhs = lua.createTableIndexExpression(
             exportsTable,
             lua.createStringLiteral(exportedName.text),
-            exportedName
+            exportedName,
         );
 
         return lua.createAssignmentStatement(lhs, rhs, node);
@@ -133,7 +133,7 @@ function transformExportSpecifiersFrom(
     context: TransformationContext,
     statement: ts.ExportDeclaration,
     moduleSpecifier: ts.Expression,
-    exportSpecifiers: ts.ExportSpecifier[]
+    exportSpecifiers: ts.ExportSpecifier[],
 ): lua.Statement {
     const result: lua.Statement[] = [];
 
@@ -156,7 +156,7 @@ function transformExportSpecifiersFrom(
         const rhs = lua.createTableIndexExpression(
             lua.cloneIdentifier(importUniqueName),
             transformPropertyName(context, exportedValue),
-            specifier
+            specifier,
         );
         result.push(lua.createAssignmentStatement(lhs, rhs, specifier));
     }

--- a/src/transformation/visitors/modules/import.ts
+++ b/src/transformation/visitors/modules/import.ts
@@ -23,7 +23,7 @@ function isNoResolutionPath(context: TransformationContext, moduleSpecifier: ts.
 export function createModuleRequire(
     context: TransformationContext,
     moduleSpecifier: ts.Expression,
-    tsOriginal: ts.Node = moduleSpecifier
+    tsOriginal: ts.Node = moduleSpecifier,
 ): lua.CallExpression {
     const params: lua.Expression[] = [];
     if (ts.isStringLiteral(moduleSpecifier)) {
@@ -44,18 +44,18 @@ function shouldBeImported(context: TransformationContext, importNode: ts.ImportC
 function transformImportSpecifier(
     context: TransformationContext,
     importSpecifier: ts.ImportSpecifier,
-    moduleTableName: lua.Identifier
+    moduleTableName: lua.Identifier,
 ): lua.VariableDeclarationStatement {
     const leftIdentifier = transformIdentifier(context, importSpecifier.name);
     const propertyName = transformPropertyName(
         context,
-        importSpecifier.propertyName ? importSpecifier.propertyName : importSpecifier.name
+        importSpecifier.propertyName ? importSpecifier.propertyName : importSpecifier.name,
     );
 
     return lua.createVariableDeclarationStatement(
         leftIdentifier,
         lua.createTableIndexExpression(moduleTableName, propertyName),
-        importSpecifier
+        importSpecifier,
     );
 }
 
@@ -96,7 +96,7 @@ export const transformImportDeclaration: FunctionVisitor<ts.ImportDeclaration> =
             const defaultImportAssignmentStatement = lua.createVariableDeclarationStatement(
                 transformIdentifier(context, statement.importClause.name),
                 lua.createTableIndexExpression(importUniqueName, propertyName),
-                statement.importClause.name
+                statement.importClause.name,
             );
 
             result.push(defaultImportAssignmentStatement);
@@ -111,7 +111,7 @@ export const transformImportDeclaration: FunctionVisitor<ts.ImportDeclaration> =
             const requireStatement = lua.createVariableDeclarationStatement(
                 transformIdentifier(context, statement.importClause.namedBindings.name),
                 requireCall,
-                statement
+                statement,
             );
 
             result.push(requireStatement);

--- a/src/transformation/visitors/namespace.ts
+++ b/src/transformation/visitors/namespace.ts
@@ -23,7 +23,7 @@ export function createModuleLocalName(context: TransformationContext, module: ts
 
 export function createModuleLocalNameIdentifier(
     context: TransformationContext,
-    declaration: ts.ModuleDeclaration
+    declaration: ts.ModuleDeclaration,
 ): lua.Identifier {
     const moduleSymbol = context.checker.getSymbolAtLocation(declaration.name);
     if (moduleSymbol !== undefined && isUnsafeName(moduleSymbol.name, context.options)) {
@@ -31,7 +31,7 @@ export function createModuleLocalNameIdentifier(
             createSafeName(declaration.name.text),
             declaration.name,
             moduleSymbol && getSymbolIdOfSymbol(context, moduleSymbol),
-            declaration.name.text
+            declaration.name.text,
         );
     }
 
@@ -40,7 +40,7 @@ export function createModuleLocalNameIdentifier(
 
 // TODO: Do it based on transform result?
 function moduleHasEmittedBody(
-    node: ts.ModuleDeclaration
+    node: ts.ModuleDeclaration,
 ): node is ts.ModuleDeclaration & { body: ts.ModuleBlock | ts.ModuleDeclaration } {
     if (node.body) {
         if (ts.isModuleBlock(node.body)) {
@@ -84,8 +84,8 @@ export const transformModuleDeclaration: FunctionVisitor<ts.ModuleDeclaration> =
             lua.createBinaryExpression(
                 addExportToIdentifier(context, nameIdentifier),
                 lua.createTableExpression(),
-                lua.SyntaxKind.OrOperator
-            )
+                lua.SyntaxKind.OrOperator,
+            ),
         );
 
         result.push(...localDeclaration);
@@ -94,7 +94,7 @@ export const transformModuleDeclaration: FunctionVisitor<ts.ModuleDeclaration> =
         const localDeclaration = createLocalOrExportedOrGlobalDeclaration(
             context,
             nameIdentifier,
-            lua.createTableExpression()
+            lua.createTableExpression(),
         );
 
         result.push(...localDeclaration);
@@ -105,7 +105,7 @@ export const transformModuleDeclaration: FunctionVisitor<ts.ModuleDeclaration> =
         const localDeclaration = createHoistableVariableDeclarationStatement(
             context,
             createModuleLocalNameIdentifier(context, node),
-            createExportedIdentifier(context, nameIdentifier, exportScope)
+            createExportedIdentifier(context, nameIdentifier, exportScope),
         );
 
         result.push(localDeclaration);
@@ -121,7 +121,7 @@ export const transformModuleDeclaration: FunctionVisitor<ts.ModuleDeclaration> =
         context.pushScope(ScopeType.Block);
         const statements = performHoisting(
             context,
-            context.transformStatements(ts.isModuleBlock(node.body) ? node.body.statements : node.body)
+            context.transformStatements(ts.isModuleBlock(node.body) ? node.body.statements : node.body),
         );
         context.popScope();
         result.push(lua.createDoStatement(statements));

--- a/src/transformation/visitors/optional-chaining.ts
+++ b/src/transformation/visitors/optional-chaining.ts
@@ -37,7 +37,7 @@ export interface ExpressionWithThisValue {
 function transformExpressionWithThisValueCapture(
     context: TransformationContext,
     node: ts.Expression,
-    thisValueCapture: lua.Identifier
+    thisValueCapture: lua.Identifier,
 ): ExpressionWithThisValue {
     if (ts.isParenthesizedExpression(node)) {
         return transformExpressionWithThisValueCapture(context, node.expression, thisValueCapture);
@@ -56,7 +56,7 @@ export function captureThisValue(
     context: TransformationContext,
     expression: lua.Expression,
     thisValueCapture: lua.Identifier,
-    tsOriginal: ts.Node
+    tsOriginal: ts.Node,
 ): lua.Expression {
     if (!shouldMoveToTemp(context, expression, tsOriginal)) {
         return expression;
@@ -99,7 +99,7 @@ export function transformOptionalChainWithCapture(
     context: TransformationContext,
     tsNode: ts.OptionalChain,
     thisValueCapture: lua.Identifier | undefined,
-    isDelete?: ts.DeleteExpression
+    isDelete?: ts.DeleteExpression,
 ): ExpressionWithThisValue {
     const luaTempName = context.createTempName("opt");
 
@@ -137,7 +137,7 @@ export function transformOptionalChainWithCapture(
             const { expression: result, thisValue } = transformExpressionWithThisValueCapture(
                 context,
                 tsRightExpression,
-                thisValueCapture
+                thisValueCapture,
             );
             returnThisValue = thisValue;
             return result;
@@ -158,13 +158,13 @@ export function transformOptionalChainWithCapture(
                 ({ expression: result, thisValue: capturedThisValue } = transformExpressionWithThisValueCapture(
                     context,
                     tsLeftExpression,
-                    leftThisValueTemp
+                    leftThisValueTemp,
                 ));
             } else {
                 result = context.transformExpression(tsLeftExpression);
             }
             return result;
-        }
+        },
     );
 
     // handle super calls by passing self as context
@@ -236,8 +236,8 @@ export function transformOptionalChainWithCapture(
         context.addPrecedingStatements(
             lua.createIfStatement(
                 lua.createBinaryExpression(leftIdentifier, lua.createNilLiteral(), lua.SyntaxKind.InequalityOperator),
-                lua.createBlock(innerStatements)
-            )
+                lua.createBlock(innerStatements),
+            ),
         );
         return { expression: lua.createNilLiteral(), thisValue: returnThisValue };
     } else if (
@@ -269,8 +269,8 @@ export function transformOptionalChainWithCapture(
                 lua.createBlock([
                     ...rightPrecedingStatements,
                     lua.createAssignmentStatement(resultIdentifier, rightExpression),
-                ])
-            )
+                ]),
+            ),
         );
         return { expression: resultIdentifier, thisValue: returnThisValue };
     }
@@ -279,7 +279,7 @@ export function transformOptionalChainWithCapture(
 export function transformOptionalDeleteExpression(
     context: TransformationContext,
     node: ts.DeleteExpression,
-    innerExpression: ts.OptionalChain
+    innerExpression: ts.OptionalChain,
 ) {
     transformOptionalChainWithCapture(context, innerExpression, undefined, node);
     return lua.createBooleanLiteral(true, node);

--- a/src/transformation/visitors/return.ts
+++ b/src/transformation/visitors/return.ts
@@ -19,7 +19,7 @@ import { isInAsyncFunction } from "../utils/typescript";
 function transformExpressionsInReturn(
     context: TransformationContext,
     node: ts.Expression,
-    insideTryCatch: boolean
+    insideTryCatch: boolean,
 ): lua.Expression[] {
     const expressionType = context.checker.getTypeAtLocation(node);
 
@@ -61,7 +61,7 @@ function transformExpressionsInReturn(
 
 export function transformExpressionBodyToReturnStatement(
     context: TransformationContext,
-    node: ts.Expression
+    node: ts.Expression,
 ): lua.Statement {
     const expressions = transformExpressionsInReturn(context, node, false);
     return createReturnStatement(context, expressions, node);
@@ -89,7 +89,7 @@ export const transformReturnStatement: FunctionVisitor<ts.ReturnStatement> = (st
 export function createReturnStatement(
     context: TransformationContext,
     values: lua.Expression[],
-    node: ts.Node
+    node: ts.Node,
 ): lua.ReturnStatement {
     if (isInAsyncFunction(node)) {
         return lua.createReturnStatement([

--- a/src/transformation/visitors/sourceFile.ts
+++ b/src/transformation/visitors/sourceFile.ts
@@ -14,7 +14,7 @@ export const transformSourceFileNode: FunctionVisitor<ts.SourceFile> = (node, co
         if (statement) {
             assert(ts.isExpressionStatement(statement));
             const { precedingStatements, result: expression } = transformInPrecedingStatementScope(context, () =>
-                context.transformExpression(statement.expression)
+                context.transformExpression(statement.expression),
             );
             statements.push(...precedingStatements);
             statements.push(lua.createReturnStatement([expression]));
@@ -36,7 +36,7 @@ export const transformSourceFileNode: FunctionVisitor<ts.SourceFile> = (node, co
             // local ____exports = {}
             if (!hasExportEquals(node)) {
                 statements.unshift(
-                    lua.createVariableDeclarationStatement(createExportsIdentifier(), lua.createTableExpression())
+                    lua.createVariableDeclarationStatement(createExportsIdentifier(), lua.createTableExpression()),
                 );
             }
 

--- a/src/transformation/visitors/switch.ts
+++ b/src/transformation/visitors/switch.ts
@@ -29,7 +29,7 @@ const createOrExpression = (
     context: TransformationContext,
     left: lua.Expression,
     right: lua.Expression,
-    rightPrecedingStatements: lua.Statement[]
+    rightPrecedingStatements: lua.Statement[],
 ): WithPrecedingStatements<lua.Expression> => {
     if (rightPrecedingStatements.length > 0) {
         return createShortCircuitBinaryExpressionPrecedingStatements(
@@ -37,7 +37,7 @@ const createOrExpression = (
             left,
             right,
             rightPrecedingStatements,
-            ts.SyntaxKind.BarBarToken
+            ts.SyntaxKind.BarBarToken,
         );
     } else {
         return {
@@ -52,17 +52,17 @@ const coalesceCondition = (
     conditionPrecedingStatements: lua.Statement[],
     switchVariable: lua.Identifier,
     expression: ts.Expression,
-    context: TransformationContext
+    context: TransformationContext,
 ): WithPrecedingStatements<lua.Expression> => {
     const { precedingStatements, result: transformedExpression } = transformInPrecedingStatementScope(context, () =>
-        context.transformExpression(expression)
+        context.transformExpression(expression),
     );
 
     // Coalesce skipped statements
     const comparison = lua.createBinaryExpression(
         switchVariable,
         transformedExpression,
-        lua.SyntaxKind.EqualityOperator
+        lua.SyntaxKind.EqualityOperator,
     );
     if (condition) {
         return createOrExpression(context, condition, comparison, precedingStatements);
@@ -122,7 +122,7 @@ export const transformSwitchStatement: FunctionVisitor<ts.SwitchStatement> = (st
                     conditionPrecedingStatements,
                     switchVariable,
                     clause.expression,
-                    context
+                    context,
                 );
                 conditionPrecedingStatements = precedingStatements;
                 condition = result;
@@ -134,21 +134,21 @@ export const transformSwitchStatement: FunctionVisitor<ts.SwitchStatement> = (st
                 if (isInitialCondition) {
                     statements.push(
                         ...conditionPrecedingStatements,
-                        lua.createVariableDeclarationStatement(conditionVariable, condition)
+                        lua.createVariableDeclarationStatement(conditionVariable, condition),
                     );
                 } else {
                     const { precedingStatements, result } = createOrExpression(
                         context,
                         conditionVariable,
                         condition,
-                        conditionPrecedingStatements
+                        conditionPrecedingStatements,
                     );
                     conditionPrecedingStatements = precedingStatements;
                     condition = result;
 
                     statements.push(
                         ...conditionPrecedingStatements,
-                        lua.createAssignmentStatement(conditionVariable, condition)
+                        lua.createAssignmentStatement(conditionVariable, condition),
                     );
                 }
                 isInitialCondition = false;
@@ -159,8 +159,8 @@ export const transformSwitchStatement: FunctionVisitor<ts.SwitchStatement> = (st
                         ...conditionPrecedingStatements,
                         lua.createVariableDeclarationStatement(
                             conditionVariable,
-                            condition ?? lua.createBooleanLiteral(false)
-                        )
+                            condition ?? lua.createBooleanLiteral(false),
+                        ),
                     );
 
                     // Clear condition ot ensure it is not evaluated twice
@@ -177,13 +177,13 @@ export const transformSwitchStatement: FunctionVisitor<ts.SwitchStatement> = (st
                             context,
                             conditionVariable,
                             condition,
-                            conditionPrecedingStatements
+                            conditionPrecedingStatements,
                         );
                         conditionPrecedingStatements = precedingStatements;
                         condition = result;
                         statements.push(
                             ...conditionPrecedingStatements,
-                            lua.createAssignmentStatement(conditionVariable, condition)
+                            lua.createAssignmentStatement(conditionVariable, condition),
                         );
                     }
                     continue;
@@ -221,7 +221,7 @@ export const transformSwitchStatement: FunctionVisitor<ts.SwitchStatement> = (st
         if (start >= 0) {
             // Find the last clause that we can fallthrough to
             const end = clauses.findIndex(
-                (clause, index) => index >= start && containsBreakOrReturn(clause.statements)
+                (clause, index) => index >= start && containsBreakOrReturn(clause.statements),
             );
 
             const {

--- a/src/transformation/visitors/template.ts
+++ b/src/transformation/visitors/template.ts
@@ -27,7 +27,7 @@ export const transformTemplateExpression: FunctionVisitor<ts.TemplateExpression>
 
     const transformedExpressions = transformOrderedExpressions(
         context,
-        node.templateSpans.map(s => s.expression)
+        node.templateSpans.map(s => s.expression),
     );
     for (let i = 0; i < node.templateSpans.length; ++i) {
         const span = node.templateSpans[i];
@@ -50,7 +50,7 @@ export const transformTemplateExpression: FunctionVisitor<ts.TemplateExpression>
 
 export const transformTaggedTemplateExpression: FunctionVisitor<ts.TaggedTemplateExpression> = (
     expression,
-    context
+    context,
 ) => {
     const strings: string[] = [];
     const rawStrings: string[] = [];
@@ -72,15 +72,15 @@ export const transformTaggedTemplateExpression: FunctionVisitor<ts.TaggedTemplat
     // Construct table with strings and literal strings
 
     const rawStringsArray = ts.factory.createArrayLiteralExpression(
-        rawStrings.map(text => ts.factory.createStringLiteral(text))
+        rawStrings.map(text => ts.factory.createStringLiteral(text)),
     );
 
     const stringObject = ts.factory.createObjectLiteralExpression([
         ...strings.map((partialString, i) =>
             ts.factory.createPropertyAssignment(
                 ts.factory.createNumericLiteral(i + 1),
-                ts.factory.createStringLiteral(partialString)
-            )
+                ts.factory.createStringLiteral(partialString),
+            ),
         ),
         ts.factory.createPropertyAssignment("raw", rawStringsArray),
     ]);

--- a/src/transformation/visitors/typeof.ts
+++ b/src/transformation/visitors/typeof.ts
@@ -12,7 +12,7 @@ export const transformTypeOfExpression: FunctionVisitor<ts.TypeOfExpression> = (
 
 export function transformTypeOfBinaryExpression(
     context: TransformationContext,
-    node: ts.BinaryExpression
+    node: ts.BinaryExpression,
 ): lua.Expression | undefined {
     const operator = node.operatorToken.kind;
     if (
@@ -53,7 +53,7 @@ export function transformTypeOfBinaryExpression(
         comparedExpression,
         [],
         operator,
-        node
+        node,
     );
     context.addPrecedingStatements(precedingStatements);
     return result;

--- a/src/transformation/visitors/typescript.ts
+++ b/src/transformation/visitors/typescript.ts
@@ -8,7 +8,7 @@ const transformAssertionExpression: FunctionVisitor<ts.AssertionExpression> = (e
             context,
             expression,
             context.checker.getTypeAtLocation(expression.expression),
-            context.checker.getTypeAtLocation(expression.type)
+            context.checker.getTypeAtLocation(expression.type),
         );
     }
 

--- a/src/transformation/visitors/unary-expression.ts
+++ b/src/transformation/visitors/unary-expression.ts
@@ -10,7 +10,7 @@ import {
 
 export function transformUnaryExpressionStatement(
     context: TransformationContext,
-    node: ts.ExpressionStatement
+    node: ts.ExpressionStatement,
 ): lua.Statement[] | undefined {
     const expression = ts.isExpressionStatement(node) ? node.expression : node;
     if (
@@ -26,7 +26,7 @@ export function transformUnaryExpressionStatement(
             expression,
             expression.operand,
             ts.factory.createNumericLiteral(1),
-            replacementOperator
+            replacementOperator,
         );
     } else if (ts.isPostfixUnaryExpression(expression)) {
         // i++, i--
@@ -38,7 +38,7 @@ export function transformUnaryExpressionStatement(
             expression,
             expression.operand,
             ts.factory.createNumericLiteral(1),
-            replacementOperator
+            replacementOperator,
         );
     }
 }
@@ -52,7 +52,7 @@ export const transformPostfixUnaryExpression: FunctionVisitor<ts.PostfixUnaryExp
                 expression.operand,
                 ts.factory.createNumericLiteral(1),
                 ts.SyntaxKind.PlusToken,
-                true
+                true,
             );
 
         case ts.SyntaxKind.MinusMinusToken:
@@ -62,7 +62,7 @@ export const transformPostfixUnaryExpression: FunctionVisitor<ts.PostfixUnaryExp
                 expression.operand,
                 ts.factory.createNumericLiteral(1),
                 ts.SyntaxKind.MinusToken,
-                true
+                true,
             );
 
         default:
@@ -79,7 +79,7 @@ export const transformPrefixUnaryExpression: FunctionVisitor<ts.PrefixUnaryExpre
                 expression.operand,
                 ts.factory.createNumericLiteral(1),
                 ts.SyntaxKind.PlusToken,
-                false
+                false,
             );
 
         case ts.SyntaxKind.MinusMinusToken:
@@ -89,7 +89,7 @@ export const transformPrefixUnaryExpression: FunctionVisitor<ts.PrefixUnaryExpre
                 expression.operand,
                 ts.factory.createNumericLiteral(1),
                 ts.SyntaxKind.MinusToken,
-                false
+                false,
             );
 
         case ts.SyntaxKind.PlusToken:
@@ -99,13 +99,13 @@ export const transformPrefixUnaryExpression: FunctionVisitor<ts.PrefixUnaryExpre
         case ts.SyntaxKind.MinusToken:
             return lua.createUnaryExpression(
                 context.transformExpression(expression.operand),
-                lua.SyntaxKind.NegationOperator
+                lua.SyntaxKind.NegationOperator,
             );
 
         case ts.SyntaxKind.ExclamationToken:
             return lua.createUnaryExpression(
                 context.transformExpression(expression.operand),
-                lua.SyntaxKind.NotOperator
+                lua.SyntaxKind.NotOperator,
             );
 
         case ts.SyntaxKind.TildeToken:
@@ -113,7 +113,7 @@ export const transformPrefixUnaryExpression: FunctionVisitor<ts.PrefixUnaryExpre
                 context,
                 expression,
                 context.transformExpression(expression.operand),
-                lua.SyntaxKind.BitwiseNotOperator
+                lua.SyntaxKind.BitwiseNotOperator,
             );
 
         default:

--- a/src/transformation/visitors/variable-declaration.ts
+++ b/src/transformation/visitors/variable-declaration.ts
@@ -16,7 +16,7 @@ import { moveToPrecedingTemp } from "./expression-list";
 
 export function transformArrayBindingElement(
     context: TransformationContext,
-    name: ts.ArrayBindingElement
+    name: ts.ArrayBindingElement,
 ): lua.Identifier {
     if (ts.isOmittedExpression(name)) {
         return lua.createAnonymousIdentifier(name);
@@ -40,7 +40,7 @@ export function transformBindingPattern(
     context: TransformationContext,
     pattern: ts.BindingPattern,
     table: lua.Expression,
-    propertyAccessStack: ts.PropertyName[] = []
+    propertyAccessStack: ts.PropertyName[] = [],
 ): lua.Statement[] {
     const result: lua.Statement[] = [];
 
@@ -64,7 +64,7 @@ export function transformBindingPattern(
         // Build the path to the table
         const tableExpression = propertyAccessStack.reduce<lua.Expression>(
             (path, property) => lua.createTableIndexExpression(path, transformPropertyName(context, property)),
-            table
+            table,
         );
 
         // The identifier of the new variable
@@ -72,7 +72,7 @@ export function transformBindingPattern(
         // The field to extract
         const elementName = element.propertyName ?? element.name;
         const { precedingStatements, result: propertyName } = transformInPrecedingStatementScope(context, () =>
-            transformPropertyName(context, elementName)
+            transformPropertyName(context, elementName),
         );
         result.push(...precedingStatements); // Keep property's preceding statements in order
 
@@ -105,7 +105,7 @@ export function transformBindingPattern(
                 }
 
                 const excludedPropertiesTable = excludedProperties.map(e =>
-                    lua.createTableFieldExpression(lua.createBooleanLiteral(true), lua.createStringLiteral(e.text, e))
+                    lua.createTableFieldExpression(lua.createBooleanLiteral(true), lua.createStringLiteral(e.text, e)),
                 );
 
                 expression = transformLuaLibFunction(
@@ -113,7 +113,7 @@ export function transformBindingPattern(
                     LuaLibFeature.ObjectRest,
                     undefined,
                     tableExpression,
-                    lua.createTableExpression(excludedPropertiesTable)
+                    lua.createTableExpression(excludedPropertiesTable),
                 );
             } else {
                 expression = transformLuaLibFunction(
@@ -121,13 +121,13 @@ export function transformBindingPattern(
                     LuaLibFeature.ArraySlice,
                     undefined,
                     tableExpression,
-                    lua.createNumericLiteral(index)
+                    lua.createNumericLiteral(index),
                 );
             }
         } else {
             expression = lua.createTableIndexExpression(
                 tableExpression,
-                ts.isObjectBindingPattern(pattern) ? propertyName : lua.createNumericLiteral(index + 1)
+                ts.isObjectBindingPattern(pattern) ? propertyName : lua.createNumericLiteral(index + 1),
             );
         }
 
@@ -143,8 +143,8 @@ export function transformBindingPattern(
                     lua.createBlock([
                         ...initializerPrecedingStatements,
                         lua.createAssignmentStatement(identifier, initializer),
-                    ])
-                )
+                    ]),
+                ),
             );
         }
     }
@@ -156,7 +156,7 @@ export function transformBindingPattern(
 export function transformBindingVariableDeclaration(
     context: TransformationContext,
     bindingPattern: ts.BindingPattern,
-    initializer?: ts.Expression
+    initializer?: ts.Expression,
 ): lua.Statement[] {
     const statements: lua.Statement[] = [];
 
@@ -174,7 +174,7 @@ export function transformBindingVariableDeclaration(
             }
             const { precedingStatements: moveStatements, result: movedExpr } = transformInPrecedingStatementScope(
                 context,
-                () => moveToPrecedingTemp(context, expression, initializer)
+                () => moveToPrecedingTemp(context, expression, initializer),
             );
             statements.push(...moveStatements);
             table = movedExpr;
@@ -198,8 +198,8 @@ export function transformBindingVariableDeclaration(
                     context,
                     vars,
                     context.transformExpression(initializer),
-                    initializer
-                )
+                    initializer,
+                ),
             );
         } else if (ts.isArrayLiteralExpression(initializer)) {
             // Don't unpack array literals
@@ -213,15 +213,15 @@ export function transformBindingVariableDeclaration(
             const unpackedInitializer = createUnpackCall(
                 context,
                 context.transformExpression(initializer),
-                initializer
+                initializer,
             );
             statements.push(
-                ...createLocalOrExportedOrGlobalDeclaration(context, vars, unpackedInitializer, initializer)
+                ...createLocalOrExportedOrGlobalDeclaration(context, vars, unpackedInitializer, initializer),
             );
         }
     } else {
         statements.push(
-            ...createLocalOrExportedOrGlobalDeclaration(context, vars, lua.createNilLiteral(), initializer)
+            ...createLocalOrExportedOrGlobalDeclaration(context, vars, lua.createNilLiteral(), initializer),
         );
     }
 
@@ -234,8 +234,8 @@ export function transformBindingVariableDeclaration(
                     lua.createBinaryExpression(identifier, lua.createNilLiteral(), lua.SyntaxKind.EqualityOperator),
                     lua.createBlock([
                         lua.createAssignmentStatement(identifier, context.transformExpression(element.initializer)),
-                    ])
-                )
+                    ]),
+                ),
             );
         }
     }
@@ -246,7 +246,7 @@ export function transformBindingVariableDeclaration(
 // TODO: FunctionVisitor<ts.VariableDeclaration>
 export function transformVariableDeclaration(
     context: TransformationContext,
-    statement: ts.VariableDeclaration
+    statement: ts.VariableDeclaration,
 ): lua.Statement[] {
     if (statement.initializer && statement.type) {
         const initializerType = context.checker.getTypeAtLocation(statement.initializer);

--- a/src/transpilation/diagnostics.ts
+++ b/src/transpilation/diagnostics.ts
@@ -3,43 +3,43 @@ import { createSerialDiagnosticFactory } from "../utils";
 
 const createDiagnosticFactory = <TArgs extends any[]>(
     getMessage: (...args: TArgs) => string,
-    category: ts.DiagnosticCategory = ts.DiagnosticCategory.Error
+    category: ts.DiagnosticCategory = ts.DiagnosticCategory.Error,
 ) => createSerialDiagnosticFactory((...args: TArgs) => ({ messageText: getMessage(...args), category }));
 
 export const couldNotResolveRequire = createDiagnosticFactory(
     (requirePath: string, containingFile: string) =>
-        `Could not resolve lua source files for require path '${requirePath}' in file ${containingFile}.`
+        `Could not resolve lua source files for require path '${requirePath}' in file ${containingFile}.`,
 );
 
 export const couldNotReadDependency = createDiagnosticFactory(
-    (dependency: string) => `Could not read content of resolved dependency ${dependency}.`
+    (dependency: string) => `Could not read content of resolved dependency ${dependency}.`,
 );
 
 export const toLoadItShouldBeTranspiled = createDiagnosticFactory(
     (kind: string, transform: string) =>
-        `To load "${transform}" ${kind} it should be transpiled or "ts-node" should be installed.`
+        `To load "${transform}" ${kind} it should be transpiled or "ts-node" should be installed.`,
 );
 
 export const couldNotResolveFrom = createDiagnosticFactory(
-    (kind: string, transform: string, base: string) => `Could not resolve "${transform}" ${kind} from "${base}".`
+    (kind: string, transform: string, base: string) => `Could not resolve "${transform}" ${kind} from "${base}".`,
 );
 
 export const shouldHaveAExport = createDiagnosticFactory(
     (kind: string, transform: string, importName: string) =>
-        `"${transform}" ${kind} should have a "${importName}" export.`
+        `"${transform}" ${kind} should have a "${importName}" export.`,
 );
 
 export const transformerShouldBeATsTransformerFactory = createDiagnosticFactory(
     (transform: string) =>
-        `"${transform}" transformer should be a ts.TransformerFactory or an object with ts.TransformerFactory values.`
+        `"${transform}" transformer should be a ts.TransformerFactory or an object with ts.TransformerFactory values.`,
 );
 
 export const couldNotFindBundleEntryPoint = createDiagnosticFactory(
-    (entryPoint: string) => `Could not find bundle entry point '${entryPoint}'. It should be a file in the project.`
+    (entryPoint: string) => `Could not find bundle entry point '${entryPoint}'. It should be a file in the project.`,
 );
 
 export const luaBundleEntryIsRequired = createDiagnosticFactory(
-    () => "'luaBundleEntry' is required when 'luaBundle' is enabled."
+    () => "'luaBundleEntry' is required when 'luaBundle' is enabled.",
 );
 
 export const usingLuaBundleWithInlineMightGenerateDuplicateCode = createSerialDiagnosticFactory(() => ({
@@ -51,11 +51,11 @@ export const usingLuaBundleWithInlineMightGenerateDuplicateCode = createSerialDi
 
 export const cannotBundleLibrary = createDiagnosticFactory(
     () =>
-        'Cannot bundle projects with "buildmode": "library". Projects including the library can still bundle (which will include external library files).'
+        'Cannot bundle projects with "buildmode": "library". Projects including the library can still bundle (which will include external library files).',
 );
 
 export const unsupportedJsxEmit = createDiagnosticFactory(() => 'JSX is only supported with "react" jsx option.');
 
 export const pathsWithoutBaseUrl = createDiagnosticFactory(
-    () => "When configuring 'paths' in tsconfig.json, the option 'baseUrl' must also be provided."
+    () => "When configuring 'paths' in tsconfig.json, the option 'baseUrl' must also be provided.",
 );

--- a/src/transpilation/index.ts
+++ b/src/transpilation/index.ts
@@ -16,7 +16,7 @@ export { TranspiledFile };
 export function transpileFiles(
     rootNames: string[],
     options: CompilerOptions = {},
-    writeFile?: ts.WriteFileCallback
+    writeFile?: ts.WriteFileCallback,
 ): EmitResult {
     const program = ts.createProgram(rootNames, options);
     const preEmitDiagnostics = ts.getPreEmitDiagnostics(program);
@@ -29,7 +29,7 @@ export function transpileFiles(
 export function transpileProject(
     configFileName: string,
     optionsToExtend?: CompilerOptions,
-    writeFile?: ts.WriteFileCallback
+    writeFile?: ts.WriteFileCallback,
 ): EmitResult {
     const parseResult = parseConfigFileWithSystem(configFileName, optionsToExtend);
     if (parseResult.errors.length > 0) {
@@ -93,7 +93,7 @@ export interface TranspileVirtualProjectResult {
 
 export function transpileVirtualProject(
     files: Record<string, string>,
-    options: CompilerOptions = {}
+    options: CompilerOptions = {},
 ): TranspileVirtualProjectResult {
     const program = createVirtualProgram(files, options);
     const preEmitDiagnostics = ts.getPreEmitDiagnostics(program);

--- a/src/transpilation/plugins.ts
+++ b/src/transpilation/plugins.ts
@@ -33,7 +33,7 @@ export interface Plugin {
         program: ts.Program,
         options: CompilerOptions,
         emitHost: EmitHost,
-        result: ProcessedFile[]
+        result: ProcessedFile[],
     ) => ts.Diagnostic[] | void;
 
     /**
@@ -43,7 +43,7 @@ export interface Plugin {
         program: ts.Program,
         options: CompilerOptions,
         emitHost: EmitHost,
-        result: EmitFile[]
+        result: EmitFile[],
     ) => ts.Diagnostic[] | void;
 
     /**
@@ -53,7 +53,7 @@ export interface Plugin {
         program: ts.Program,
         options: CompilerOptions,
         emitHost: EmitHost,
-        result: EmitFile[]
+        result: EmitFile[],
     ) => ts.Diagnostic[] | void;
 
     /**
@@ -64,7 +64,7 @@ export interface Plugin {
         moduleIdentifier: string,
         requiringFile: string,
         options: CompilerOptions,
-        emitHost: EmitHost
+        emitHost: EmitHost,
     ) => string | undefined;
 }
 
@@ -82,7 +82,7 @@ export function getPlugins(program: ts.Program): { diagnostics: ts.Diagnostic[];
             `${optionName}.name`,
             getConfigDirectory(options),
             pluginOption.name,
-            pluginOption.import
+            pluginOption.import,
         );
 
         if (resolveError) diagnostics.push(resolveError);

--- a/src/transpilation/resolve.ts
+++ b/src/transpilation/resolve.ts
@@ -36,7 +36,7 @@ class ResolutionContext {
         public readonly program: ts.Program,
         public readonly options: CompilerOptions,
         private readonly emitHost: EmitHost,
-        private readonly plugins: Plugin[]
+        private readonly plugins: Plugin[],
     ) {
         const unique = [...new Set(options.noResolvePaths)];
         const matchers = unique.map(x => picomatch(x));
@@ -76,7 +76,7 @@ class ResolutionContext {
         if (this.noResolvePaths.find(isMatch => isMatch(required.requirePath))) {
             if (this.options.tstlVerbose) {
                 console.log(
-                    `Skipping module resolution of ${required.requirePath} as it is in the tsconfig noResolvePaths.`
+                    `Skipping module resolution of ${required.requirePath} as it is in the tsconfig noResolvePaths.`,
                 );
             }
             return;
@@ -109,7 +109,7 @@ class ResolutionContext {
                     dependency,
                     requiringFile.fileName,
                     this.options,
-                    this.emitHost
+                    this.emitHost,
                 );
                 if (pluginResolvedPath !== undefined) {
                     // If resolved path is absolute no need to further resolve it
@@ -122,12 +122,12 @@ class ResolutionContext {
                         // If requiring file is in lua module, try to resolve sibling in that file first
                         const resolvedNodeModulesFile = this.resolveLuaDependencyPathFromNodeModules(
                             requiringFile,
-                            pluginResolvedPath
+                            pluginResolvedPath,
                         );
                         if (resolvedNodeModulesFile) {
                             if (this.options.tstlVerbose) {
                                 console.log(
-                                    `Resolved file path for module ${dependency} to path ${pluginResolvedPath} using plugin.`
+                                    `Resolved file path for module ${dependency} to path ${pluginResolvedPath} using plugin.`,
                                 );
                             }
                             return resolvedNodeModulesFile;
@@ -140,7 +140,7 @@ class ResolutionContext {
                     if (fileFromPath) {
                         if (this.options.tstlVerbose) {
                             console.log(
-                                `Resolved file path for module ${dependency} to path ${pluginResolvedPath} using plugin.`
+                                `Resolved file path for module ${dependency} to path ${pluginResolvedPath} using plugin.`,
                             );
                         }
                         return fileFromPath;
@@ -158,7 +158,7 @@ class ResolutionContext {
         // // If the import is relative, always resolve it relative to the requiring file
         // // If the import is not relative, resolve it relative to options.baseUrl if it is set
         const fileDirectory = path.dirname(required.fileName);
-        const relativeTo = isRelative ? fileDirectory : this.options.baseUrl ?? fileDirectory;
+        const relativeTo = isRelative ? fileDirectory : (this.options.baseUrl ?? fileDirectory);
 
         // // Check if file is a file in the project
         const resolvedPath = path.join(relativeTo, targetPath);
@@ -191,7 +191,7 @@ class ResolutionContext {
         replaceRequireInSourceMap(file, required, fallbackRequire, this.options.extension);
 
         this.diagnostics.push(
-            couldNotResolveRequire(required.requirePath, path.relative(getProjectRoot(this.program), file.fileName))
+            couldNotResolveRequire(required.requirePath, path.relative(getProjectRoot(this.program), file.fileName)),
         );
     }
 
@@ -220,7 +220,7 @@ class ResolutionContext {
             const fileFromPaths = this.tryGetModuleNameFromPaths(
                 dependencyPath,
                 this.options.paths,
-                this.options.baseUrl
+                this.options.baseUrl,
             );
             if (fileFromPaths) return fileFromPaths;
         }
@@ -242,7 +242,7 @@ class ResolutionContext {
 
     private resolveLuaDependencyPathFromNodeModules(
         requiringFile: ProcessedFile,
-        dependency: string
+        dependency: string,
     ): string | undefined {
         // We don't know for sure where the lua root is, so guess it is at package root
         const splitPath = path.normalize(requiringFile.fileName).split(path.sep);
@@ -345,7 +345,7 @@ export function resolveDependencies(
     program: ts.Program,
     files: ProcessedFile[],
     emitHost: EmitHost,
-    plugins: Plugin[]
+    plugins: Plugin[],
 ): ResolutionResult {
     const options = program.getCompilerOptions() as CompilerOptions;
 
@@ -383,7 +383,7 @@ function replaceRequireInCode(
     file: ProcessedFile,
     originalRequire: LuaRequire,
     newRequire: string,
-    extension: string | undefined
+    extension: string | undefined,
 ): void {
     const requirePath = requirePathForFile(newRequire, extension);
     file.code = file.code =
@@ -396,7 +396,7 @@ function replaceRequireInSourceMap(
     file: ProcessedFile,
     originalRequire: LuaRequire,
     newRequire: string,
-    extension?: string | undefined
+    extension?: string | undefined,
 ): void {
     const requirePath = requirePathForFile(newRequire, extension);
     if (file.sourceMapNode) {
@@ -404,7 +404,7 @@ function replaceRequireInSourceMap(
             file.sourceMapNode,
             file.sourceMapNode,
             `"${originalRequire.requirePath}"`,
-            `"${requirePath}"`
+            `"${requirePath}"`,
         );
     }
 }
@@ -464,7 +464,7 @@ function fallbackResolve(required: LuaRequire, sourceRootDir: string, fileDir: s
             .normalize(path.join(path.relative(sourceRootDir, fileDir), required.requirePath))
             .split(path.sep)
             .filter(s => s !== "." && s !== "..")
-            .join(path.sep)
+            .join(path.sep),
     );
 }
 

--- a/src/transpilation/transformers.ts
+++ b/src/transpilation/transformers.ts
@@ -9,7 +9,7 @@ export function getTransformers(
     program: ts.Program,
     diagnostics: ts.Diagnostic[],
     customTransformers: ts.CustomTransformers,
-    onSourceFile: (sourceFile: ts.SourceFile) => void
+    onSourceFile: (sourceFile: ts.SourceFile) => void,
 ): ts.CustomTransformers {
     const luaTransformer: ts.TransformerFactory<ts.SourceFile> = () => sourceFile => {
         onSourceFile(sourceFile);
@@ -69,7 +69,7 @@ export const stripParenthesisExpressionsTransformer: ts.TransformerFactory<ts.So
                 node,
                 unwrapParentheses(node.expression),
                 node.typeArguments,
-                node.arguments
+                node.arguments,
             );
         } else if (ts.isVoidExpression(node)) {
             return ts.factory.updateVoidExpression(node, unwrapParentheses(node.expression));
@@ -100,7 +100,7 @@ function loadTransformersFromOptions(program: ts.Program, diagnostics: ts.Diagno
                 `${optionName}.transform`,
                 getConfigDirectory(options),
                 transformerImport.transform,
-                transformerImport.import
+                transformerImport.import,
             );
 
             if (resolveError) diagnostics.push(resolveError);
@@ -144,7 +144,7 @@ type ProgramTransformerFactory = (program: ts.Program, options: Record<string, a
 type ConfigTransformerFactory = (options: Record<string, any>) => Transformer;
 type CompilerOptionsTransformerFactory = (
     compilerOptions: CompilerOptions,
-    options: Record<string, any>
+    options: Record<string, any>,
 ) => Transformer;
 type TypeCheckerTransformerFactory = (typeChecker: ts.TypeChecker, options: Record<string, any>) => Transformer;
 type RawTransformerFactory = Transformer;
@@ -160,7 +160,7 @@ function loadTransformer(
     optionPath: string,
     program: ts.Program,
     factory: unknown,
-    { transform, after = false, afterDeclarations = false, type = "program", ...extraOptions }: TransformerImport
+    { transform, after = false, afterDeclarations = false, type = "program", ...extraOptions }: TransformerImport,
 ): { error?: ts.Diagnostic; transformer?: GroupTransformer } {
     let transformer: Transformer;
     switch (type) {

--- a/src/transpilation/transpile.ts
+++ b/src/transpilation/transpile.ts
@@ -24,7 +24,7 @@ export interface TranspileResult {
 export function getProgramTranspileResult(
     emitHost: EmitHost,
     writeFileResult: ts.WriteFileCallback,
-    { program, sourceFiles: targetSourceFiles, customTransformers = {}, plugins = [] }: TranspileOptions
+    { program, sourceFiles: targetSourceFiles, customTransformers = {}, plugins = [] }: TranspileOptions,
 ): TranspileResult {
     performance.startSection("beforeTransform");
 

--- a/src/transpilation/transpiler.ts
+++ b/src/transpilation/transpiler.ts
@@ -42,7 +42,7 @@ export class Transpiler {
             {
                 ...emitOptions,
                 plugins,
-            }
+            },
         );
 
         const { emitPlan } = this.getEmitPlan(program, transpileDiagnostics, freshFiles, plugins);
@@ -59,7 +59,7 @@ export class Transpiler {
         program: ts.Program,
         plugins: Plugin[],
         emitPlan: EmitFile[],
-        writeFile: ts.WriteFileCallback
+        writeFile: ts.WriteFileCallback,
     ): ts.Diagnostic[] {
         performance.startSection("emit");
 
@@ -110,7 +110,7 @@ export class Transpiler {
         program: ts.Program,
         diagnostics: ts.Diagnostic[],
         files: ProcessedFile[],
-        plugins: Plugin[]
+        plugins: Plugin[],
     ): { emitPlan: EmitFile[] } {
         performance.startSection("getEmitPlan");
         const options = program.getCompilerOptions() as CompilerOptions;
@@ -160,7 +160,7 @@ export class Transpiler {
             const usedFeatures = findUsedLualibFeatures(
                 luaTarget,
                 this.emitHost,
-                resolvedFiles.map(f => f.code)
+                resolvedFiles.map(f => f.code),
             );
             return buildMinimalLualibBundle(usedFeatures, luaTarget, this.emitHost);
         } else {

--- a/src/transpilation/utils.ts
+++ b/src/transpilation/utils.ts
@@ -41,7 +41,7 @@ export function resolvePlugin(
     optionName: string,
     basedir: string,
     query: unknown,
-    importName = "default"
+    importName = "default",
 ): { error?: ts.Diagnostic; result?: unknown } {
     if (typeof query !== "string") {
         return { error: cliDiagnostics.compilerOptionRequiresAValueOfType(optionName, "string") };

--- a/src/tstl.ts
+++ b/src/tstl.ts
@@ -10,7 +10,7 @@ import { isBundleEnabled } from "./CompilerOptions";
 import * as performance from "./measure-performance";
 
 const shouldBePretty = ({ pretty }: ts.CompilerOptions = {}) =>
-    pretty !== undefined ? (pretty as boolean) : ts.sys.writeOutputIsTTY?.() ?? false;
+    pretty !== undefined ? (pretty as boolean) : (ts.sys.writeOutputIsTTY?.() ?? false);
 
 let reportDiagnostic = createDiagnosticReporter(false);
 function updateReportDiagnostic(options?: ts.CompilerOptions): void {
@@ -72,7 +72,7 @@ function executeCommandLine(args: string[]): void {
                 configParseResult.fileNames,
                 configParseResult.projectReferences,
                 configParseResult.options,
-                ts.getConfigFileParsingDiagnostics(configParseResult)
+                ts.getConfigFileParsingDiagnostics(configParseResult),
             );
         }
     } else {
@@ -94,7 +94,7 @@ function performCompilation(
     rootNames: string[],
     projectReferences: readonly ts.ProjectReference[] | undefined,
     options: tstl.CompilerOptions,
-    configFileParsingDiagnostics?: readonly ts.Diagnostic[]
+    configFileParsingDiagnostics?: readonly ts.Diagnostic[],
 ): void {
     if (options.measurePerformance) performance.enableMeasurement();
 
@@ -121,8 +121,8 @@ function performCompilation(
         diagnostics.filter(d => d.category === ts.DiagnosticCategory.Error).length === 0
             ? ts.ExitStatus.Success
             : emitSkipped
-            ? ts.ExitStatus.DiagnosticsPresent_OutputsSkipped
-            : ts.ExitStatus.DiagnosticsPresent_OutputsGenerated;
+              ? ts.ExitStatus.DiagnosticsPresent_OutputsSkipped
+              : ts.ExitStatus.DiagnosticsPresent_OutputsGenerated;
 
     return ts.sys.exit(exitCode);
 }
@@ -134,7 +134,7 @@ function createWatchOfConfigFile(configFileName: string, optionsToExtend: tstl.C
         ts.sys,
         ts.createSemanticDiagnosticsBuilderProgram,
         undefined,
-        createWatchStatusReporter(optionsToExtend)
+        createWatchStatusReporter(optionsToExtend),
     );
 
     updateWatchCompilationHost(watchCompilerHost, optionsToExtend);
@@ -148,7 +148,7 @@ function createWatchOfFilesAndCompilerOptions(rootFiles: string[], options: tstl
         ts.sys,
         ts.createSemanticDiagnosticsBuilderProgram,
         undefined,
-        createWatchStatusReporter(options)
+        createWatchStatusReporter(options),
     );
 
     updateWatchCompilationHost(watchCompilerHost, options);
@@ -157,7 +157,7 @@ function createWatchOfFilesAndCompilerOptions(rootFiles: string[], options: tstl
 
 function updateWatchCompilationHost(
     host: ts.WatchCompilerHost<ts.SemanticDiagnosticsBuilderProgram>,
-    optionsToExtend: tstl.CompilerOptions
+    optionsToExtend: tstl.CompilerOptions,
 ): void {
     let hadErrorLastTime = true;
     const updateConfigFile = createConfigFileUpdater(optionsToExtend);

--- a/src/typescript-internal.d.ts
+++ b/src/typescript-internal.d.ts
@@ -52,7 +52,7 @@ declare module "typescript" {
     export function nodeNextJsonConfigResolver(
         moduleName: string,
         containingFile: string,
-        host: ModuleResolutionHost
+        host: ModuleResolutionHost,
     ): ResolvedModuleWithFailedLookupLocations;
 
     export function pathIsAbsolute(path: string): boolean;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,7 +28,7 @@ export const createDiagnosticFactoryWithCode = <T extends DiagnosticFactory>(cod
             source: "typescript-to-lua",
             ...create(...(args as any)),
         }),
-        { code }
+        { code },
     );
 
 let serialDiagnosticCodeCounter = 100000;
@@ -52,7 +52,7 @@ type NoInfer<T> = [T][T extends any ? 0 : never];
 export function getOrUpdate<K, V>(
     map: Map<K, V> | (K extends object ? WeakMap<K, V> : never),
     key: K,
-    getDefaultValue: () => NoInfer<V>
+    getDefaultValue: () => NoInfer<V>,
 ): V {
     if (!map.has(key)) {
         map.set(key, getDefaultValue());
@@ -67,7 +67,7 @@ export function isNonNull<T>(value: T | null | undefined): value is T {
 
 export function cast<TOriginal, TCast extends TOriginal>(
     item: TOriginal,
-    cast: (item: TOriginal) => item is TCast
+    cast: (item: TOriginal) => item is TCast,
 ): TCast {
     if (cast(item)) {
         return item;

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -19,7 +19,7 @@ expect.extend({
 
         const diagnosticMessages = ts.formatDiagnosticsWithColorAndContext(
             diagnostics.map(tstl.prepareDiagnosticForFormatting),
-            { getCurrentDirectory: () => "", getCanonicalFileName: fileName => fileName, getNewLine: () => "\n" }
+            { getCurrentDirectory: () => "", getCanonicalFileName: fileName => fileName, getNewLine: () => "\n" },
         );
 
         if (this.isNot && expected !== undefined) {
@@ -36,10 +36,10 @@ expect.extend({
                 const message = this.isNot
                     ? diagnosticMessages
                     : expected
-                    ? `Expected:\n${expected.join("\n")}\nReceived:\n${diagnostics
-                          .map(diag => diag.code)
-                          .join("\n")}\n\n${diagnosticMessages}\n`
-                    : `Received: ${this.utils.printReceived([])}\n`;
+                      ? `Expected:\n${expected.join("\n")}\nReceived:\n${diagnostics
+                            .map(diag => diag.code)
+                            .join("\n")}\n\n${diagnosticMessages}\n`
+                      : `Received: ${this.utils.printReceived([])}\n`;
 
                 return matcherHint + "\n\n" + message;
             },

--- a/test/transpile/directories.spec.ts
+++ b/test/transpile/directories.spec.ts
@@ -23,7 +23,7 @@ test.each<DirectoryTestCase>([
     };
 
     const { fileNames, options } = tstl.updateParsedConfigFile(
-        ts.parseJsonConfigFileContent(config, ts.sys, projectPath)
+        ts.parseJsonConfigFileContent(config, ts.sys, projectPath),
     );
 
     const { diagnostics, emittedFiles } = transpileFilesResult(fileNames, options);

--- a/test/transpile/module-resolution.spec.ts
+++ b/test/transpile/module-resolution.spec.ts
@@ -52,7 +52,7 @@ describe("basic module resolution", () => {
     test("can resolve package depencency with a dependency on another package", () => {
         // Declarations in the node_modules directory
         expect(projectWithNodeModules.getLuaExecutionResult().moduleWithDependencyResult).toBe(
-            "Calling dependency: foo from lua module with decls"
+            "Calling dependency: foo from lua module with decls",
         );
     });
 
@@ -396,7 +396,7 @@ test("module resolution should not try to resolve @noResolution annotation", () 
                     function encode(this: void, data: unknown): string;
                     function decode(this: void, data: string): unknown;
                 }
-            `
+            `,
         )
         .expectToHaveNoDiagnostics();
 });
@@ -422,7 +422,7 @@ describe("module resolution should not try to resolve modules in noResolvePaths"
                 "directimport.d.ts",
                 `declare module "directimport" {
                     export function foo(): void;
-                }`
+                }`,
             )
             .setOptions({ noResolvePaths: ["directimport"] })
             .expectToHaveNoDiagnostics();
@@ -441,7 +441,7 @@ describe("module resolution should not try to resolve modules in noResolvePaths"
                 require("a.b.c.foo")
 
                 return { foo = function() return "bar" end }
-            `
+            `,
             )
             .setOptions({ noResolvePaths: ["a.b.c.foo", "somethingExtra", "dontResolveThis"] })
             .expectToHaveNoDiagnostics();
@@ -463,13 +463,13 @@ describe("module resolution should not try to resolve modules in noResolvePaths"
                 `export function foo()
                 {
                     return 'foo';
-                }`
+                }`,
             )
             .addExtraFile(
                 "ignoreme.d.ts",
                 `declare module "ignoreme" {
                     export function foo(): void;
-                }`
+                }`,
             )
             .setOptions({ noResolvePaths: ["ignore*"] })
             .expectToHaveNoDiagnostics()
@@ -500,7 +500,7 @@ describe("module resolution should not try to resolve modules in noResolvePaths"
                 `
                 require("ignoreme!")
                 require("i.g.n.o.r.e")
-            `
+            `,
             )
             .setOptions({ noResolvePaths: ["**"] })
             .expectToHaveNoDiagnostics();
@@ -521,7 +521,7 @@ test("module resolution should not rewrite @NoResolution requires in library mod
                     function encode(this: void, data: unknown): string;
                     function decode(this: void, data: string): unknown;
                 }
-            `
+            `,
         )
         .setOptions({ buildMode: BuildMode.Library })
         .getLuaResult();
@@ -578,25 +578,25 @@ test("module resolution uses baseURL to resolve imported files", () => {
             "myproject/mydeps/dep1.ts",
             `
                 export function foo() { return "foo"; }
-            `
+            `,
         )
         .addExtraFile(
             "myproject/mydeps/dep2.ts",
             `
                 export function bar() { return "bar"; }
-            `
+            `,
         )
         .addExtraFile(
             "myproject/mydeps/luadep.d.ts",
             `
                 export function baz(): string;
-            `
+            `,
         )
         .addExtraFile(
             "myproject/mydeps/luadep.lua",
             `
                 return { baz = function() return "baz" end }
-            `
+            `,
         )
         .setOptions({ baseUrl: "./myproject/mydeps" })
         .expectToEqual({
@@ -615,7 +615,7 @@ test("includes lualib_bundle when external lua requests it", () => {
             "lualibuser.d.ts",
             `
                 export const foo: string[];
-            `
+            `,
         )
         .addExtraFile(
             "lualibuser.lua",
@@ -628,7 +628,7 @@ test("includes lualib_bundle when external lua requests it", () => {
                 __TS__ArrayPush(result, "bar")
 
                 return { foo = result }
-            `
+            `,
         )
         .expectToEqual({
             foo: ["foo", "bar"],

--- a/test/transpile/plugins/afterPrint.ts
+++ b/test/transpile/plugins/afterPrint.ts
@@ -6,7 +6,7 @@ const plugin: tstl.Plugin = {
         program: ts.Program,
         options: tstl.CompilerOptions,
         emitHost: tstl.EmitHost,
-        result: tstl.ProcessedFile[]
+        result: tstl.ProcessedFile[],
     ) {
         void program;
         void options;

--- a/test/transpile/plugins/arguments.ts
+++ b/test/transpile/plugins/arguments.ts
@@ -14,11 +14,11 @@ export default function plugin(options: Options): tstl.Plugin {
                     tstl.createTableExpression([
                         tstl.createTableFieldExpression(
                             tstl.createStringLiteral(options.name),
-                            tstl.createStringLiteral("name")
+                            tstl.createStringLiteral("name"),
                         ),
                         tstl.createTableFieldExpression(
                             tstl.createBooleanLiteral(options.option),
-                            tstl.createStringLiteral("option")
+                            tstl.createStringLiteral("option"),
                         ),
                     ]),
                 ]),

--- a/test/transpile/plugins/moduleResolution.ts
+++ b/test/transpile/plugins/moduleResolution.ts
@@ -9,7 +9,7 @@ const plugin: tstl.Plugin = {
                 "module-resolution",
                 "project-with-module-resolution-plugin",
                 "lua_sources",
-                "absolutebar.lua"
+                "absolutebar.lua",
             );
         }
 

--- a/test/transpile/plugins/plugins.spec.ts
+++ b/test/transpile/plugins/plugins.spec.ts
@@ -18,7 +18,7 @@ test("printer in bundle", () => {
             "otherfile.ts",
             `
                 const bar = "bar";
-            `
+            `,
         )
         .setOptions({ luaPlugins: [{ name: path.join(__dirname, "printer.ts") }] })
         .expectToHaveNoDiagnostics()
@@ -79,7 +79,7 @@ test.each(["namespace", "module"])("%s with TS transformer plugin", moduleOrName
                     return false;
                 }
             }
-            `
+            `,
         )
         .setOptions({ plugins: [{ transform: path.join(__dirname, "transformer-plugin.ts") }] })
         .expectNoExecutionError();
@@ -105,7 +105,7 @@ test("afterPrint plugin", () => {
             "extrafile.ts",
             `
                 console.log("Hello, Mars!");
-            `
+            `,
         )
         .setOptions({ luaPlugins: [{ name: path.join(__dirname, "afterPrint.ts") }] })
         .getLuaResult();
@@ -126,7 +126,7 @@ test("beforeEmit plugin", () => {
             "extrafile.ts",
             `
             console.log("Hello, Mars!");
-        `
+        `,
         )
         .setOptions({ luaPlugins: [{ name: path.join(__dirname, "beforeEmit.ts") }] })
         .getLuaResult();
@@ -149,7 +149,7 @@ test("beforeEmit plugin bundle", () => {
             "extrafile.ts",
             `
             console.log("Hello, Mars!");
-        `
+        `,
         )
         .setOptions({ luaPlugins: [{ name: path.join(__dirname, "beforeEmit.ts") }] })
         .getLuaResult();
@@ -171,7 +171,7 @@ test("afterEmit plugin", () => {
             "extrafile.ts",
             `
                 console.log("Hello, Mars!");
-            `
+            `,
         )
         .setOptions({ luaPlugins: [{ name: path.join(__dirname, "afterEmit.ts") }] })
         .getLuaResult();

--- a/test/transpile/project.spec.ts
+++ b/test/transpile/project.spec.ts
@@ -11,7 +11,7 @@ test("should transpile", () => {
         .getLuaResult();
 
     expect(
-        transpiledFiles.map(f => ({ filePath: path.relative(projectDir, f.outPath), lua: f.lua }))
+        transpiledFiles.map(f => ({ filePath: path.relative(projectDir, f.outPath), lua: f.lua })),
     ).toMatchSnapshot();
 });
 

--- a/test/unit/assignments.spec.ts
+++ b/test/unit/assignments.spec.ts
@@ -54,7 +54,7 @@ test.each(["let result;", "const result = null;", "const result = undefined;"])(
             ${declaration}
             return result;
         `.expectToEqual(undefined);
-    }
+    },
 );
 
 test.each(["x = y", "x += y"])("Assignment expressions (%p)", expression => {
@@ -84,7 +84,7 @@ test.each(["o.p = x", "a[0] = x", "o.p = a[0]", "o.p = a[0] = x"])(
             let a = ["a"];
             return ${expression};
         `.expectToMatchJsResult();
-    }
+    },
 );
 
 test.each([

--- a/test/unit/builtins/array.spec.ts
+++ b/test/unit/builtins/array.spec.ts
@@ -572,7 +572,7 @@ test.each([{ array: [1, 2, 3] }, { array: [1, 2, 3, 4] }, { array: [1] }, { arra
             array.reverse();
             return array;
         `.expectToMatchJsResult();
-    }
+    },
 );
 
 test.each([{ array: [1, 2, 3] }, { array: [1] }, { array: [] }])("array.shift (%p)", ({ array }) => {
@@ -679,7 +679,7 @@ test.each([{ array: [] }, { array: ["a", "b", "c"] }, { array: [{ foo: "foo" }, 
             }
             return result;
         `.expectToMatchJsResult();
-    }
+    },
 );
 
 test("array.entries indirect use", () => {
@@ -733,7 +733,7 @@ test.each(["[]", '"hello"', "42", "[1, 2, 3]", '{ a: "foo", b: "bar" }'])(
     "Array.isArray matches JavaScript (%p)",
     valueString => {
         util.testExpression`Array.isArray(${valueString})`.expectToMatchJsResult();
-    }
+    },
 );
 
 test("Array.isArray returns true for empty objects", () => {
@@ -775,7 +775,7 @@ test.each(["[1, undefined, 3]", "[1, null, 3]", "[1, undefined, 2, null]"])(
     "not allowed to use null or undefined in array literals (%p)",
     literal => {
         util.testExpression(literal).expectToHaveDiagnostics([undefinedInArrayLiteral.code]);
-    }
+    },
 );
 
 test("not allowed to use null or undefined in array literals ([undefined, null, 1])", () => {

--- a/test/unit/builtins/async-await.spec.ts
+++ b/test/unit/builtins/async-await.spec.ts
@@ -143,7 +143,7 @@ test.each(["async function abc() {", "const abc = async () => {"])(
                 "resolving awaiting promise",
                 "abc return data",
             ]);
-    }
+    },
 );
 
 test.each(["async function abc() {", "const abc = async () => {"])(
@@ -185,7 +185,7 @@ test.each(["async function abc() {", "const abc = async () => {"])(
                 "resolving awaiting promise",
                 ["data1", "data2", "data3"],
             ]);
-    }
+    },
 );
 
 test("can make inline async functions", () => {
@@ -509,7 +509,7 @@ test.each(["async function abc() {", "const abc = async () => {"])(
     `
             .setTsHeader(promiseTestLib)
             .expectToEqual(["resolving first promise", "resolved data", "run abc", "caught error", "test throw"]);
-    }
+    },
 );
 
 test.each(["async function abc() {", "const abc = async () => {"])(
@@ -543,7 +543,7 @@ test.each(["async function abc() {", "const abc = async () => {"])(
                     stack: expect.stringContaining("stack traceback"),
                 },
             ]);
-    }
+    },
 );
 
 // https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1105
@@ -570,7 +570,7 @@ describe("try/catch in async function", () => {
                 builder.expectToHaveDiagnostics([unsupportedForTargetButOverrideAvailable.code]),
             [LuaTarget.Lua51]: builder =>
                 builder.expectToHaveDiagnostics([unsupportedForTargetButOverrideAvailable.code]),
-        }
+        },
     );
 
     util.testEachVersion(
@@ -590,13 +590,13 @@ describe("try/catch in async function", () => {
         `,
         {
             ...util.expectEachVersionExceptJit(builder =>
-                builder.expectToEqual({ reason: "an error occurred in the async function: test error" })
+                builder.expectToEqual({ reason: "an error occurred in the async function: test error" }),
             ),
             [LuaTarget.Lua50]: builder =>
                 builder.expectToHaveDiagnostics([unsupportedForTargetButOverrideAvailable.code]),
             [LuaTarget.Lua51]: builder =>
                 builder.expectToHaveDiagnostics([unsupportedForTargetButOverrideAvailable.code]),
-        }
+        },
     );
 
     util.testEachVersion(
@@ -620,13 +620,13 @@ describe("try/catch in async function", () => {
         `,
         {
             ...util.expectEachVersionExceptJit(builder =>
-                builder.expectToEqual({ reason: "an error occurred in the async function: test error" })
+                builder.expectToEqual({ reason: "an error occurred in the async function: test error" }),
             ),
             [LuaTarget.Lua50]: builder =>
                 builder.expectToHaveDiagnostics([unsupportedForTargetButOverrideAvailable.code]),
             [LuaTarget.Lua51]: builder =>
                 builder.expectToHaveDiagnostics([unsupportedForTargetButOverrideAvailable.code]),
-        }
+        },
     );
 
     test("try/finally in async function", () => {

--- a/test/unit/builtins/loading.spec.ts
+++ b/test/unit/builtins/loading.spec.ts
@@ -44,7 +44,7 @@ describe("luaLibImport", () => {
 local ____lualib = require("lualib_bundle")
 local __TS__ArrayIndexOf = ____lualib.__TS__ArrayIndexOf
 __TS__ArrayIndexOf({}, 1)
-            `
+            `,
             )
             // note: indent matters in above code, because searching for lualib checks for start & end of line
             .tap(testLualibOnlyHasArrayIndexOf)
@@ -63,7 +63,7 @@ test.each([
 
 test("lualib should not include tstl header", () => {
     util.testExpression`[0].indexOf(1)`.tap(builder =>
-        expect(builder.getMainLuaCodeChunk()).not.toContain("Generated with")
+        expect(builder.getMainLuaCodeChunk()).not.toContain("Generated with"),
     );
 });
 

--- a/test/unit/builtins/map.spec.ts
+++ b/test/unit/builtins/map.spec.ts
@@ -50,7 +50,7 @@ test("map foreach", () => {
         `let mymap = new Map([["a", 2],["b", 3],["c", 4]]);
         let count = 0;
         mymap.forEach(i => count += i);
-        return count;`
+        return count;`,
     ).expectToMatchJsResult();
 });
 

--- a/test/unit/builtins/math.spec.ts
+++ b/test/unit/builtins/math.spec.ts
@@ -101,11 +101,11 @@ util.testEachVersion("Math.atan2", () => util.testExpression`Math.atan2(4, 5)`, 
 util.testEachVersion(
     "Math.atan2(4, 5)",
     () => util.testExpression`Math.atan2(4, 5)`,
-    util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+    util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
 );
 
 util.testEachVersion(
     "Math.pow(3, 5)",
     () => util.testExpression`Math.pow(3, 5)`,
-    util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+    util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
 );

--- a/test/unit/builtins/numbers.spec.ts
+++ b/test/unit/builtins/numbers.spec.ts
@@ -136,7 +136,7 @@ describe.each(["parseInt", "parseFloat", "Number.parseInt", "Number.parseFloat"]
         test.each([" 3", "          4", "   -231", "    1px"])("leading whitespace (%s)", numberString => {
             util.testExpression`${parseFunction}("${numberString}")`.expectToMatchJsResult();
         });
-    }
+    },
 );
 
 test.each(["Infinity", "-Infinity", "   -Infinity"])("parseFloat handles Infinity", numberString => {

--- a/test/unit/builtins/object.spec.ts
+++ b/test/unit/builtins/object.spec.ts
@@ -32,7 +32,7 @@ test.each(["[]", '[["a", 1], ["b", 2]]', '[["a", 1], ["a", 2]]', 'new Map([["foo
     "Object.fromEntries(%s)",
     entries => {
         util.testExpression`Object.fromEntries(${entries})`.expectToMatchJsResult();
-    }
+    },
 );
 
 describe(".toString()", () => {

--- a/test/unit/builtins/string.spec.ts
+++ b/test/unit/builtins/string.spec.ts
@@ -77,7 +77,7 @@ describe.each(["replace", "replaceAll"])("string.%s", method => {
     test.each(testCases)("string replacer %p", ({ inp, searchValue, replaceValue }) => {
         util.testExpression`"${inp}${inp}".${method}(${util.formatCode(
             searchValue,
-            replaceValue
+            replaceValue,
         )})`.expectToMatchJsResult();
     });
 
@@ -166,7 +166,7 @@ test.each([{ inp: "0123456789", args: [] }, { inp: "0123456789", args: [undefine
     "string.slice (%p)",
     ({ inp, args }) => {
         util.testExpression`"${inp}".slice(${util.formatCode(...args)})`.expectToMatchJsResult();
-    }
+    },
 );
 
 test.each(stringPartCases)("string.substring (%p)", ({ inp, args }) => {
@@ -396,7 +396,7 @@ test.each(["string | undefined", "string | null", "null | string", "null | undef
     `
             .setOptions({ strictNullChecks: true })
             .expectToMatchJsResult();
-    }
+    },
 );
 
 // https://github.com/TypeScriptToLua/TypeScriptToLua/issues/1406

--- a/test/unit/builtins/weakMap.spec.ts
+++ b/test/unit/builtins/weakMap.spec.ts
@@ -100,5 +100,5 @@ test.each(["clear()", "keys()", "values()", "entries()", "forEach(() => {})"])(
         const testBuilder = util.testFunction(`(new WeakMap() as any).${call}`);
         const luaResult = testBuilder.getLuaExecutionResult();
         expect(luaResult.message).toContain("attempt to call a nil value");
-    }
+    },
 );

--- a/test/unit/builtins/weakSet.spec.ts
+++ b/test/unit/builtins/weakSet.spec.ts
@@ -66,5 +66,5 @@ test.each(["clear()", "keys()", "values()", "entries()", "forEach(() => {})"])(
         const testBuilder = util.testFunction(`(new WeakSet() as any).${call}`);
         const luaResult = testBuilder.getLuaExecutionResult();
         expect(luaResult.message).toContain("attempt to call a nil value");
-    }
+    },
 );

--- a/test/unit/bundle.spec.ts
+++ b/test/unit/bundle.spec.ts
@@ -52,7 +52,7 @@ test("entry point in directory", () => {
             "main/main.ts",
             `
                 export { value } from "../module";
-            `
+            `,
         )
         .addExtraFile("module.ts", "export const value = true")
         .setEntryPoint("main/main.ts")
@@ -86,7 +86,7 @@ test("LuaLibImportKind.Inline generates a warning", () => {
         .setOptions({ luaLibImport: LuaLibImportKind.Inline })
         .expectDiagnosticsToMatchSnapshot(
             [diagnosticFactories.usingLuaBundleWithInlineMightGenerateDuplicateCode.code],
-            true
+            true,
         )
         .expectToEqual({ result: [1, 2, 3] });
 });
@@ -104,7 +104,7 @@ test("cyclic imports", () => {
                 import * as a from "./main";
                 export const value = a.a;
                 export const lazyValue = () => a.a;
-            `
+            `,
         )
         .expectToEqual(new util.ExecutionError("stack overflow"));
 });
@@ -120,14 +120,14 @@ test("does not evaluate files multiple times", () => {
             "otherfile.ts",
             `
                 import "./countingfile";
-            `
+            `,
         )
         .addExtraFile(
             "countingfile.ts",
             `
                 declare var _count: number | undefined;
                 _count = (_count ?? 0) + 1;
-            `
+            `,
         )
         .expectToEqual({ count: 1 });
 });

--- a/test/unit/classes/classes.spec.ts
+++ b/test/unit/classes/classes.spec.ts
@@ -905,7 +905,7 @@ test("get inherted __index member from super (DotA 2 inheritance) (#1537)", () =
             // Connect class 'Connected' to 'traditional' class A
             setmetatable(Connected.prototype, {
                 __index: A
-            });`
+            });`,
         )
         .expectToEqual("foo");
 });

--- a/test/unit/classes/decorators.spec.ts
+++ b/test/unit/classes/decorators.spec.ts
@@ -159,7 +159,7 @@ test("exported class with decorator", () => {
                 foo() {
                     return "foo";
                 }
-            }`
+            }`,
         )
         .expectToEqual({ result: "overridden" });
 });
@@ -185,7 +185,7 @@ test("default exported class with decorator", () => {
                 foo() {
                     return "foo";
                 }
-            }`
+            }`,
         )
         .expectToEqual({ result: "overridden" });
 });
@@ -546,7 +546,7 @@ describe("legacy experimentalDecorators", () => {
                 `
                     .setOptions({ experimentalDecorators: true })
                     .expectToMatchJsResult();
-            }
+            },
         );
     });
 
@@ -572,7 +572,7 @@ describe("legacy experimentalDecorators", () => {
                     foo() {
                         return "foo";
                     }
-                }`
+                }`,
             )
             .setOptions({ experimentalDecorators: true })
             .expectToEqual({ result: "overridden" });
@@ -599,7 +599,7 @@ describe("legacy experimentalDecorators", () => {
                     foo() {
                         return "foo";
                     }
-                }`
+                }`,
             )
             .setOptions({ experimentalDecorators: true })
             .expectToEqual({ result: "overridden" });

--- a/test/unit/conditionals.spec.ts
+++ b/test/unit/conditionals.spec.ts
@@ -154,7 +154,7 @@ test.each(["string", "number", "string | number"])(
             .setTsHeader(`declare var condition: ${type};`)
             .setOptions({ strict: true })
             .expectToHaveDiagnostics([truthyOnlyConditionalValue.code]);
-    }
+    },
 );
 
 test.each(["string", "number", "string | number"])("Warning can be disabled when strict is true (%p)", type => {
@@ -175,7 +175,7 @@ test.each(["string", "number", "string | number"])(
             .setTsHeader(`declare var condition: ${type};`)
             .setOptions({ strict: true })
             .expectToHaveDiagnostics([truthyOnlyConditionalValue.code]);
-    }
+    },
 );
 
 test.each(["string", "number", "string | number"])(
@@ -187,7 +187,7 @@ test.each(["string", "number", "string | number"])(
             .setTsHeader(`declare var condition: ${type};`)
             .setOptions({ strict: true })
             .expectToHaveDiagnostics([truthyOnlyConditionalValue.code]);
-    }
+    },
 );
 
 test.each(["string", "number", "string | number"])(
@@ -197,7 +197,7 @@ test.each(["string", "number", "string | number"])(
             .setTsHeader(`declare var condition: ${type};`)
             .setOptions({ strict: true })
             .expectToHaveDiagnostics([truthyOnlyConditionalValue.code]);
-    }
+    },
 );
 
 test.each(["string", "number", "string | number"])("No warning when using element index in condition (%p)", type => {

--- a/test/unit/enum.spec.ts
+++ b/test/unit/enum.spec.ts
@@ -199,7 +199,7 @@ test("enum merging multiple files", () => {
             `enum TestEnum {
                 C = 3,
                 D
-            }`
+            }`,
         )
         .expectToMatchJsResult();
 });

--- a/test/unit/expressions.spec.ts
+++ b/test/unit/expressions.spec.ts
@@ -22,7 +22,7 @@ for (const expression of ["3+4", "5-2", "6*3", "6**3", "20/5", "15/10", "15%3"])
     util.testEachVersion(
         `Binary expressions basic numeric (${expression})`,
         () => util.testExpression(expression),
-        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
     );
 }
 
@@ -30,7 +30,7 @@ test.each(["1==1", "1===1", "1!=1", "1!==1", "1>1", "1>=1", "1<1", "1<=1", "1&&1
     "Binary expressions basic boolean (%p)",
     input => {
         util.testExpression(input).expectToMatchJsResult();
-    }
+    },
 );
 
 test.each(["'key' in obj", "'existingKey' in obj", "0 in obj", "9 in obj"])("Binary expression in (%p)", input => {
@@ -114,7 +114,7 @@ test.each(["1+1", "-1+1", "1*30+4", "1*(3+4)", "1*(3+4*2)", "10-(4+5)"])(
     "Binary expressions ordering parentheses (%p)",
     input => {
         util.testExpression(input).expectLuaToMatchSnapshot();
-    }
+    },
 );
 
 test("Assignment order of operations is preserved", () => {

--- a/test/unit/functions/functions.spec.ts
+++ b/test/unit/functions/functions.spec.ts
@@ -34,7 +34,7 @@ test.each(["b => a = b", "b => a += b", "b => a -= b", "b => a *= b", "b => a /=
             lambda(5);
             return a;
         `.expectToMatchJsResult();
-    }
+    },
 );
 
 test.each([{ args: [] }, { args: [1] }, { args: [1, 2] }])("Arrow default values (%p)", ({ args }) => {
@@ -71,7 +71,7 @@ test.each([{ inp: [] }, { inp: [5] }, { inp: [1, 2] }])("Function Default Values
 
     util.testFunction(
         `let add = function(a: number = 3, b: number = 4) { return a+b; };
-        return add(${callArgs});`
+        return add(${callArgs});`,
     ).expectToMatchJsResult();
 });
 
@@ -275,7 +275,7 @@ test.each([tstl.LuaTarget.Lua50, tstl.LuaTarget.Lua51, tstl.LuaTarget.Universal]
         `
             .setOptions({ luaTarget })
             .expectDiagnosticsToMatchSnapshot([unsupportedForTarget.code]);
-    }
+    },
 );
 
 test("Recursive function definition", () => {

--- a/test/unit/functions/generators.spec.ts
+++ b/test/unit/functions/generators.spec.ts
@@ -167,5 +167,5 @@ util.testEachVersion(
         ...util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
         [LuaTarget.Lua50]: builder => builder.expectToHaveDiagnostics([unsupportedForTarget.code]),
         [LuaTarget.Lua51]: builder => builder.expectToHaveDiagnostics([unsupportedForTarget.code]),
-    }
+    },
 );

--- a/test/unit/functions/noImplicitSelfOption.spec.ts
+++ b/test/unit/functions/noImplicitSelfOption.spec.ts
@@ -24,7 +24,7 @@ test.each(["\\", "/"])("transpileFiles handles paths with noImplicitSelf and %s 
             `${projectDir}${separator}otherFile.ts`,
         ],
         { noImplicitSelf: true },
-        (fileName, text) => (emittedFiles[fileName] = text)
+        (fileName, text) => (emittedFiles[fileName] = text),
     );
     expect(diagnostics).toHaveLength(0);
     expect(Object.keys(emittedFiles)).not.toHaveLength(0);

--- a/test/unit/functions/noSelfAnnotation.spec.ts
+++ b/test/unit/functions/noSelfAnnotation.spec.ts
@@ -97,7 +97,7 @@ test("respect noSelfInFile over noImplicitSelf (func declared in other file)", (
             /** @noSelfInFile **/
             export const func: Function = () => 1;
             export const result = func(2);
-            `
+            `,
         )
         .expectToMatchJsResult()
         .getLuaResult();

--- a/test/unit/functions/validation/functionExpressionTypeInference.spec.ts
+++ b/test/unit/functions/validation/functionExpressionTypeInference.spec.ts
@@ -38,7 +38,7 @@ test.each(["(this: void, s: string) => string", "(this: any, s: string) => strin
         `
             .setTsHeader(header)
             .expectToMatchJsResult();
-    }
+    },
 );
 
 test.each(["s => s", "(s => s)", "function(s) { return s; }", "(function(s) { return s; })"])(
@@ -54,7 +54,7 @@ test.each(["s => s", "(s => s)", "function(s) { return s; }", "(function(s) { re
             const foo = new Foo();
             return foo.func("a") + foo.method("b") + Foo.staticFunc("c") + Foo.staticMethod("d");
         `.expectToMatchJsResult();
-    }
+    },
 );
 
 test.each([

--- a/test/unit/functions/validation/functionPermutations.ts
+++ b/test/unit/functions/validation/functionPermutations.ts
@@ -375,7 +375,7 @@ export const noSelfTestFunctionType = "(this: void, s: string) => string";
 type TestFunctionCast = [
     /* testFunction: */ TestFunction,
     /* castedFunction: */ string,
-    /* isSelfConversion?: */ boolean?
+    /* isSelfConversion?: */ boolean?,
 ];
 export const validTestMethodCasts: TestFunctionCast[] = [
     [selfTestFunctions[0], `<${anonTestFunctionType}>(${selfTestFunctions[0].value})`],
@@ -406,7 +406,7 @@ export const invalidTestFunctionCasts: TestFunctionCast[] = [
 export type TestFunctionAssignment = [
     /* testFunction: */ TestFunction,
     /* functionType: */ string,
-    /* isSelfConversion?: */ boolean?
+    /* isSelfConversion?: */ boolean?,
 ];
 export const validTestMethodAssignments: TestFunctionAssignment[] = [
     ...selfTestFunctions.map((f): TestFunctionAssignment => [f, anonTestFunctionType]),

--- a/test/unit/functions/validation/invalidFunctionAssignments.spec.ts
+++ b/test/unit/functions/validation/invalidFunctionAssignments.spec.ts
@@ -18,9 +18,9 @@ test.each(invalidTestFunctionAssignments)(
             const fn: ${functionType} = ${testFunction.value};
         `.expectDiagnosticsToMatchSnapshot(
             [isSelfConversion ? unsupportedSelfFunctionConversion.code : unsupportedNoSelfFunctionConversion.code],
-            true
+            true,
         );
-    }
+    },
 );
 
 test.each(invalidTestMethodAssignments)(
@@ -31,9 +31,9 @@ test.each(invalidTestMethodAssignments)(
             const obj: { fn: ${functionType} } = {fn: ${testFunction.value}};
         `.expectDiagnosticsToMatchSnapshot(
             [isSelfConversion ? unsupportedSelfFunctionConversion.code : unsupportedNoSelfFunctionConversion.code],
-            true
+            true,
         );
-    }
+    },
 );
 
 test.each(invalidTestFunctionAssignments)(
@@ -45,9 +45,9 @@ test.each(invalidTestFunctionAssignments)(
             fn = ${testFunction.value};
         `.expectDiagnosticsToMatchSnapshot(
             [isSelfConversion ? unsupportedSelfFunctionConversion.code : unsupportedNoSelfFunctionConversion.code],
-            true
+            true,
         );
-    }
+    },
 );
 
 test.each(invalidTestMethodAssignments)(
@@ -59,9 +59,9 @@ test.each(invalidTestMethodAssignments)(
             obj = {fn: ${testFunction.value}};
         `.expectDiagnosticsToMatchSnapshot(
             [isSelfConversion ? unsupportedSelfFunctionConversion.code : unsupportedNoSelfFunctionConversion.code],
-            true
+            true,
         );
-    }
+    },
 );
 
 test.each(invalidTestFunctionCasts)("Invalid function assignment with cast (%p)", (testFunction, castedFunction) => {
@@ -71,7 +71,7 @@ test.each(invalidTestFunctionCasts)("Invalid function assignment with cast (%p)"
         fn = ${castedFunction};
     `.expectDiagnosticsToMatchSnapshot(
         [unsupportedNoSelfFunctionConversion.code, unsupportedSelfFunctionConversion.code],
-        true
+        true,
     );
 });
 
@@ -86,9 +86,9 @@ test.each(invalidTestFunctionCasts)(
             isSelfConversion
                 ? [unsupportedSelfFunctionConversion.code, unsupportedNoSelfFunctionConversion.code]
                 : [unsupportedNoSelfFunctionConversion.code, unsupportedSelfFunctionConversion.code],
-            true
+            true,
         );
-    }
+    },
 );
 
 test.each(invalidTestFunctionAssignments)(
@@ -100,9 +100,9 @@ test.each(invalidTestFunctionAssignments)(
             takesFunction(${testFunction.value});
         `.expectDiagnosticsToMatchSnapshot(
             [isSelfConversion ? unsupportedSelfFunctionConversion.code : unsupportedNoSelfFunctionConversion.code],
-            true
+            true,
         );
-    }
+    },
 );
 
 test.each(invalidTestMethodAssignments)(
@@ -114,9 +114,9 @@ test.each(invalidTestMethodAssignments)(
             takesObjectWithMethod({fn: ${testFunction.value}});
         `.expectDiagnosticsToMatchSnapshot(
             [isSelfConversion ? unsupportedSelfFunctionConversion.code : unsupportedNoSelfFunctionConversion.code],
-            true
+            true,
         );
-    }
+    },
 );
 
 test("Invalid lua lib function argument", () => {
@@ -134,7 +134,7 @@ test.each(invalidTestFunctionCasts)("Invalid function argument with cast (%p)", 
         takesFunction(${castedFunction});
     `.expectDiagnosticsToMatchSnapshot(
         [unsupportedNoSelfFunctionConversion.code, unsupportedSelfFunctionConversion.code],
-        true
+        true,
     );
 });
 
@@ -147,9 +147,9 @@ test.each(invalidTestFunctionAssignments)(
             takesFunction(${testFunction.value});
         `.expectDiagnosticsToMatchSnapshot(
             [isSelfConversion ? unsupportedSelfFunctionConversion.code : unsupportedNoSelfFunctionConversion.code],
-            true
+            true,
         );
-    }
+    },
 );
 
 test.each(invalidTestFunctionAssignments)(
@@ -162,9 +162,9 @@ test.each(invalidTestFunctionAssignments)(
             }
         `.expectDiagnosticsToMatchSnapshot(
             [isSelfConversion ? unsupportedSelfFunctionConversion.code : unsupportedNoSelfFunctionConversion.code],
-            true
+            true,
         );
-    }
+    },
 );
 
 test.each(invalidTestFunctionCasts)(
@@ -179,9 +179,9 @@ test.each(invalidTestFunctionCasts)(
             isSelfConversion
                 ? [unsupportedSelfFunctionConversion.code, unsupportedNoSelfFunctionConversion.code]
                 : [unsupportedNoSelfFunctionConversion.code, unsupportedSelfFunctionConversion.code],
-            true
+            true,
         );
-    }
+    },
 );
 
 test("Invalid function tuple assignment", () => {
@@ -237,7 +237,7 @@ test("Does not fail on union type signatures (#896)", () => {
             [key: string]: (this: void) => void;
         }      
         declare function foo<T extends 'a' | 'b'>(callback: Events[T]): void;
-    `
+    `,
         )
         .expectToHaveDiagnostics([unsupportedOverloadAssignment.code]);
 });

--- a/test/unit/functions/validation/validFunctionAssignments.spec.ts
+++ b/test/unit/functions/validation/validFunctionAssignments.spec.ts
@@ -64,7 +64,7 @@ test.each(validTestMethodCasts)(
         `
             .setTsHeader(testFunction.definition ?? "")
             .expectToMatchJsResult();
-    }
+    },
 );
 
 test.each(validTestFunctionAssignments)("Valid function argument (%p)", (testFunction, functionType) => {
@@ -244,7 +244,7 @@ test("Does not fail on union type signatures (#896)", () => {
             [key: string]: Function;
         }      
         declare function foo<T extends 'a' | 'b'>(callback: Events[T]): void;
-    `
+    `,
         )
         .expectToHaveNoDiagnostics();
 });

--- a/test/unit/hoisting.spec.ts
+++ b/test/unit/hoisting.spec.ts
@@ -56,7 +56,7 @@ test("Namespace Function Hoisting", () => {
                 foo = bar();
                 function bar() { return "bar"; }
             }
-        `
+        `,
         )
         .expectToMatchJsResult();
 });
@@ -70,7 +70,7 @@ test("Exported Namespace Function Hoisting", () => {
                 foo = bar();
                 export function bar() { return "bar"; }
             }
-        `
+        `,
         )
         .expectToMatchJsResult();
 });
@@ -114,7 +114,7 @@ test("Hoisting with synthetic source file node", () => {
                         sourceFile.referencedFiles,
                         sourceFile.typeReferenceDirectives,
                         sourceFile.hasNoDefaultLib,
-                        sourceFile.libReferenceDirectives
+                        sourceFile.libReferenceDirectives,
                     ),
             ],
         })

--- a/test/unit/identifiers.spec.ts
+++ b/test/unit/identifiers.spec.ts
@@ -110,7 +110,7 @@ test.each(validTsInvalidLuaNames)(
             declare var ${name}: any;
             const foo = { ${name} };
         `.expectDiagnosticsToMatchSnapshot([invalidAmbientIdentifierName.code]);
-    }
+    },
 );
 
 test.each(validTsInvalidLuaNames)("undeclared identifier must be a valid lua identifier (%p)", name => {
@@ -129,7 +129,7 @@ test.each(validTsInvalidLuaNames)(
         `
             .disableSemanticCheck()
             .expectDiagnosticsToMatchSnapshot([invalidAmbientIdentifierName.code]);
-    }
+    },
 );
 
 test.each(validTsInvalidLuaNames)("exported values with invalid lua identifier names (%p)", name => {
@@ -184,7 +184,7 @@ test.each(validTsInvalidLuaNames)(
             }
             export const bar = NS.foo;
         `.expectToMatchJsResult();
-    }
+    },
 );
 
 test.each(validTsInvalidLuaNames)("class with invalid lua name has correct name property", name => {
@@ -296,7 +296,7 @@ test("unicode export class", () => {
                 hello() {
                     return "你好";
                 }
-            }`
+            }`,
         )
         .expectToEqual({ result: "你好" });
 });
@@ -312,7 +312,7 @@ test("unicode export default class", () => {
                 hello() {
                     return "你好";
                 }
-            }`
+            }`,
         )
         .expectToEqual({ result: "你好" });
 });

--- a/test/unit/jsx.spec.ts
+++ b/test/unit/jsx.spec.ts
@@ -297,7 +297,7 @@ describe("jsx", () => {
             .setTsHeader(
                 `function createElement(tag: string | Function, props: { [key: string]: string | boolean }, ...children: any[]) {
                 return { tag, children };
-            }`
+            }`,
             )
             .setOptions({ jsxFactory: "createElement", noImplicitSelf: true })
             .expectToMatchJsResult();
@@ -337,7 +337,7 @@ describe("jsx", () => {
             return <><b>c</b></>
         `
             .setTsHeader(
-                '/** @jsx MyLib.myCreate */\n/** @jsxFrag MyLib.MyFragment */\nimport { MyLib } from "./myJsx";'
+                '/** @jsx MyLib.myCreate */\n/** @jsxFrag MyLib.MyFragment */\nimport { MyLib } from "./myJsx";',
             )
             .addExtraFile("myJsx.ts", customJsxLib)
             .expectToMatchJsResult();
@@ -346,7 +346,7 @@ describe("jsx", () => {
         `
             .setTsHeader(
                 "/** @jsx MyLib.myCreate */\n/** @jsxFrag MyFragment2 */\n" +
-                    'import { MyLib } from "./myJsx";function MyFragment2(){};'
+                    'import { MyLib } from "./myJsx";function MyFragment2(){};',
             )
             .setOptions({ jsxFactory: "MyLib.myCreate", jsxFragmentFactory: "MyFragment" })
             .addExtraFile("myJsx.ts", customJsxLib)

--- a/test/unit/language-extensions/iterable.spec.ts
+++ b/test/unit/language-extensions/iterable.spec.ts
@@ -456,7 +456,7 @@ describe("LuaIterable with LuaMultiReturn value type", () => {
         `
                 .withLanguageExtensions()
                 .expectDiagnosticsToMatchSnapshot([invalidMultiIterableWithoutDestructuring.code]);
-        }
+        },
     );
 });
 

--- a/test/unit/language-extensions/multi.spec.ts
+++ b/test/unit/language-extensions/multi.spec.ts
@@ -98,7 +98,7 @@ test.each<[string, any]>(createCasesThatCall("multi"))(
             .withLanguageExtensions()
             .setReturnExport("a")
             .expectToEqual(result);
-    }
+    },
 );
 
 test.each<[string, number[]]>([

--- a/test/unit/language-extensions/operators.spec.ts
+++ b/test/unit/language-extensions/operators.spec.ts
@@ -78,7 +78,7 @@ test.each(binaryMathOperatorTests)(
             .setOptions(operatorsProjectOptions)
             .setReturnExport("result")
             .expectToEqual(expectResult);
-    }
+    },
 );
 
 test.each(binaryMathOperatorTests)(
@@ -96,7 +96,7 @@ test.each(binaryMathOperatorTests)(
             .setOptions(operatorsProjectOptions)
             .setReturnExport("result")
             .expectToEqual(expectResult);
-    }
+    },
 );
 
 test.each(binaryMathOperatorTests)(
@@ -114,7 +114,7 @@ test.each(binaryMathOperatorTests)(
             .setOptions(operatorsProjectOptions)
             .setReturnExport("result")
             .expectToEqual(expectResult);
-    }
+    },
 );
 
 const luaTargetsPre53 = [LuaTarget.Lua50, LuaTarget.Lua51, LuaTarget.Lua52, LuaTarget.LuaJIT, LuaTarget.Universal];
@@ -140,7 +140,7 @@ test.each(luaTargetsPre53.flatMap(target => operatorTypesPost53.map(opType => [t
     `
             .setOptions({ ...operatorsProjectOptions, luaTarget })
             .expectDiagnosticsToMatchSnapshot([unsupportedForTarget.code]);
-    }
+    },
 );
 
 const comparisonOperatorTests: Array<{ opType: string; left: number; right: number; expectResult: boolean }> = [
@@ -163,7 +163,7 @@ test.each(comparisonOperatorTests)(
             .setOptions(operatorsProjectOptions)
             .setReturnExport("result")
             .expectToEqual(expectResult);
-    }
+    },
 );
 
 test.each(comparisonOperatorTests)(
@@ -181,7 +181,7 @@ test.each(comparisonOperatorTests)(
             .setOptions(operatorsProjectOptions)
             .setReturnExport("result")
             .expectToEqual(expectResult);
-    }
+    },
 );
 
 test.each(comparisonOperatorTests)(
@@ -199,7 +199,7 @@ test.each(comparisonOperatorTests)(
             .setOptions(operatorsProjectOptions)
             .setReturnExport("result")
             .expectToEqual(expectResult);
-    }
+    },
 );
 
 test("concat operator mapping - global function", () => {

--- a/test/unit/language-extensions/pairsIterable.spec.ts
+++ b/test/unit/language-extensions/pairsIterable.spec.ts
@@ -116,7 +116,7 @@ test.each(["for (const s of testIterable) {}", "let s; for (s of testIterable) {
     `
             .withLanguageExtensions()
             .expectDiagnosticsToMatchSnapshot([invalidPairsIterableWithoutDestructuring.code]);
-    }
+    },
 );
 
 const testKeyIterable = `

--- a/test/unit/language-extensions/table.spec.ts
+++ b/test/unit/language-extensions/table.spec.ts
@@ -180,7 +180,7 @@ describe("LuaTableHas extension", () => {
             `
                 .withLanguageExtensions()
                 .expectDiagnosticsToMatchSnapshot([invalidCallExtensionUse.code]);
-        }
+        },
     );
 
     test.each(["LuaTable<string, number>", "LuaMap<string, number>", "LuaSet<string>"])(
@@ -192,7 +192,7 @@ describe("LuaTableHas extension", () => {
             `
                 .withLanguageExtensions()
                 .expectDiagnosticsToMatchSnapshot([invalidCallExtensionUse.code]);
-        }
+        },
     );
 });
 
@@ -400,7 +400,7 @@ describe("LuaTable extension interface", () => {
                 .setOptions({ strict: true })
                 .expectToHaveDiagnostics()
                 .expectDiagnosticsToMatchSnapshot();
-        }
+        },
     );
 
     test("object keyed table", () => {
@@ -477,7 +477,7 @@ describe("LuaTable extension interface", () => {
         "table immediate access (%p)",
         statement => {
             util.testFunction(statement).withLanguageExtensions().expectToHaveNoDiagnostics();
-        }
+        },
     );
 
     test("table pairs iterate", () => {

--- a/test/unit/loops.spec.ts
+++ b/test/unit/loops.spec.ts
@@ -39,7 +39,7 @@ util.testEachVersion(
         }
         return arrTest;
         `,
-    util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+    util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
 );
 
 util.testEachVersion(
@@ -66,7 +66,7 @@ util.testEachVersion(
         } while (i < arrTest.length)
         return arrTest;
         `,
-    util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+    util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
 );
 
 test("for", () => {
@@ -108,7 +108,7 @@ util.testEachVersion(
         }
         return arrTest;
         `,
-    util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+    util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
 );
 
 test("forMirror", () => {
@@ -234,8 +234,8 @@ const luaTargetsExceptJit = [
 
 test.each(
     luaTargetsExceptJit.flatMap(target =>
-        [{ inp: { a: 0, b: 1, c: 2, d: 3, e: 4 } }].map(testCase => [target, testCase] as const)
-    )
+        [{ inp: { a: 0, b: 1, c: 2, d: 3, e: 4 } }].map(testCase => [target, testCase] as const),
+    ),
 )("forin with continue (%s %p)", (luaTarget, { inp }) => {
     util.testFunctionTemplate`
             let obj = ${inp};
@@ -374,7 +374,7 @@ util.testEachVersion(
         }
         return testArr;
     `,
-    util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+    util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
 );
 
 test("forof with iterator", () => {

--- a/test/unit/modules/modules.spec.ts
+++ b/test/unit/modules/modules.spec.ts
@@ -61,7 +61,7 @@ test.each(["ke-bab", "dollar$", "singlequote'", "hash#", "s p a c e", "ɥɣɎɌ�
             .addExtraFile(`${name}.ts`, 'export const foo = "bar";')
             .setReturnExport("foo")
             .expectToEqual("bar");
-    }
+    },
 );
 
 test.each(["export default value;", "export { value as default };"])("Export Default From (%p)", exportStatement => {
@@ -73,7 +73,7 @@ test.each(["export default value;", "export { value as default };"])("Export Def
             `
                 export const value = true;
                 ${exportStatement};
-            `
+            `,
         )
         .expectToMatchJsResult();
 });
@@ -87,7 +87,7 @@ test("Default Import and Export Expression", () => {
             "module.ts",
             `
                 export default 1 + 2 + 3;
-            `
+            `,
         )
         .expectToMatchJsResult();
 });
@@ -103,7 +103,7 @@ test("Import and Export Assignment", () => {
             "module.ts",
             `
                 export = true;
-            `
+            `,
         )
         .expectToMatchJsResult();
 });
@@ -120,7 +120,7 @@ test("Mixed Exports, Default and Named Imports", () => {
                 export const b = 2;
                 export const c = 3;
                 export default a;
-            `
+            `,
         )
         .expectToMatchJsResult();
 });
@@ -137,7 +137,7 @@ test("Mixed Exports, Default and Namespace Import", () => {
                 export const b = 2;
                 export const c = 3;
                 export default a;
-            `
+            `,
         )
         .expectToMatchJsResult();
 });
@@ -154,7 +154,7 @@ test("Export Default Function", () => {
                 export default function() {
                     return true;
                 }
-            `
+            `,
         )
         .expectToMatchJsResult();
 });
@@ -309,7 +309,7 @@ test("correctly exports @compileMembersOnly enums (#1572)", () => {
             C = 2
         }
         export const val = MyEnum.B | MyEnum.C;
-    `
+    `,
         )
         .expectToEqual({ val: 3 });
 });

--- a/test/unit/modules/resolution.spec.ts
+++ b/test/unit/modules/resolution.spec.ts
@@ -102,7 +102,7 @@ test("resolves non-standard requires", () => {
                 require "requiredLuaFile5"  -- no parentheses and space
                 require "requiredLua'File6"  -- no parentheses and space
                 require 'requiredLua"File7'  -- no parentheses and space
-            `
+            `,
         )
         .addExtraFile("requiredLuaFile1.lua", "")
         .addExtraFile("requiredLuaFile2.lua", "")

--- a/test/unit/nullishCoalescing.spec.ts
+++ b/test/unit/nullishCoalescing.spec.ts
@@ -30,7 +30,7 @@ test.each(["boolean | string", "number | false", "undefined | true"])(
             const unknownType = false as ${unionType};
             return unknownType ?? "This should not be returned!";
         `.expectToMatchJsResult();
-    }
+    },
 );
 
 test("nullish-coalescing operator with side effect lhs", () => {

--- a/test/unit/objectLiteral.spec.ts
+++ b/test/unit/objectLiteral.spec.ts
@@ -4,7 +4,7 @@ test.each(['{ a: 3, b: "4" }', '{ "a": 3, b: "4" }', '{ ["a"]: 3, b: "4" }', '{ 
     "Object Literal (%p)",
     inp => {
         util.testExpression(inp).expectToMatchJsResult();
-    }
+    },
 );
 
 test("object literal with function call to get key", () => {
@@ -61,7 +61,7 @@ test.each(['{x: "foobar"}.x', '{x: "foobar"}["x"]', '{x: () => "foobar"}.x()', '
     "object literal property access (%p)",
     expression => {
         util.testExpression(expression).expectToMatchJsResult();
-    }
+    },
 );
 
 describe("noSelf in functions", () => {

--- a/test/unit/optionalChaining.spec.ts
+++ b/test/unit/optionalChaining.spec.ts
@@ -36,7 +36,7 @@ test.each(["undefined", "{}", "{ foo: {} }", "{ foo: {bar: 'baz'}}"])(
         const obj: { foo?: { bar?: string } } | undefined = ${value};
         return obj?.foo?.bar ?? "not found";
     `.expectToMatchJsResult();
-    }
+    },
 );
 
 test.each(["[1, 2, 3, 4]", "undefined"])("optional array access (%p)", value => {
@@ -53,7 +53,7 @@ test.each(["[1, [2, [3, [4, 5]]]]", "[1, [2, [3, undefined]]] ", "[1, undefined]
         const arr: [number, [number, [number, [number, number] | undefined]]] | [number, undefined] = ${value};
         return arr[1]?.[1][1]?.[0];
     `.expectToMatchJsResult();
-    }
+    },
 );
 
 test.each(["{ }", "{ a: { } }", "{ a: { b: [{ c: 10 }] } }"])(
@@ -63,7 +63,7 @@ test.each(["{ }", "{ a: { } }", "{ a: { b: [{ c: 10 }] } }"])(
         const obj: {a?: {b?: Array<{c: number }> } } = ${value};
         return [obj["a"]?.["b"]?.[0]?.["c"] ?? "not found", obj["a"]?.["b"]?.[2]?.["c"] ?? "not found"];
     `.expectToMatchJsResult();
-    }
+    },
 );
 
 test("optional element function calls", () => {
@@ -132,7 +132,7 @@ test.each(["undefined", "{ foo(val) {return val} }"])(
             .expectToHaveNoDiagnostics()
             .expectLuaToMatchSnapshot();
         // should use if statement, as there are preceding statements
-    }
+    },
 );
 
 test.each(["undefined", "{ foo(v) { return v} }"])("with preceding statements on right side modifying left", value => {

--- a/test/unit/printer/semicolons.spec.ts
+++ b/test/unit/printer/semicolons.spec.ts
@@ -13,5 +13,5 @@ test.each(["const a = 1; const b = a;", "const a = 1; let b: number; b = a;", "{
             .ignoreDiagnostics([2873 /* TS2873: This kind of expression is always falsy. */])
             .expectToMatchJsResult()
             .expectLuaToMatchSnapshot();
-    }
+    },
 );

--- a/test/unit/printer/sourcemaps.spec.ts
+++ b/test/unit/printer/sourcemaps.spec.ts
@@ -335,7 +335,7 @@ test("loadstring sourceMapTraceback gives traceback", () => {
             return trace;
         }
         return bar();`,
-        { sourceMapTraceback: true, luaTarget: LuaTarget.Lua51 }
+        { sourceMapTraceback: true, luaTarget: LuaTarget.Lua51 },
     ).file?.lua;
 
     const builder = util.testModule`

--- a/test/unit/spread.spec.ts
+++ b/test/unit/spread.spec.ts
@@ -81,7 +81,7 @@ describe("in function call", () => {
             [tstl.LuaTarget.Lua52]: builder => builder.tap(expectTableUnpack).expectToMatchJsResult(),
             [tstl.LuaTarget.Lua53]: builder => builder.tap(expectTableUnpack).expectToMatchJsResult(),
             [tstl.LuaTarget.Lua54]: builder => builder.tap(expectTableUnpack).expectToMatchJsResult(),
-        }
+        },
     );
 });
 
@@ -143,7 +143,7 @@ describe("vararg spread optimization", () => {
                 return pick(...args);
             }
             return test("a", "b", "c");`,
-        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
     );
 
     util.testEachVersion(
@@ -152,7 +152,7 @@ describe("vararg spread optimization", () => {
             function pick(...args: string[]) { return args[1]; }
             const test = (...args: string[]) => pick(...args);
             return test("a", "b", "c");`,
-        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
     );
 
     util.testEachVersion(
@@ -165,7 +165,7 @@ describe("vararg spread optimization", () => {
                 }
             }
             return test("a", "b", "c");`,
-        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
     );
 
     util.testEachVersion(
@@ -178,7 +178,7 @@ describe("vararg spread optimization", () => {
                 } while (false);
             }
             return test("a", "b", "c");`,
-        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
     );
 
     util.testEachVersion(
@@ -193,7 +193,7 @@ describe("vararg spread optimization", () => {
                 return result;
             }
             return test("a", "b", "c");`,
-        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
     );
 
     util.testEachVersion(
@@ -209,7 +209,7 @@ describe("vararg spread optimization", () => {
                 }
             }
             return test("a" ,"b", "c");`,
-        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
     );
 
     test("$multi", () => {
@@ -234,7 +234,7 @@ describe("vararg spread optimization", () => {
                 return fn(...args);
             }
             return test((arg: string) => arg, "foobar");`,
-        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
     );
 
     util.testEachVersion(
@@ -245,7 +245,7 @@ describe("vararg spread optimization", () => {
                 return fn(...args);
             }
             return test({fn: (arg: string) => arg}, "foobar");`,
-        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
     );
 
     util.testEachVersion(
@@ -256,7 +256,7 @@ describe("vararg spread optimization", () => {
                 return fn(...args);
             }
             test("foobar");`,
-        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
     );
 
     util.testEachVersion(
@@ -267,7 +267,7 @@ describe("vararg spread optimization", () => {
                 return pick(...(args as any[]));
             }
             return test<(...args: string[])=>void>("a", "b", "c");`,
-        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
     );
 });
 
@@ -281,7 +281,7 @@ describe("vararg spread de-optimization", () => {
                 return pick(...args);
             }
             return test("a", "b", "c");`,
-        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
     );
 
     util.testEachVersion(
@@ -295,7 +295,7 @@ describe("vararg spread de-optimization", () => {
                 return result;
             }
             return test("a", "b", "c");`,
-        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
     );
 
     util.testEachVersion(
@@ -310,7 +310,7 @@ describe("vararg spread de-optimization", () => {
                 return result;
             }
             return test("a", "b", "c");`,
-        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
     );
 });
 
@@ -324,7 +324,7 @@ describe("vararg spread in IIFE", () => {
                 return (dummy(), pick(...args));
             }
             return test("a", "b", "c");`,
-        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
     );
 
     util.testEachVersion(
@@ -336,7 +336,7 @@ describe("vararg spread in IIFE", () => {
                 return (x = pick(...args));
             }
             return test("a", "b", "c");`,
-        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
     );
 
     util.testEachVersion(
@@ -348,7 +348,7 @@ describe("vararg spread in IIFE", () => {
                 return ([x] = pick(...args));
             }
             return test("a", "b", "c");`,
-        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
     );
 
     util.testEachVersion(
@@ -360,7 +360,7 @@ describe("vararg spread in IIFE", () => {
                 return (x.val = pick(...args));
             }
             return test("a", "b", "c");`,
-        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
     );
 
     util.testEachVersion(
@@ -372,7 +372,7 @@ describe("vararg spread in IIFE", () => {
                 return x += pick(...args);
             }
             return test(1, 2, 3);`,
-        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
     );
 
     util.testEachVersion(
@@ -384,7 +384,7 @@ describe("vararg spread in IIFE", () => {
                 return x[pick(...args)]++;
             }
             return test(1, 2, 3);`,
-        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
     );
 
     util.testEachVersion(
@@ -396,7 +396,7 @@ describe("vararg spread in IIFE", () => {
                 return ++x[pick(...args)];
             }
             return test(1, 2, 3);`,
-        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
     );
 
     util.testEachVersion(
@@ -409,7 +409,7 @@ describe("vararg spread in IIFE", () => {
                 } catch {}
             }
             return test("a" ,"b", "c");`,
-        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
     );
 
     util.testEachVersion(
@@ -424,7 +424,7 @@ describe("vararg spread in IIFE", () => {
                 }
             }
             return test("a" ,"b", "c");`,
-        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
     );
 
     util.testEachVersion(
@@ -436,7 +436,7 @@ describe("vararg spread in IIFE", () => {
                 return new fooClass().foo;
             }
             return test("a" ,"b", "c");`,
-        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
     );
 
     util.testEachVersion(
@@ -447,7 +447,7 @@ describe("vararg spread in IIFE", () => {
                 return \`\${typeof testName}:\${pick(...args)}\`;
             }
             return test("a" ,"b", "c");`,
-        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
     );
 
     util.testEachVersion(
@@ -459,7 +459,7 @@ describe("vararg spread in IIFE", () => {
                 return getObj(...args).$method();
             }
             return test("a" ,"b", "c");`,
-        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
     );
 
     util.testEachVersion(
@@ -471,7 +471,7 @@ describe("vararg spread in IIFE", () => {
                 return getObj().$pick(...args);
             }
             return test("a" ,"b", "c");`,
-        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
     );
 
     util.testEachVersion(
@@ -484,7 +484,7 @@ describe("vararg spread in IIFE", () => {
                 return getObj().$tag\`FOO\${pick(...args)}BAR\`;
             }
             return test("a" ,"b", "c");`,
-        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult())
+        util.expectEachVersionExceptJit(builder => builder.expectToMatchJsResult()),
     );
 });
 
@@ -499,7 +499,7 @@ test.each(["pairs", "ipairs"])("can spread %s (#1244)", func => {
             `
             declare function ipairs<T>(this: void, t: T): LuaIterable<LuaMultiReturn<[number, NonNullable<T[keyof T]>]>>;
             declare function pairs<T>(this: void, t: T): LuaIterable<LuaMultiReturn<[keyof T, NonNullable<T[keyof T]>]>>;
-            `
+            `,
         )
         .expectToEqual([
             [1, "a"],
@@ -518,7 +518,7 @@ test.each(["LuaTable", "LuaMap"])("can spread %s with pairs (#1244)", type => {
     `
         .withLanguageExtensions()
         .setTsHeader(
-            "declare function pairs<T>(this: void, t: T): LuaIterable<LuaMultiReturn<[keyof T, NonNullable<T[keyof T]>]>>;"
+            "declare function pairs<T>(this: void, t: T): LuaIterable<LuaMultiReturn<[keyof T, NonNullable<T[keyof T]>]>>;",
         )
         .getLuaExecutionResult();
 

--- a/test/unit/templateLiterals.spec.ts
+++ b/test/unit/templateLiterals.spec.ts
@@ -58,7 +58,7 @@ test.each(["func`noSelfParameter`", "obj.func`noSelfParameter`", "obj[`func`]`no
             const obj = { func };
             return ${expression};
         `.expectToMatchJsResult();
-    }
+    },
 );
 
 test.each(["number", "string | any"])("template span expect tostring for non string type (%p)", type => {
@@ -81,5 +81,5 @@ test.each(["string", "'string literal type'", "string & unknown"])(
         `
             .tap(builder => expect(builder.getMainLuaCodeChunk()).not.toContain("tostring"))
             .expectToMatchJsResult();
-    }
+    },
 );

--- a/test/unit/typeof.spec.ts
+++ b/test/unit/typeof.spec.ts
@@ -95,5 +95,5 @@ test.each([...equalityComparisonCases, ...relationalComparisonCases])(
         `
             .tap(expectTypeOfHelper)
             .expectToMatchJsResult();
-    }
+    },
 );

--- a/test/util.ts
+++ b/test/util.ts
@@ -59,7 +59,7 @@ export const formatCode = (...values: unknown[]) => values.map(e => stringify(e)
 export function testEachVersion<T extends TestBuilder>(
     name: string | undefined,
     common: () => T,
-    special?: Record<tstl.LuaTarget, ((builder: T) => void) | boolean>
+    special?: Record<tstl.LuaTarget, ((builder: T) => void) | boolean>,
 ): void {
     for (const version of Object.values(tstl.LuaTarget) as tstl.LuaTarget[]) {
         const specialBuilder = special?.[version];
@@ -77,7 +77,7 @@ export function testEachVersion<T extends TestBuilder>(
 }
 
 export function expectEachVersionExceptJit<T>(
-    expectation: (builder: T) => void
+    expectation: (builder: T) => void,
 ): Record<tstl.LuaTarget, ((builder: T) => void) | boolean> {
     return {
         [tstl.LuaTarget.Universal]: expectation,
@@ -221,7 +221,7 @@ export abstract class TestBuilder {
 
         // Exclude lua files from TS program, but keep them in extraFiles so module resolution can find them
         const nonLuaExtraFiles = Object.fromEntries(
-            Object.entries(this.extraFiles).filter(([fileName]) => !fileName.endsWith(".lua"))
+            Object.entries(this.extraFiles).filter(([fileName]) => !fileName.endsWith(".lua")),
         );
 
         return tstl.createVirtualProgram({ ...nonLuaExtraFiles, [this.mainFileName]: this.getTsCode() }, this.options);
@@ -266,7 +266,7 @@ export abstract class TestBuilder {
             throw new Error(
                 `No source file could be found matching main file: ${mainFileName}.\nSource files in test:\n${transpiledFiles
                     .flatMap(f => f.sourceFiles.map(sf => sf.fileName))
-                    .join("\n")}`
+                    .join("\n")}`,
             );
         }
 
@@ -299,7 +299,7 @@ export abstract class TestBuilder {
     public getMainJsCodeChunk(): string {
         const { transpiledFiles } = this.getJsResult();
         const code = transpiledFiles.find(({ sourceFiles }) =>
-            sourceFiles.some(f => f.fileName === this.mainFileName)
+            sourceFiles.some(f => f.fileName === this.mainFileName),
         )?.js;
         assert(code !== undefined);
 
@@ -319,7 +319,7 @@ export abstract class TestBuilder {
     private getLuaDiagnostics(): ts.Diagnostic[] {
         const { diagnostics } = this.getLuaResult();
         return diagnostics.filter(
-            d => (this.semanticCheck || d.source === "typescript-to-lua") && !this.ignoredDiagnostics.includes(d.code)
+            d => (this.semanticCheck || d.source === "typescript-to-lua") && !this.ignoredDiagnostics.includes(d.code),
         );
     }
 
@@ -339,7 +339,7 @@ export abstract class TestBuilder {
                     getCurrentDirectory: () => "",
                     getCanonicalFileName: fileName => fileName,
                     getNewLine: () => "\n",
-                })
+                }),
             );
         }
 
@@ -423,7 +423,7 @@ export abstract class TestBuilder {
 
         const diagnosticMessages = ts.formatDiagnostics(
             this.getLuaDiagnostics().map(tstl.prepareDiagnosticForFormatting),
-            { getCurrentDirectory: () => "", getCanonicalFileName: fileName => fileName, getNewLine: () => "\n" }
+            { getCurrentDirectory: () => "", getCanonicalFileName: fileName => fileName, getNewLine: () => "\n" },
         );
 
         expect(diagnosticMessages.trim()).toMatchSnapshot("diagnostics");
@@ -533,7 +533,7 @@ end)());`;
             globalContext.exports = moduleExports;
             globalContext.module = { exports: moduleExports };
             const transpiledExtraFile = transpiledFiles.find(({ sourceFiles }) =>
-                sourceFiles.some(f => f.fileName === fileName.replace("./", "") + ".ts")
+                sourceFiles.some(f => f.fileName === fileName.replace("./", "") + ".ts"),
             );
 
             if (transpiledExtraFile?.js) {


### PR DESCRIPTION
The deps were very old so this PR updates them to the latest.
Additionally, this fixes the big warning when running `npm run lint`.
Updating Prettier to latest required also running `npm run fix:prettier`, which changed a lot of files.
Please do a release after this PR so that end-users can solve the peer dependencies problem with TypeScript.