### PR TITLE
Allow stacktraces in Lua 5.1 and LuaJIT and fix level in lualib

### DIFF
--- a/src/lualib/Error.ts
+++ b/src/lualib/Error.ts
@@ -1,3 +1,5 @@
+import { __TS__New } from "./New";
+
 interface ErrorType {
     name: string;
     new (...args: any[]): Error;
@@ -22,6 +24,10 @@ function getErrorStack(constructor: () => any): string | undefined {
 
     if (_VERSION.includes("Lua 5.0")) {
         return debug.traceback(`[Level ${level}]`);
+    } else if (_VERSION === "Lua 5.1") {
+        // Lua 5.1 and LuaJIT have a bug where it's not possible to specify the level without a message.
+        // @ts-ignore Fails when compiled with Lua 5.0 types
+        return string.sub(debug.traceback("", level), 2);
     } else {
         // @ts-ignore Fails when compiled with Lua 5.0 types
         return debug.traceback(undefined, level);
@@ -33,7 +39,7 @@ function wrapErrorToString<T extends Error>(getDescription: (this: T) => string)
         const description = getDescription.call(this as T);
         const caller = debug.getinfo(3, "f");
         // @ts-ignore Fails when compiled with Lua 5.0 types
-        const isClassicLua = _VERSION.includes("Lua 5.0") || _VERSION === "Lua 5.1";
+        const isClassicLua = _VERSION.includes("Lua 5.0");
         if (isClassicLua || (caller && caller.func !== error)) {
             return description;
         } else {
@@ -55,7 +61,7 @@ export const Error: ErrorConstructor = initErrorClass(
         public stack?: string;
 
         constructor(public message = "") {
-            this.stack = getErrorStack((this.constructor as any).new);
+            this.stack = getErrorStack(__TS__New as any);
             const metatable = getmetatable(this);
             if (metatable && !metatable.__errorToStringPatched) {
                 metatable.__errorToStringPatched = true;

--- a/src/lualib/Error.ts
+++ b/src/lualib/Error.ts
@@ -24,6 +24,7 @@ function getErrorStack(constructor: () => any): string | undefined {
 
     if (_VERSION.includes("Lua 5.0")) {
         return debug.traceback(`[Level ${level}]`);
+        // @ts-ignore Fails when compiled with Lua 5.0 types
     } else if (_VERSION === "Lua 5.1") {
         // Lua 5.1 and LuaJIT have a bug where it's not possible to specify the level without a message.
         // @ts-ignore Fails when compiled with Lua 5.0 types

--- a/test/unit/error.spec.ts
+++ b/test/unit/error.spec.ts
@@ -355,13 +355,15 @@ util.testEachVersion(
         ...util.expectEachVersionExceptJit(builder => {
             builder.expectToHaveNoDiagnostics();
             const luaResult = builder.getLuaExecutionResult();
-            expect(luaResult.split('\n').length).toBe(4);
+            // eslint-disable-next-line jest/no-standalone-expect
+            expect(luaResult.split('\n')).toHaveLength(4);
         }),
         
         // 5.0 debug.traceback doesn't support levels
-        [tstl.LuaTarget.Lua50]: builder => {
+        [tstl.LuaTarget.Lua50](builder) {
             builder.expectToHaveNoDiagnostics();
             const luaResult = builder.getLuaExecutionResult();
+            // eslint-disable-next-line jest/no-standalone-expect
             expect(luaResult).toContain("Level 4");
         }, 
     }

--- a/test/unit/error.spec.ts
+++ b/test/unit/error.spec.ts
@@ -356,15 +356,15 @@ util.testEachVersion(
             builder.expectToHaveNoDiagnostics();
             const luaResult = builder.getLuaExecutionResult();
             // eslint-disable-next-line jest/no-standalone-expect
-            expect(luaResult.split('\n')).toHaveLength(4);
+            expect(luaResult.split("\n")).toHaveLength(4);
         }),
-        
+
         // 5.0 debug.traceback doesn't support levels
         [tstl.LuaTarget.Lua50](builder) {
             builder.expectToHaveNoDiagnostics();
             const luaResult = builder.getLuaExecutionResult();
             // eslint-disable-next-line jest/no-standalone-expect
             expect(luaResult).toContain("Level 4");
-        }, 
+        },
     }
 );

--- a/test/util.ts
+++ b/test/util.ts
@@ -43,7 +43,7 @@ function getLuaBindingsForVersion(target: tstl.LuaTarget): { lauxlib: LauxLib; l
         return { lauxlib, lua, lualib };
     }
     if (target === tstl.LuaTarget.LuaJIT) {
-        throw Error("Can't use executeLua() or expectToMatchJsResult() wit LuaJIT as target!");
+        throw Error("Can't use executeLua() or expectToMatchJsResult() with LuaJIT as target!");
     }
 
     const { lauxlib, lua, lualib } = require("lua-wasm-bindings/dist/lua.54");
@@ -63,7 +63,7 @@ export function testEachVersion<T extends TestBuilder>(
 ): void {
     for (const version of Object.values(tstl.LuaTarget) as tstl.LuaTarget[]) {
         const specialBuilder = special?.[version];
-        if (specialBuilder === false) return;
+        if (specialBuilder === false) continue;
 
         const testName = name === undefined ? version : `${name} [${version}]`;
         defineTest(testName, () => {


### PR DESCRIPTION
Lua 5.1 and LuaJIT have a bug where it's not possible to specify the level without a message. Previously the stacktrace was just ignored in TSTL for these versions; but we can workaround this bug by just specifying an empty message and trimming the newline with string.sub.

Also:
* Fix the constructor passed when getting the stacktrace, as `constructor.new` doesn't seem to exist. I suspect that .new used to be a thing but was never updated when this was changed.
  * Is there any circumstance where finding the `__TS__New` would result in the wrong level? Since `__TS__New` is not specifically for Error.
* I also noticed a typo and what looks like a bug in the testEachVersion util where if it found any target that was disabled, it would completely exit even if other versions were specified.
