### PR TITLE
fix: ensure parent pointers are correctly set for transformed nodes

### DIFF
--- a/src/transformation/pre-transformers/using-transformer.ts
+++ b/src/transformation/pre-transformers/using-transformer.ts
@@ -10,10 +10,10 @@ export function usingTransformer(context: TransformationContext): ts.Transformer
                 if (hasUsings) {
                     // Recurse visitor into updated block to find further usings
                     const updatedBlock = ts.factory.updateBlock(node, newStatements);
-                    const result = ts.visitEachChild(updatedBlock, visit, ctx);
+                    const visitedBlock = ts.visitEachChild(updatedBlock, visit, ctx);
 
                     // Set all the synthetic node parents to something that makes sense
-                    const parent: ts.Node[] = [updatedBlock];
+                    const parent: ts.Node[] = [];
                     function setParent(node2: ts.Node): ts.Node {
                         ts.setParent(node2, parent[parent.length - 1]);
                         parent.push(node2);
@@ -21,10 +21,11 @@ export function usingTransformer(context: TransformationContext): ts.Transformer
                         parent.pop();
                         return node2;
                     }
-                    ts.visitEachChild(updatedBlock, setParent, ctx);
-                    ts.setParent(updatedBlock, node.parent);
+                    parent.push(visitedBlock);
+                    ts.visitEachChild(visitedBlock, setParent, ctx);
+                    ts.setParent(visitedBlock, node.parent);
 
-                    return result;
+                    return visitedBlock;
                 }
             }
             return ts.visitEachChild(node, visit, ctx);


### PR DESCRIPTION
I've been working on writing plugins recently and encountered some issues, so I've been reading source codes of TSTL to learn more. Thus, I noticed some parts that seem a bit unreasonable.

Previously, the `setParent` function was applied to `updatedBlock` instead of `result`, which may lead to incorrect parent pointers in the final transformed AST. This fix ensures that parent pointers are correctly set for the final transformed node `result` and its subtree, maintaining the integrity of the AST during transformations.

As I am just beginning to delve into the source code, my understanding of it may not be entirely accurate. If this is an erroneous fix, please correct me and do not hesitate to explain the rationale behind your coding approach.