### PR TITLE
Add in-memory plugins

### DIFF
--- a/src/CompilerOptions.ts
+++ b/src/CompilerOptions.ts
@@ -1,6 +1,7 @@
 import * as ts from "typescript";
 import { JsxEmit } from "typescript";
 import * as diagnosticFactories from "./transpilation/diagnostics";
+import { Plugin } from "./transpilation/plugins";
 
 type OmitIndexSignature<T> = {
     [K in keyof T as string extends K ? never : number extends K ? never : K]: T[K];
@@ -23,6 +24,11 @@ export interface LuaPluginImport {
     [option: string]: any;
 }
 
+export interface InMemoryLuaPlugin {
+    plugin: Plugin | ((options: Record<string, any>) => Plugin);
+    [option: string]: any;
+}
+
 export interface TypeScriptToLuaOptions {
     buildMode?: BuildMode;
     extension?: string;
@@ -30,7 +36,7 @@ export interface TypeScriptToLuaOptions {
     luaBundleEntry?: string;
     luaTarget?: LuaTarget;
     luaLibImport?: LuaLibImportKind;
-    luaPlugins?: LuaPluginImport[];
+    luaPlugins?: Array<LuaPluginImport | InMemoryLuaPlugin>;
     noImplicitGlobalVariables?: boolean;
     noImplicitSelf?: boolean;
     noHeader?: boolean;

--- a/src/transpilation/plugins.ts
+++ b/src/transpilation/plugins.ts
@@ -77,15 +77,23 @@ export function getPlugins(program: ts.Program): { diagnostics: ts.Diagnostic[];
     for (const [index, pluginOption] of (options.luaPlugins ?? []).entries()) {
         const optionName = `tstl.luaPlugins[${index}]`;
 
-        const { error: resolveError, result: factory } = resolvePlugin(
-            "plugin",
-            `${optionName}.name`,
-            getConfigDirectory(options),
-            pluginOption.name,
-            pluginOption.import
-        );
+        const factory = (() => {
+            if ("plugin" in pluginOption) {
+                return pluginOption.plugin;
+            } else {
+                const { error: resolveError, result: factory } = resolvePlugin(
+                    "plugin",
+                    `${optionName}.name`,
+                    getConfigDirectory(options),
+                    pluginOption.name,
+                    pluginOption.import
+                );
 
-        if (resolveError) diagnostics.push(resolveError);
+                if (resolveError) diagnostics.push(resolveError);
+                return factory;
+            }
+        })();
+
         if (factory === undefined) continue;
 
         const plugin = typeof factory === "function" ? factory(pluginOption) : factory;


### PR DESCRIPTION
Allows passing plugins or plugin factories directly in `luaPlugins`. Some unit tests are included to illustrate usage.