### PR TITLE
Add `bit` and `bit32` as lua keywords

### DIFF
--- a/src/transformation/utils/safe-names.ts
+++ b/src/transformation/utils/safe-names.ts
@@ -16,6 +16,8 @@ export const isValidLuaIdentifier = (name: string, options: CompilerOptions) =>
 
 export const luaKeywords: ReadonlySet<string> = new Set([
     "and",
+    "bit",
+    "bit32",
     "break",
     "do",
     "else",

--- a/test/unit/identifiers.spec.ts
+++ b/test/unit/identifiers.spec.ts
@@ -577,6 +577,15 @@ describe("lua keyword as identifier doesn't interfere with lua's value", () => {
         expect(luaResult).toBe("foobar");
     });
 
+    test("variable (bit32)", () => {
+        util.testFunction`
+        const bit32 = 1;
+        return bit32 << 1;
+        `
+            .setOptions({ luaTarget: LuaTarget.Lua52 })
+            .expectToMatchJsResult();
+    });
+
     test("variable (_G)", () => {
         util.testFunction`
             const _G = "bar";


### PR DESCRIPTION
If code uses bitwise operations, it will import `bit32` (for lua 5.2 target) or `bit` (for luajit target). Add these to the keywords list in safe-names.ts to make sure that they are not overwritten by a variable with the same name.

Closes #1615