### PR TITLE
Change currentIndent to protected

### DIFF
--- a/src/LuaPrinter.ts
+++ b/src/LuaPrinter.ts
@@ -157,7 +157,7 @@ export class LuaPrinter {
     };
     private static rightAssociativeOperators = new Set([lua.SyntaxKind.ConcatOperator, lua.SyntaxKind.PowerOperator]);
 
-    private currentIndent = "";
+    protected currentIndent = "";
     protected luaFile: string;
     protected relativeSourcePath: string;
     protected options: CompilerOptions;


### PR DESCRIPTION
Allows overriding `pushIndent` / `popIndent` to change indention style in plugins. It's useful for projects that auto-formats processed files (it seems MapleStory Worlds does this).

```ts
import * as tstl from "typescript-to-lua";

export class Printer extends tstl.LuaPrinter {
    pushIndent() {
        this.currentIndent += `\t`;
    }

    popIndent() {
        this.currentIndent = this.currentIndent.slice(1);
    }
}
```