### PR TITLE
fix: only parse arguments from first line of tag comment

### DIFF
--- a/src/transformation/utils/annotations.ts
+++ b/src/transformation/utils/annotations.ts
@@ -105,7 +105,8 @@ export function getFileAnnotations(sourceFile: ts.SourceFile): AnnotationsMap {
 function getTagArgsFromComment(tag: ts.JSDocTag): string[] {
     if (tag.comment) {
         if (typeof tag.comment === "string") {
-            return tag.comment.split(" ");
+            const firstLine = tag.comment.split("\n")[0];
+            return firstLine.trim().split(" ");
         } else {
             return tag.comment.map(part => part.text);
         }

--- a/test/translation/__snapshots__/transformation.spec.ts.snap
+++ b/test/translation/__snapshots__/transformation.spec.ts.snap
@@ -36,6 +36,8 @@ escapedCharsInTemplateString = "\\\\ \\0 \\b \\t \\n \\v \\f \\" ' \`"
 nonEmptyTemplateString = ("Level 0: \\n\\t " .. ("Level 1: \\n\\t\\t " .. ("Level 3: \\n\\t\\t\\t " .. "Last level \\n --") .. " \\n --") .. " \\n --") .. " \\n --""
 `;
 
+exports[`Transformation (customNameWithExtraComment) 1`] = `"TestNamespace.pass()"`;
+
 exports[`Transformation (customNameWithNoSelf) 1`] = `"TestNamespace.pass()"`;
 
 exports[`Transformation (exportStatement) 1`] = `

--- a/test/translation/transformation/customNameWithExtraComment.ts
+++ b/test/translation/transformation/customNameWithExtraComment.ts
@@ -1,0 +1,10 @@
+/** @noSelf */
+declare namespace TestNamespace {
+    /**
+     * @customName pass
+     * The first word should not be included.
+     **/
+    function fail(): void;
+}
+
+TestNamespace.fail();


### PR DESCRIPTION
I had this issue, where I was trying to use customName annotation to rename methods and I noticed that it was also including a new line and the first word of the next line. For example:
```ts
/** @noSelf */
declare namespace TestNamespace {
    /**
     * @customName pass
     * The first word should not be included.
     **/
    function fail(): void;
}

TestNamespace.fail();
```
Would result in:
```ts
TestNamespace["pass\nThe"]()
```

The solution was pretty simple, I only had to get the first line before splitting it by space.
I ran the tests and everything passes. Let me know if there's other changes I need to make.